### PR TITLE
refactor(logging): merge message and data in notification params

### DIFF
--- a/src/logging.ts
+++ b/src/logging.ts
@@ -8,12 +8,16 @@ let currentLogLevel: LoggingLevel = "info";
 export function logMessage(server: Server, level: LoggingLevel, message: string, data?: unknown): void {
   if (shouldLog(level)) {
     try {
+      // Merge message and data together for the notification body
+      const notificationData = data !== undefined
+        ? (typeof data === 'object' && data !== null ? { message, ...data } : { message, data })
+        : { message };
+
       server.notification({
         method: "notifications/message",
         params: {
           level,
-          message,
-          data
+          data: notificationData
         }
       }).catch((error) => {
         // Silently ignore "Not connected" errors during server startup


### PR DESCRIPTION
### Background
Pydantic AI is emitting a verification warning when interacting with this MCP server because the field name does not match the MCP schema. 

### Change Summary
Change the notification param name to match the mcp specification

### 📎 References
 https://modelcontextprotocol.io/specification/2025-06-18/schema#loggingmessagenotification  
