### PR TITLE
Allow reading a page in parts

### DIFF
--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,0 +1,87 @@
+interface CacheEntry {
+  htmlContent: string;
+  markdownContent: string;
+  timestamp: number;
+}
+
+class SimpleCache {
+  private cache = new Map<string, CacheEntry>();
+  private readonly ttlMs: number;
+  private cleanupInterval: NodeJS.Timeout | null = null;
+
+  constructor(ttlMs: number = 60000) { // Default 1 minute TTL
+    this.ttlMs = ttlMs;
+    this.startCleanup();
+  }
+
+  private startCleanup(): void {
+    // Clean up expired entries every 30 seconds
+    this.cleanupInterval = setInterval(() => {
+      this.cleanupExpired();
+    }, 30000);
+  }
+
+  private cleanupExpired(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.cache.entries()) {
+      if (now - entry.timestamp > this.ttlMs) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  get(url: string): CacheEntry | null {
+    const entry = this.cache.get(url);
+    if (!entry) {
+      return null;
+    }
+
+    // Check if expired
+    if (Date.now() - entry.timestamp > this.ttlMs) {
+      this.cache.delete(url);
+      return null;
+    }
+
+    return entry;
+  }
+
+  set(url: string, htmlContent: string, markdownContent: string): void {
+    this.cache.set(url, {
+      htmlContent,
+      markdownContent,
+      timestamp: Date.now()
+    });
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  destroy(): void {
+    if (this.cleanupInterval) {
+      clearInterval(this.cleanupInterval);
+      this.cleanupInterval = null;
+    }
+    this.clear();
+  }
+
+  // Get cache statistics for debugging
+  getStats(): { size: number; entries: Array<{ url: string; age: number }> } {
+    const now = Date.now();
+    const entries = Array.from(this.cache.entries()).map(([url, entry]) => ({
+      url,
+      age: now - entry.timestamp
+    }));
+
+    return {
+      size: this.cache.size,
+      entries
+    };
+  }
+}
+
+// Global cache instance
+export const urlCache = new SimpleCache();
+
+// Export for testing and cleanup
+export { SimpleCache };

--- a/src/types.ts
+++ b/src/types.ts
@@ -77,6 +77,28 @@ export const READ_URL_TOOL: Tool = {
         type: "string",
         description: "URL",
       },
+      startChar: {
+        type: "number",
+        description: "Starting character position for content extraction (default: 0)",
+        minimum: 0,
+      },
+      maxLength: {
+        type: "number",
+        description: "Maximum number of characters to return",
+        minimum: 1,
+      },
+      section: {
+        type: "string",
+        description: "Extract content under a specific heading (searches for heading text)",
+      },
+      paragraphRange: {
+        type: "string",
+        description: "Return specific paragraph ranges (e.g., '1-5', '3', '10-')",
+      },
+      readHeadings: {
+        type: "boolean",
+        description: "Return only a list of headings instead of full content",
+      },
     },
     required: ["url"],
   },

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -2,6 +2,7 @@ import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import { createProxyAgent } from "./proxy.js";
 import { logMessage } from "./logging.js";
