### PR TITLE
feat: add categories parameter to searxng_web_search tool

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -117,7 +117,8 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         args.pageno,
         args.time_range,
         args.language,
-        args.safesearch
+        args.safesearch,
+        args.categories
       );
 
       return {

--- a/src/search.ts
+++ b/src/search.ts
@@ -18,7 +18,8 @@ export async function performWebSearch(
   pageno: number = 1,
   time_range?: string,
   language: string = "all",
-  safesearch?: number
+  safesearch?: number,
+  categories?: string
 ) {
   const startTime = Date.now();
   
@@ -27,7 +28,8 @@ export async function performWebSearch(
     `page ${pageno}`,
     `lang: ${language}`,
     time_range ? `time: ${time_range}` : null,
-    safesearch ? `safesearch: ${safesearch}` : null
+    safesearch ? `safesearch: ${safesearch}` : null,
+    categories ? `categories: ${categories}` : null
   ].filter(Boolean).join(", ");
   
   logMessage(mcpServer, "info", `Starting web search: "${query}" (${searchParams})`);
@@ -70,6 +72,10 @@ export async function performWebSearch(
 
   if (safesearch !== undefined && [0, 1, 2].includes(safesearch)) {
     url.searchParams.set("safesearch", safesearch.toString());
+  }
+
+  if (categories) {
+    url.searchParams.set("categories", categories);
   }
 
   // Prepare request options with headers

--- a/src/types.ts
+++ b/src/types.ts
@@ -15,6 +15,7 @@ export function isSearXNGWebSearchArgs(args: unknown): args is {
   time_range?: string;
   language?: string;
   safesearch?: number;
+  categories?: string;
 } {
   return (
     typeof args === "object" &&
@@ -63,6 +64,14 @@ export const WEB_SEARCH_TOOL: Tool = {
           "Safe search filter level (0: None, 1: Moderate, 2: Strict)",
         enum: [0, 1, 2],
         default: 0,
+      },
+      categories: {
+        type: "string",
+        description:
+          "Comma-separated search categories to filter results by engine type. " +
+          "Available: general, images, videos, news, map, music, it, science, files, social media. " +
+          "The 'it' category targets developer engines (GitHub, StackOverflow, npm, PyPI, Docker Hub, crates.io). " +
+          "Multiple categories can be combined, e.g. 'it,general'.",
       },
     },
     required: ["query"],


### PR DESCRIPTION
## Summary

- Adds an optional `categories` parameter to the `searxng_web_search` tool, mapping to SearXNG's native `?categories=` query parameter
- Enables filtering search results by engine type (e.g. `it` for developer engines, `science` for academic sources, `news` for news)
- Three-file change touching types, search execution, and tool dispatch — fully backwards compatible

## Motivation

SearXNG organizes its search engines into categories (`general`, `it`, `science`, `news`, `images`, etc.). The `it` category is particularly valuable for developer workflows as it targets GitHub, StackOverflow, npm, PyPI, Docker Hub, and crates.io. Currently there is no way to leverage this from the MCP tool — all searches go through the default category set.

This parameter allows MCP clients to target specific engine categories, significantly improving result relevance for domain-specific queries. Multiple categories can be combined (e.g. `it,general`).

## Changes

| File | Change |
|------|--------|
| `src/types.ts` | Add `categories?: string` to type guard interface; add `categories` property to `WEB_SEARCH_TOOL` input schema |
| `src/search.ts` | Add `categories` parameter to `performWebSearch` function signature, logging, and URL params |
| `src/index.ts` | Pass `args.categories` through to `performWebSearch` call |

## Backwards Compatibility

The parameter is optional with no default value. When omitted, behavior is identical to before — SearXNG uses its default category set. No breaking changes.

## Available Categories

Per SearXNG docs: `general`, `images`, `videos`, `news`, `map`, `music`, `it`, `science`, `files`, `social media`

## Test Plan

- [ ] Build passes (`npm run build` -- verified locally)
- [ ] Search without `categories` parameter works as before (no regression)
- [ ] Search with `categories: "it"` returns results from developer engines
- [ ] Search with `categories: "it,general"` combines multiple category results
- [ ] Invalid category values are passed through (SearXNG handles gracefully)