### PR TITLE
feat: Add MCP tool annotations for LLM safety hints

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -29,6 +29,10 @@ export const WEB_SEARCH_TOOL: Tool = {
   description:
     "Performs a web search using the SearXNG API, ideal for general queries, news, articles, and online content. " +
     "Use this for broad information gathering, recent events, or when you need diverse web sources.",
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {
@@ -70,6 +74,10 @@ export const READ_URL_TOOL: Tool = {
   description:
     "Read the content from an URL. " +
     "Use this for further information retrieving to understand the content of each URL.",
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
   inputSchema: {
     type: "object",
     properties: {


### PR DESCRIPTION
## Summary

Adds MCP tool annotations to help LLMs understand tool behavior and make safer decisions:

| Tool | readOnlyHint | openWorldHint |
|------|-------------|---------------|
| `searxng_web_search` | `true` | `true` |
| `web_url_read` | `true` | `true` |

## Why

MCP tool annotations (introduced in SDK 1.7.0) provide hints to LLMs about tool behavior:

- **readOnlyHint**: Indicates the tool doesn't modify data (safe to call without user confirmation)
- **openWorldHint**: Indicates the tool queries unbounded external data sources (web search, URL fetching)

Both tools in this server are read-only operations that fetch data from external sources, making these annotations accurate.

## Changes

- Added `annotations` block to `WEB_SEARCH_TOOL` in `src/types.ts`
- Added `annotations` block to `READ_URL_TOOL` in `src/types.ts`

## Testing

- Build passes (`npm run build`)
- All 93 tests pass (`npm test`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)