+import { urlCache } from "./cache.js";
 import {
   createURLFormatError,
   createNetworkError,
@@ -14,13 +15,150 @@ import {
   type ErrorContext
 } from "./error-handler.js";
 
+interface PaginationOptions {
+  startChar?: number;
+  maxLength?: number;
+  section?: string;
+  paragraphRange?: string;
+  readHeadings?: boolean;
+}
+
+function applyCharacterPagination(content: string, startChar: number = 0, maxLength?: number): string {
+  if (startChar >= content.length) {
+    return "";
+  }
+
+  const start = Math.max(0, startChar);
+  const end = maxLength ? Math.min(content.length, start + maxLength) : content.length;
+
+  return content.slice(start, end);
+}
+
+function extractSection(markdownContent: string, sectionHeading: string): string {
+  const lines = markdownContent.split('\n');
+  const sectionRegex = new RegExp(`^#{1,6}\s*.*${sectionHeading}.*$`, 'i');
+
+  let startIndex = -1;
+  let currentLevel = 0;
+
+  // Find the section start
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (sectionRegex.test(line)) {
+      startIndex = i;
+      currentLevel = (line.match(/^#+/) || [''])[0].length;
+      break;
+    }
+  }
+
+  if (startIndex === -1) {
+    return "";
+  }
+
+  // Find the section end (next heading of same or higher level)
+  let endIndex = lines.length;
+  for (let i = startIndex + 1; i < lines.length; i++) {
+    const line = lines[i];
+    const match = line.match(/^#+/);
+    if (match && match[0].length <= currentLevel) {
+      endIndex = i;
+      break;
+    }
+  }
+
+  return lines.slice(startIndex, endIndex).join('\n');
+}
+
+function extractParagraphRange(markdownContent: string, range: string): string {
+  const paragraphs = markdownContent.split('\n\n').filter(p => p.trim().length > 0);
+
+  // Parse range (e.g., "1-5", "3", "10-")
+  const rangeMatch = range.match(/^(\d+)(?:-(\d*))?$/);
+  if (!rangeMatch) {
+    return "";
+  }
+
+  const start = parseInt(rangeMatch[1]) - 1; // Convert to 0-based index
+  const endStr = rangeMatch[2];
+
+  if (start < 0 || start >= paragraphs.length) {
+    return "";
+  }
+
+  if (endStr === undefined) {
+    // Single paragraph (e.g., "3")
+    return paragraphs[start] || "";
+  } else if (endStr === "") {
+    // Range to end (e.g., "10-")
+    return paragraphs.slice(start).join('\n\n');
+  } else {
+    // Specific range (e.g., "1-5")
+    const end = parseInt(endStr);
+    return paragraphs.slice(start, end).join('\n\n');
+  }
+}
+
+function extractHeadings(markdownContent: string): string {
+  const lines = markdownContent.split('\n');
+  const headings = lines.filter(line => /^#{1,6}\s/.test(line));
+
+  if (headings.length === 0) {
+    return "No headings found in the content.";
+  }
+
+  return headings.join('\n');
+}
+
+function applyPaginationOptions(markdownContent: string, options: PaginationOptions): string {
+  let result = markdownContent;
+
+  // Apply heading extraction first if requested
+  if (options.readHeadings) {
+    return extractHeadings(result);
+  }
+
+  // Apply section extraction
+  if (options.section) {
+    result = extractSection(result, options.section);
+    if (result === "") {
+      return `Section "${options.section}" not found in the content.`;
+    }
+  }
+
+  // Apply paragraph range filtering
+  if (options.paragraphRange) {
+    result = extractParagraphRange(result, options.paragraphRange);
+    if (result === "") {
+      return `Paragraph range "${options.paragraphRange}" is invalid or out of bounds.`;
+    }
+  }
+
+  // Apply character-based pagination last
+  if (options.startChar !== undefined || options.maxLength !== undefined) {
+    result = applyCharacterPagination(result, options.startChar, options.maxLength);
+  }
+
+  return result;
+}
+
 export async function fetchAndConvertToMarkdown(
   server: Server,
   url: string,
-  timeoutMs: number = 10000
+  timeoutMs: number = 10000,
+  paginationOptions: PaginationOptions = {}
 ) {
   const startTime = Date.now();
   logMessage(server, "info", `Fetching URL: ${url}`);
+
+  // Check cache first
+  const cachedEntry = urlCache.get(url);
+  if (cachedEntry) {
+    logMessage(server, "info", `Using cached content for URL: ${url}`);
+    const result = applyPaginationOptions(cachedEntry.markdownContent, paginationOptions);
+    const duration = Date.now() - startTime;
+    logMessage(server, "info", `Processed cached URL: ${url} (${result.length} chars in ${duration}ms)`);
+    return result;
+  }
   
   // Validate URL format
   let parsedUrl: URL;
@@ -97,12 +235,19 @@ export async function fetchAndConvertToMarkdown(
 
     if (!markdownContent || markdownContent.trim().length === 0) {
       logMessage(server, "warning", `Empty content after conversion: ${url}`);
+      // DON'T cache empty/failed conversions - return warning directly
       return createEmptyContentWarning(url, htmlContent.length, htmlContent);
     }
 
+    // Only cache successful markdown conversion
+    urlCache.set(url, htmlContent, markdownContent);
+
+    // Apply pagination options
+    const result = applyPaginationOptions(markdownContent, paginationOptions);
+
     const duration = Date.now() - startTime;
-    logMessage(server, "info", `Successfully fetched and converted URL: ${url} (${markdownContent.length} chars in ${duration}ms)`);
-    return markdownContent;
+    logMessage(server, "info", `Successfully fetched and converted URL: ${url} (${result.length} chars in ${duration}ms)`);
+    return result;
   } catch (error: any) {
     if (error.name === "AbortError") {
       logMessage(server, "error", `Timeout fetching URL: ${url} (${timeoutMs}ms)`);


### PR DESCRIPTION
Some documentation (e.g. https://docs.ntfy.sh/publish/) output exceeds length limits imposed by certain tools (e.g. Claude Code).

This PR enhances the `web_url_read tool` with pagination and filtering options to handle long web pages more efficiently, plus adds an in-memory cache for consistent results across MCP requests.

**Pagination Options (all optional, backward compatible):**

- startChar - Starting character position (default: 0)
- maxLength - Maximum characters to return
- section - Extract content under specific heading
- paragraphRange - Return specific paragraph ranges (e.g., "1-5", "3", "10-")
- readHeadings - Return only headings list instead of full content

**In-Memory Cache:**

- 1-minute TTL for URL content consistency
- Multiple requests with different pagination use cached content
- Only caches successful results, not errors/warnings
- Automatic cleanup of expired entries

**Manual Testing:**

I have tested these changes with the MCP Inspector tool as well as with [OpenCode](https://opencode.ai).