### PR TITLE
feat: Add READ_WEB_URL tool

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,10 +16,10 @@
     "scripts": {
         "build": "tsc && shx chmod +x dist/*.js",
         "prepare": "npm run build",
-        "watch": "tsc --watch"
+        "watch": "tsc --watch",
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "1.0.1"
+        "node-html-markdown": "^1.3.0"
     },
     "devDependencies": {
         "@types/node": "^22.10.2",


### PR DESCRIPTION
Fixes #4 

This PR implements a READ_WEB_URL tool, that allows the LLM to further retrieve any URL content it needed.

Here's the demo on how it work in Cursor, after the first web search, it fetch the content of the articles it found in the search result:

![image](https://github.com/user-attachments/assets/3ab23c78-dd2b-4e12-852d-62743145ab53)

Here's the prompt that used to perform search:

```
You have access to the searxng-web-search MCP tool. Use it to search the web as much as possible, especially for technical/programming/coding issues. Note that this tool will return a list of search result with a brief description and an URL. Make sure you fetch each URL to read for its content to fully understand the result.
```