### PR TITLE
Use a more accurate way of detecting the script directory

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -9,11 +9,15 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import { readFileSync } from "fs";
-import { join } from "path";
+import { join, dirname } from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
 
 // Read package.json to get the version
 const packageJson = JSON.parse(
-  readFileSync(join(process.cwd(), "package.json"), "utf-8")
+  readFileSync(join(__dirname, "package.json"), "utf-8")
 );
 const packageVersion = packageJson.version;
 


### PR DESCRIPTION
## Description
This pull request updates the `index.ts` file to improve compatibility with ES modules by replacing `process.cwd()` with `__dirname` for resolving the path to `package.json`. The change ensures the code works correctly in environments where `process.cwd()` may not point to the expected directory.

For example: When running the MCP server using `npx -y tsx \path\to\index.ts`

## Key changes:

* Added imports for `fileURLToPath` and `dirname` from the `url` and `path` modules, respectively, to support ES module path resolution.
* Introduced `__filename` and `__dirname` variables to derive the directory of the current module, replacing `process.cwd()` in the `readFileSync` call. This ensures the correct path to `package.json` is resolved.