### PR TITLE
Fix #56: SearXNG Plugin

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,22 @@ An [MCP server](https://modelcontextprotocol.io/introduction) implementation tha
 
 <a href="https://glama.ai/mcp/servers/0j7jjyt7m9"><img width="380" height="200" src="https://glama.ai/mcp/servers/0j7jjyt7m9/badge" alt="SearXNG Server MCP server" /></a>
 
+## How It Works
+
+`mcp-searxng` is an **MCP (Model Context Protocol) server** — it is a separate process that AI assistants (such as Claude) connect to in order to perform web searches. It communicates with a SearXNG instance over SearXNG's HTTP JSON API.
+
+> **Not a SearXNG plugin:** This project cannot be installed as a native SearXNG plugin (i.e., a Python module loaded inside the SearXNG process). It is a standalone MCP server that runs alongside your SearXNG instance and queries it via its API. You point it at any existing SearXNG instance by setting the `SEARXNG_URL` environment variable.
+
+```
+AI Assistant (e.g. Claude)
+        │  MCP protocol
+        ▼
+  mcp-searxng  (this project — Node.js process)
+        │  HTTP JSON API  (SEARXNG_URL)
+        ▼
+  SearXNG instance
+```
+
 ## Features
 
 - **Web Search**: General queries, news, articles, with pagination.


### PR DESCRIPTION
Closes #56

Adds a "How It Works" section to `README.md` (between the Glama badge and the Features section) clarifying the architecture of `mcp-searxng`.

## Changes

- **`README.md`**: Inserts a new `## How It Works` section (lines 11–26) containing:
  - A prose explanation that `mcp-searxng` is a standalone Node.js MCP server that communicates with SearXNG via its HTTP JSON API, not a native Python plugin loaded inside the SearXNG process.
  - A callout block explicitly addressing the "not a SearXNG plugin" distinction.
  - An ASCII architecture diagram showing the call chain: `AI Assistant → mcp-searxng (MCP protocol) → SearXNG instance (HTTP JSON API / SEARXNG_URL)`.

## Motivation

Issue #56 asked how to install this project as a native SearXNG plugin hosted inside the SearXNG process. There was no documentation explaining that this is architecturally impossible — `mcp-searxng` is a separate Node.js process, not a Python module, and it interacts with SearXNG solely through the external HTTP JSON API via `SEARXNG_URL`. Without this section, users unfamiliar with the MCP model will repeatedly attempt plugin-style installation and find no guidance.

## Testing

Documentation-only change. Verified manually by rendering `README.md` locally:
- The new section appears between the badge and `## Features` with correct heading hierarchy.
- The ASCII diagram renders as a preformatted block.
- The blockquote callout displays the "Not a SearXNG plugin" note correctly in GitHub Markdown preview.