### PR TITLE
Fix orphaned STDIO processes not cleaned up on parent exit

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -300,21 +300,29 @@ async function main() {
     // When launched via npx, signals may not propagate through the process
     // tree (npx → npm exec → sh -c → node). Detect parent death via stdin
     // EOF and signal handlers to prevent orphaned processes accumulating.
-    const shutdownStdio = () => {
-      server.close().catch(() => {});
+    let isShuttingDown = false;
+    const shutdownStdio = async () => {
+      if (isShuttingDown) return;
+      isShuttingDown = true;
+
+      // Give the server a chance to clean up, then force exit
+      const forceExit = setTimeout(() => process.exit(0), 2000);
+      forceExit.unref();
+
+      await server.close().catch(() => {});
       process.exit(0);
     };
 
-    process.on('SIGINT', shutdownStdio);
-    process.on('SIGTERM', shutdownStdio);
-    process.on('SIGHUP', shutdownStdio);
+    process.once('SIGINT', () => { shutdownStdio(); });
+    process.once('SIGTERM', () => { shutdownStdio(); });
+    process.once('SIGHUP', () => { shutdownStdio(); });
 
     // Per MCP spec, when the parent closes stdin the server should exit
-    process.stdin.on('end', shutdownStdio);
-    process.stdin.on('close', shutdownStdio);
+    process.stdin.once('end', () => { shutdownStdio(); });
+    process.stdin.once('close', () => { shutdownStdio(); });
 
-    // Periodic parent liveness check — if parent dies (PPID becomes 1 on
-    // Linux or changes), exit to avoid becoming an orphan
+    // Periodic parent liveness check — if the parent process dies, exit
+    // to avoid becoming an orphan (PPID=1 on Linux)
     const parentPid = process.ppid;
     if (parentPid && parentPid !== 1) {
       const parentCheck = setInterval(() => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -286,15 +286,47 @@ async function main() {
       console.error(`🌐 SearXNG URL: ${process.env.SEARXNG_URL}`);
       console.error("📡 Waiting for MCP client connection via STDIO...\n");
     }
-    
+
     const transport = new StdioServerTransport();
     await server.connect(transport);
-    
+
     // Log after connection is established
     logMessage(server, "info", `MCP SearXNG Server v${packageVersion} connected via STDIO`);
     logMessage(server, "info", `Log level: ${currentLogLevel}`);
     logMessage(server, "info", `Environment: ${process.env.NODE_ENV || 'development'}`);
     logMessage(server, "info", `SearXNG URL: ${process.env.SEARXNG_URL || 'not configured'}`);
+
+    // Graceful shutdown for STDIO transport.
+    // When launched via npx, signals may not propagate through the process
+    // tree (npx → npm exec → sh -c → node). Detect parent death via stdin
+    // EOF and signal handlers to prevent orphaned processes accumulating.
+    const shutdownStdio = () => {
+      server.close().catch(() => {});
+      process.exit(0);
+    };
+
+    process.on('SIGINT', shutdownStdio);
+    process.on('SIGTERM', shutdownStdio);
+    process.on('SIGHUP', shutdownStdio);
+
+    // Per MCP spec, when the parent closes stdin the server should exit
+    process.stdin.on('end', shutdownStdio);
+    process.stdin.on('close', shutdownStdio);
+
+    // Periodic parent liveness check — if parent dies (PPID becomes 1 on
+    // Linux or changes), exit to avoid becoming an orphan
+    const parentPid = process.ppid;
+    if (parentPid && parentPid !== 1) {
+      const parentCheck = setInterval(() => {
+        try {
+          process.kill(parentPid, 0);
+        } catch {
+          clearInterval(parentCheck);
+          shutdownStdio();
+        }
+      }, 5000);
+      parentCheck.unref();
+    }
   }
 }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -287,19 +287,13 @@ async function main() {
       console.error("📡 Waiting for MCP client connection via STDIO...\n");
     }
 
-    const transport = new StdioServerTransport();
-    await server.connect(transport);
-
-    // Log after connection is established
-    logMessage(server, "info", `MCP SearXNG Server v${packageVersion} connected via STDIO`);
-    logMessage(server, "info", `Log level: ${currentLogLevel}`);
-    logMessage(server, "info", `Environment: ${process.env.NODE_ENV || 'development'}`);
-    logMessage(server, "info", `SearXNG URL: ${process.env.SEARXNG_URL || 'not configured'}`);
-
     // Graceful shutdown for STDIO transport.
     // When launched via npx, signals may not propagate through the process
     // tree (npx → npm exec → sh -c → node). Detect parent death via stdin
     // EOF and signal handlers to prevent orphaned processes accumulating.
+    //
+    // Handlers are registered BEFORE server.connect() to avoid a race
+    // where the parent dies during startup before handlers are attached.
     let isShuttingDown = false;
     const shutdownStdio = async () => {
       if (isShuttingDown) return;
@@ -322,19 +316,35 @@ async function main() {
     process.stdin.once('close', () => { shutdownStdio(); });
 
     // Periodic parent liveness check — if the parent process dies, exit
-    // to avoid becoming an orphan (PPID=1 on Linux)
+    // to avoid becoming an orphan (PPID=1 on Linux). This is a third
+    // safety layer for cases where signals don't propagate and stdin
+    // pipes aren't closed (e.g. parent killed with SIGKILL).
     const parentPid = process.ppid;
     if (parentPid && parentPid !== 1) {
       const parentCheck = setInterval(() => {
         try {
           process.kill(parentPid, 0);
-        } catch {
-          clearInterval(parentCheck);
-          shutdownStdio();
+        } catch (err) {
+          const code = (err as NodeJS.ErrnoException).code;
+          if (code === 'ESRCH') {
+            // Parent process no longer exists
+            clearInterval(parentCheck);
+            shutdownStdio();
+          }
+          // EPERM means process exists but not signalable — treat as alive
         }
       }, 5000);
       parentCheck.unref();
     }
+
+    const transport = new StdioServerTransport();
+    await server.connect(transport);
+
+    // Log after connection is established
+    logMessage(server, "info", `MCP SearXNG Server v${packageVersion} connected via STDIO`);
+    logMessage(server, "info", `Log level: ${currentLogLevel}`);
+    logMessage(server, "info", `Environment: ${process.env.NODE_ENV || 'development'}`);
+    logMessage(server, "info", `SearXNG URL: ${process.env.SEARXNG_URL || 'not configured'}`);
   }
 }
 


### PR DESCRIPTION
## Problem

When `mcp-searxng` is launched as an MCP server by Claude Code (via stdio transport), the node process becomes an orphan (`PPID=1`) after the parent session ends. These orphaned processes accumulate over time and consume all available RAM.

### Real-world impact (production server, 61GB RAM):
- **1,073 orphaned `mcp-searxng` node processes** accumulated over ~2 weeks
- **~70 GB RAM consumed** (RSS ~70-90 MB per process)
- Server went into heavy swap, nearly OOM

### How to reproduce:
1. Configure mcp-searxng in Claude Code settings
2. Start a Claude Code session (the MCP server starts automatically)
3. End the session (Ctrl+C, `/exit`, terminal close, or kill the claude process)
4. Check: `pgrep -f mcp-searxng` — the node process is still running with `PPID=1`

### Root cause

When launched via `npx -y mcp-searxng`, the process tree is:
```
claude → npx → npm exec → sh -c "mcp-searxng" → node dist/index.js
```

1. **Signal propagation fails** — when Claude sends SIGTERM to npx, intermediate processes may exit, but the final node process survives because signals are not propagated through the full tree.
2. **No shutdown handler for STDIO transport** — the HTTP transport already has graceful shutdown (lines 269-279), but the STDIO transport (the default, used by Claude Code) had none.

This is a known class of issues in the MCP ecosystem:
- https://github.com/anthropics/claude-code/issues/1935
- https://github.com/anthropics/claude-code/issues/33979
- https://github.com/anthropics/claude-code/issues/16397

## Fix

Add graceful shutdown handling for STDIO transport (matching what HTTP transport already has):

1. **Signal handlers** (`SIGTERM`, `SIGINT`, `SIGHUP`) — gracefully close the server and exit
2. **stdin EOF detection** — per [MCP spec](https://modelcontextprotocol.io/specification/2025-03-26/basic/transports), when the parent closes stdin the server should terminate
3. **Parent PID liveness check** — periodic check every 5s, self-terminate if parent died
4. **Idempotent shutdown** — guard flag + `process.once()` to prevent double shutdown
5. **Graceful with timeout** — `await server.close()` with 2s force-exit fallback

## Testing

Verified in Docker (`node:20-slim`):

**Test 1: stdin close**
```bash
timeout 10 node dist/index.js < /dev/null
# Result: Process exited with code 0 ✅
```

**Test 2: SIGTERM**
```bash
node dist/index.js &
kill -TERM $!
# Result: Process exited cleanly ✅
```

Both tests pass — the process exits cleanly instead of becoming an orphan.