### PR TITLE
Fix #59: [Feature Request] Add simplied searxng_web_search tool

### DIFF
--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -7,7 +7,7 @@
  */
 
 import { strict as assert } from 'node:assert';
-import { isSearXNGWebSearchArgs } from '../../src/types.js';
+import { isSearXNGWebSearchArgs, WEB_SEARCH_SIMPLE_TOOL } from '../../src/types.js';
 import { isWebUrlReadArgs } from '../../src/index.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 
@@ -29,6 +29,14 @@ async function runTests() {
     assert.equal(isSearXNGWebSearchArgs('string'), false);
     assert.equal(isSearXNGWebSearchArgs(123), false);
     assert.equal(isSearXNGWebSearchArgs({}), false);
+  }, results);
+
+  await testFunction('WEB_SEARCH_SIMPLE_TOOL definition', () => {
+    assert.equal(WEB_SEARCH_SIMPLE_TOOL.name, 'searxng_web_search_simple');
+    assert.deepEqual(WEB_SEARCH_SIMPLE_TOOL.inputSchema.required, ['query']);
+    const props = WEB_SEARCH_SIMPLE_TOOL.inputSchema.properties as Record<string, unknown>;
+    assert.ok('query' in props, 'query property should exist');
+    assert.equal(Object.keys(props).length, 1, 'only query property should exist');
   }, results);
 
   await testFunction('isWebUrlReadArgs type guard - basic valid cases', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,7 +13,7 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 // Import modularized functionality
-import { WEB_SEARCH_TOOL, READ_URL_TOOL, isSearXNGWebSearchArgs } from "./types.js";
+import { WEB_SEARCH_TOOL, WEB_SEARCH_SIMPLE_TOOL, READ_URL_TOOL, isSearXNGWebSearchArgs } from "./types.js";
 import { logMessage, setLogLevel } from "./logging.js";
 import { performWebSearch } from "./search.js";
 import { fetchAndConvertToMarkdown } from "./url-reader.js";
@@ -96,7 +96,7 @@ const server = mcpServer.server;
 server.setRequestHandler(ListToolsRequestSchema, async () => {
   logMessage(mcpServer, "debug", "Handling list_tools request");
   return {
-    tools: [WEB_SEARCH_TOOL, READ_URL_TOOL],
+    tools: [WEB_SEARCH_TOOL, WEB_SEARCH_SIMPLE_TOOL, READ_URL_TOOL],
   };
 });
 
@@ -119,6 +119,21 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         args.language,
         args.safesearch
       );
+
+      return {
+        content: [
+          {
+            type: "text",
+            text: result,
+          },
+        ],
+      };
+    } else if (name === "searxng_web_search_simple") {
+      if (!isSearXNGWebSearchArgs(args)) {
+        throw new Error("Invalid arguments for web search");
+      }
+
+      const result = await performWebSearch(mcpServer, args.query);
 
       return {
         content: [

--- a/src/types.ts
+++ b/src/types.ts
@@ -69,6 +69,27 @@ export const WEB_SEARCH_TOOL: Tool = {
   },
 };
 
+export const WEB_SEARCH_SIMPLE_TOOL: Tool = {
+  name: "searxng_web_search_simple",
+  description:
+    "Performs a web search using the SearXNG API with only a query parameter. " +
+    "Use this simplified tool when you only need to provide a search query without additional options.",
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: {
+    type: "object",
+    properties: {
+      query: {
+        type: "string",
+        description: "The search query",
+      },
+    },
+    required: ["query"],
+  },
+};
+
 export const READ_URL_TOOL: Tool = {
   name: "web_url_read",
   description:


### PR DESCRIPTION
Closes #59

## Motivation

Local LLMs with limited context windows often struggle with the full `searxng_web_search` tool's parameter surface. A simplified variant accepting only `query` reduces token overhead and improves compatibility with smaller models that don't use optional search parameters anyway.

## Changes

**`src/types.ts`**
- Added `WEB_SEARCH_SIMPLE_TOOL` constant (exported `Tool` definition) with name `searxng_web_search_simple`, `readOnlyHint`/`openWorldHint` annotations, and an `inputSchema` containing only the required `query` string property.

**`src/index.ts`**
- Imported `WEB_SEARCH_SIMPLE_TOOL` alongside the existing tool imports.
- Added `WEB_SEARCH_SIMPLE_TOOL` to the `tools` array returned by the `ListToolsRequestSchema` handler.
- Added an `else if (name === "searxng_web_search_simple")` branch in the `CallToolRequestSchema` handler that validates args with `isSearXNGWebSearchArgs`, calls `performWebSearch(mcpServer, args.query)` with no additional parameters (falling back to server defaults), and returns the result as a `text` content block.

**`__tests__/unit/types.test.ts`**
- Imported `WEB_SEARCH_SIMPLE_TOOL` and added a `WEB_SEARCH_SIMPLE_TOOL definition` test case that asserts the tool name is `searxng_web_search_simple`, `inputSchema.required` is `['query']`, the `query` property exists, and it is the **only** property in `inputSchema.properties`.

## Testing

The new unit test in `__tests__/unit/types.test.ts` covers the tool definition shape:

```
✓ WEB_SEARCH_SIMPLE_TOOL definition
  - name === 'searxng_web_search_simple'
  - inputSchema.required deep equals ['query']
  - 'query' property exists
  - inputSchema.properties has exactly 1 key
```

Manual verification: call the tool via MCP with `{"query": "test search"}` and confirm it returns results using the server's default `language`, `time_range`, `safesearch`, and `categories` values without requiring the caller to supply them.