### PR TITLE
Add support for HTTP Basic Auth

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,13 @@ An [MCP server](https://modelcontextprotocol.io/introduction) implementation tha
 2. Set the `SEARXNG_URL` environment variable to the instance URL.
 3. The default `SEARXNG_URL` value is `http://localhost:8080`.
 
+### Using Authentication
+
+If you are using a password protected SearxNG instance you can set a username and password for HTTP Basic Auth:
+
+- Set the `AUTH_USERNAME` environmental variable to your username
+- Set the `AUTH_PASSWORD` environmental variable to your password
+
 ### Usage with Claude Desktop
 
 ### Installing via Smithery

--- a/index.ts
+++ b/index.ts
@@ -145,9 +145,24 @@ async function performWebSearch(
     url.searchParams.set("safesearch", safesearch);
   }
 
-  const response = await fetch(url.toString(), {
-    method: "GET",
-  });
+  // Prepare request options with headers
+  const requestOptions: RequestInit = {
+    method: "GET"
+  };
+
+  // Add basic authentication if credentials are provided
+  const username = process.env.AUTH_USERNAME;
+  const password = process.env.AUTH_PASSWORD;
+
+  if (username && password) {
+    const base64Auth = Buffer.from(`${username}:${password}`).toString('base64');
+    requestOptions.headers = {
+      ...requestOptions.headers,
+      'Authorization': `Basic ${base64Auth}`
+    };
+  }
+
+  const response = await fetch(url.toString(), requestOptions);
 
   if (!response.ok) {
     throw new Error(


### PR DESCRIPTION
HTTP Basic Auth is a simple, but common method for securing publically facing searxng instances from unauthorized access. Adding optional support for this in the tool is useful