### PR TITLE
Deployment: Smithery config

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@
 An [MCP server](https://modelcontextprotocol.io/introduction) implementation that integrates the SearxNG API, providing web search capabilities.
 
 <a href="https://glama.ai/mcp/servers/0j7jjyt7m9"><img width="380" height="200" src="https://glama.ai/mcp/servers/0j7jjyt7m9/badge" alt="SearXNG Server MCP server" /></a>
+[![smithery badge](https://smithery.ai/badge/@ihor-sokoliuk/server-searxng)](https://smithery.ai/server/@ihor-sokoliuk/server-searxng)
 
 ## Features
 
@@ -27,6 +28,14 @@ An [MCP server](https://modelcontextprotocol.io/introduction) implementation tha
 3. The default `SEARXNG_URL` value is `http://localhost:8080`.
 
 ### Usage with Claude Desktop
+
+### Installing via Smithery
+
+To install SearxNG Server for Claude Desktop automatically via [Smithery](https://smithery.ai/server/@ihor-sokoliuk/server-searxng):
+
+```bash
+npx -y @smithery/cli install @ihor-sokoliuk/server-searxng --client claude
+```
 
 ### NPX
 

--- a/smithery.yaml
+++ b/smithery.yaml
@@ -1,0 +1,17 @@
+# Smithery configuration file: https://smithery.ai/docs/config#smitheryyaml
+
+startCommand:
+  type: stdio
+  configSchema:
+    # JSON Schema defining the configuration options for the MCP.
+    type: object
+    required:
+      - searxngUrl
+    properties:
+      searxngUrl:
+        type: string
+        description: The URL of the SearxNG instance to connect to.
+  commandFunction:
+    # A function that produces the CLI command to start the MCP on stdio.
+    |-
+    (config) => ({command: 'docker', args: ['run', '-i', '--rm', '-e', `SEARXNG_URL=${config.searxngUrl}`, 'mcp-server-searxng:latest']})


### PR DESCRIPTION
This pull request introduces the following updates:

- **Smithery Configuration**: Adds a Smithery YAML file, which specifies how to start the MCP and the configuration options it supports. It allows you to [deploy](https://smithery.ai/docs/deployments) your MCP to [Smithery](https://smithery.ai?utm_campaign=pr), serving it over SSE so end-users do not need to install additional dependencies. To deploy, merge this PR, then visit your [server page](https://smithery.ai/server/@ihor-sokoliuk/server-searxng?utm_campaign=pr&modal=claim) and click "Deploy" under the deployments page.
- **README**: Updates the README to include installation instructions via Smithery and a popularity badge. _Note that the installation only works after the server is deployed on Smithery._

Please review these updates to verify their accuracy for your server and feel free to customize it to your needs. Let me know if you have any questions. 🙂