### PR TITLE
feat: add searxng_instance_info tool backed by /config

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Replace `YOUR_SEARXNG_INSTANCE_URL` with the URL of your SearXNG instance (e.g. 
 ## Features
 
 - **Web Search**: General queries, news, articles, with pagination.
+- **Instance Discovery**: Inspect live SearXNG categories, engine counts, plugins, locales, and optional engine details from `/config`.
 - **URL Content Reading**: Advanced content extraction with pagination, section filtering, and heading extraction.
 - **Intelligent Caching**: URL content is cached with TTL (Time-To-Live) to improve performance and reduce redundant requests.
 - **Pagination**: Control which page of results to retrieve.
@@ -74,6 +75,13 @@ AI Assistant (e.g. Claude)
     - `section` (string, optional): Extract content under a specific heading (searches for heading text)
     - `paragraphRange` (string, optional): Return specific paragraph ranges (e.g., '1-5', '3', '10-')
     - `readHeadings` (boolean, optional): Return only a list of headings instead of full content
+
+- **searxng_instance_info**
+  - Inspect the connected SearXNG instance using its `/config` endpoint
+  - Inputs:
+    - `includeEngines` (boolean, optional): Include matching engine details in the response (default `false`)
+    - `includeDisabled` (boolean, optional): Include disabled engines when returning engine details (default `false`)
+    - `category` (string, optional): Filter the engine list to a specific category such as `it`, `news`, or `science`
 
 ## Installation
 

--- a/__tests__/integration/index.test.ts
+++ b/__tests__/integration/index.test.ts
@@ -12,7 +12,10 @@ import {
   isWebUrlReadArgs,
   createMcpServer
 } from '../../src/index.js';
-import { isSearXNGWebSearchArgs } from '../../src/types.js';
+import {
+  isSearXNGInstanceInfoArgs,
+  isSearXNGWebSearchArgs,
+} from '../../src/types.js';
 import { createConfigResource, createHelpResource } from '../../src/resources.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 
@@ -30,6 +33,7 @@ async function runTests() {
   await testFunction('Call tool handler - unknown tool error', async () => {
     const unknownToolRequest = { name: 'unknown_tool', arguments: {} };
     assert.notEqual(unknownToolRequest.name, 'searxng_web_search');
+    assert.notEqual(unknownToolRequest.name, 'searxng_instance_info');
     assert.notEqual(unknownToolRequest.name, 'web_url_read');
 
     // Simulate error response
@@ -161,6 +165,13 @@ async function runTests() {
     assert.ok(!isSearXNGWebSearchArgs({}));
   }, results);
 
+  await testFunction('Tool arguments validation - instance info tool', () => {
+    assert.ok(isSearXNGInstanceInfoArgs(undefined));
+    assert.ok(isSearXNGInstanceInfoArgs({ includeEngines: true, category: 'it' }));
+    assert.ok(!isSearXNGInstanceInfoArgs({ includeDisabled: 'no' }));
+    assert.ok(!isSearXNGInstanceInfoArgs({ category: '' }));
+  }, results);
+
   await testFunction('Tool arguments validation - URL read tool', () => {
     // Valid cases with various pagination parameters
     assert.ok(isWebUrlReadArgs({ url: 'https://example.com' }));
@@ -193,6 +204,15 @@ async function runTests() {
     const server = createMcpServer();
     assert.ok(server, 'should return a truthy value');
     assert.ok(server.server, 'should expose underlying Server via .server');
+  }, results);
+
+  await testFunction('Config resource reflects all exposed tools', () => {
+    const config = JSON.parse(createConfigResource());
+    assert.deepEqual(config.capabilities.tools, [
+      'searxng_web_search',
+      'searxng_instance_info',
+      'web_url_read',
+    ]);
   }, results);
 
   await testFunction('createMcpServer returns independent instances per call', () => {

--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -16,6 +16,7 @@ import { runTests as runProxyTests } from './unit/proxy.test.js';
 import { runTests as runErrorHandlerTests } from './unit/error-handler.test.js';
 import { runTests as runResourcesTests } from './unit/resources.test.js';
 import { runTests as runSearchTests } from './unit/search.test.js';
+import { runTests as runInstanceInfoTests } from './unit/instance-info.test.js';
 import { runTests as runUrlReaderTests } from './unit/url-reader.test.js';
 import { runTests as runTlsConfigTests } from './unit/tls-config.test.js';
 import { runTests as runHttpServerTests } from './integration/http-server.test.js';
@@ -36,6 +37,7 @@ const testSuites: TestSuite[] = [
   { name: 'Error Handler', category: 'unit', run: runErrorHandlerTests },
   { name: 'Resources', category: 'unit', run: runResourcesTests },
   { name: 'Search', category: 'unit', run: runSearchTests },
+  { name: 'Instance Info', category: 'unit', run: runInstanceInfoTests },
   { name: 'URL Reader', category: 'unit', run: runUrlReaderTests },
   { name: 'TLS Config', category: 'unit', run: runTlsConfigTests },
 

--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -1,0 +1,261 @@
+#!/usr/bin/env tsx
+
+/**
+ * Unit Tests: instance-info.ts
+ *
+ * Tests for SearXNG instance discovery functionality.
+ */
+
+import { strict as assert } from "node:assert";
+import {
+  fetchInstanceConfig,
+  formatInstanceInfo,
+  getInstanceInfo,
+} from "../../src/instance-info.js";
+import { createMockServer } from "../helpers/mock-server.js";
+import {
+  FetchMocker,
+  createCapturingMockFetch,
+  createMockFetch,
+} from "../helpers/mock-fetch.js";
+import {
+  createTestResults,
+  printTestSummary,
+  testFunction,
+} from "../helpers/test-utils.js";
+import { EnvManager } from "../helpers/env-utils.js";
+
+const results = createTestResults();
+const fetchMocker = new FetchMocker();
+const envManager = new EnvManager();
+
+async function runTests() {
+  console.log("🧪 Testing: instance-info.ts\n");
+
+  await testFunction("Error handling for missing SEARXNG_URL", async () => {
+    envManager.delete("SEARXNG_URL");
+
+    const mockServer = createMockServer();
+
+    try {
+      await fetchInstanceConfig(mockServer as any);
+      assert.fail("Should have thrown configuration error");
+    } catch (error: any) {
+      assert.ok(
+        error.message.includes("SEARXNG_URL not set") ||
+          error.message.includes("Configuration")
+      );
+    }
+
+    envManager.restore();
+  }, results);
+
+  await testFunction("Config URL construction with subpath", async () => {
+    envManager.set("SEARXNG_URL", "https://test-searx.example.com/subpath");
+
+    const mockServer = createMockServer();
+    const capture = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await capture.mockFetch(url, options);
+      throw new Error("MOCK_NETWORK_ERROR");
+    });
+
+    try {
+      await fetchInstanceConfig(mockServer as any);
+    } catch {
+      // Expected mock failure after capture.
+    }
+
+    const url = new URL(capture.getCapturedUrl());
+    assert.ok(
+      url.pathname.includes("/subpath/config"),
+      `Expected path to contain /subpath/config, got ${url.pathname}`
+    );
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction("Authentication header construction", async () => {
+    envManager.set("SEARXNG_URL", "https://test-searx.example.com");
+    envManager.set("AUTH_USERNAME", "testuser");
+    envManager.set("AUTH_PASSWORD", "testpass");
+
+    const mockServer = createMockServer();
+    const capture = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await capture.mockFetch(url, options);
+      throw new Error("MOCK_NETWORK_ERROR");
+    });
+
+    try {
+      await fetchInstanceConfig(mockServer as any);
+    } catch {
+      // Expected mock failure after capture.
+    }
+
+    const options = capture.getCapturedOptions();
+    const headers = options?.headers as Record<string, string>;
+    assert.ok(headers.Authorization);
+    assert.ok(headers.Authorization.startsWith("Basic "));
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction("Summary formatting includes live capability data", async () => {
+    envManager.set("SEARXNG_URL", "https://test-searx.example.com");
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(
+      createMockFetch({
+        json: {
+          autocomplete: "duckduckgo",
+          categories: ["general", "it", "science"],
+          default_locale: "en",
+          default_theme: "simple",
+          engines: [
+            {
+              categories: ["general"],
+              enabled: true,
+              name: "duckduckgo",
+              shortcut: "ddg",
+            },
+            {
+              categories: ["it"],
+              enabled: false,
+              name: "github",
+              shortcut: "gh",
+            },
+          ],
+          instance_name: "Test Instance",
+          locales: {
+            en: "English",
+            fr: "French",
+          },
+          plugins: [
+            { enabled: true, name: "HTTPS rewrite" },
+            { enabled: false, name: "Tracker URL remover" },
+          ],
+          safe_search: 1,
+        },
+      })
+    );
+
+    const result = await getInstanceInfo(mockServer as any);
+    assert.ok(result.includes("Instance Name: Test Instance"));
+    assert.ok(result.includes("Categories (3): general, it, science"));
+    assert.ok(result.includes("Engines: 1 enabled / 2 total"));
+    assert.ok(result.includes("Locales Available: 2"));
+    assert.ok(result.includes("HTTPS rewrite (enabled)"));
+    assert.ok(result.includes("Tracker URL remover (disabled)"));
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction(
+    "Engine filtering uses category and excludes disabled engines by default",
+    async () => {
+      const formatted = formatInstanceInfo(
+        {
+          categories: ["general", "it"],
+          default_locale: "en",
+          default_theme: "simple",
+          engines: [
+            {
+              categories: ["it"],
+              enabled: true,
+              name: "github",
+              shortcut: "gh",
+            },
+            {
+              categories: ["it"],
+              enabled: false,
+              name: "gitlab",
+              shortcut: "gl",
+            },
+            {
+              categories: ["general"],
+              enabled: true,
+              name: "duckduckgo",
+              shortcut: "ddg",
+            },
+          ],
+          instance_name: "Test Instance",
+          locales: {},
+          plugins: [],
+          safe_search: 0,
+        },
+        { includeEngines: true, category: "it" }
+      );
+
+      assert.ok(formatted.includes('Matching Engines (1) for category "it":'));
+      assert.ok(formatted.includes("- github | shortcut: gh | categories: it | enabled: yes"));
+      assert.ok(!formatted.includes("gitlab"));
+      assert.ok(!formatted.includes("duckduckgo | shortcut: ddg"));
+    },
+    results
+  );
+
+  await testFunction("Disabled engines are included on request", () => {
+    const formatted = formatInstanceInfo(
+      {
+        categories: ["it"],
+        default_locale: "en",
+        default_theme: "simple",
+        engines: [
+          {
+            categories: ["it"],
+            enabled: false,
+            name: "gitlab",
+            shortcut: "gl",
+          },
+        ],
+        instance_name: "Test Instance",
+        locales: {},
+        plugins: [],
+        safe_search: 0,
+      },
+      { includeEngines: true, includeDisabled: true, category: "it" }
+    );
+
+    assert.ok(formatted.includes("Matching Engines (1)"));
+    assert.ok(formatted.includes("- gitlab | shortcut: gl | categories: it | enabled: no"));
+  }, results);
+
+  await testFunction("Invalid config payload shape is rejected", async () => {
+    envManager.set("SEARXNG_URL", "https://test-searx.example.com");
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(createMockFetch({ json: "not-an-object" }));
+
+    try {
+      await fetchInstanceConfig(mockServer as any);
+      assert.fail("Should have thrown config shape error");
+    } catch (error: any) {
+      assert.ok(
+        error.message.includes("Config Error") ||
+          error.message.includes("response shape")
+      );
+    }
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  printTestSummary(results, "Instance Info Module");
+  return results;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  runTests()
+    .then((summary) => {
+      process.exit(summary.failed > 0 ? 1 : 0);
+    })
+    .catch(console.error);
+}
+
+export { runTests };

--- a/__tests__/unit/resources.test.ts
+++ b/__tests__/unit/resources.test.ts
@@ -52,6 +52,17 @@ async function runTests() {
     assert.ok(help.includes('searxng') || help.includes('search') || help.includes('SearXNG'));
   }, results);
 
+  await testFunction('createConfigResource lists the instance info tool', () => {
+    const config = JSON.parse(createConfigResource());
+    assert.ok(config.capabilities.tools.includes('searxng_instance_info'));
+  }, results);
+
+  await testFunction('createHelpResource documents instance discovery', () => {
+    const help = createHelpResource();
+    assert.ok(help.includes('searxng_instance_info'));
+    assert.ok(help.includes('/config'));
+  }, results);
+
   await testFunction('createConfigResource - hasAuth true when both credentials set', () => {
     envManager.set('AUTH_USERNAME', 'testuser');
     envManager.set('AUTH_PASSWORD', 'testpass');

--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -7,7 +7,10 @@
  */
 
 import { strict as assert } from 'node:assert';
-import { isSearXNGWebSearchArgs } from '../../src/types.js';
+import {
+  isSearXNGInstanceInfoArgs,
+  isSearXNGWebSearchArgs,
+} from '../../src/types.js';
 import { isWebUrlReadArgs } from '../../src/index.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 
@@ -72,6 +75,21 @@ async function runTests() {
     assert.equal(isWebUrlReadArgs({ url: 'https://example.com', section: 123 }), false);
     assert.equal(isWebUrlReadArgs({ url: 'https://example.com', paragraphRange: 123 }), false);
     assert.equal(isWebUrlReadArgs({ url: 'https://example.com', readHeadings: 'invalid' }), false);
+  }, results);
+
+  await testFunction('isSearXNGInstanceInfoArgs type guard - valid cases', () => {
+    assert.equal(isSearXNGInstanceInfoArgs(undefined), true);
+    assert.equal(isSearXNGInstanceInfoArgs({}), true);
+    assert.equal(isSearXNGInstanceInfoArgs({ includeEngines: true }), true);
+    assert.equal(isSearXNGInstanceInfoArgs({ includeDisabled: false, category: 'it' }), true);
+  }, results);
+
+  await testFunction('isSearXNGInstanceInfoArgs type guard - invalid cases', () => {
+    assert.equal(isSearXNGInstanceInfoArgs(null), false);
+    assert.equal(isSearXNGInstanceInfoArgs('string'), false);
+    assert.equal(isSearXNGInstanceInfoArgs({ includeEngines: 'yes' }), false);
+    assert.equal(isSearXNGInstanceInfoArgs({ includeDisabled: 1 }), false);
+    assert.equal(isSearXNGInstanceInfoArgs({ category: '' }), false);
   }, results);
 
   printTestSummary(results, 'Types Module');

--- a/src/index.ts
+++ b/src/index.ts
@@ -12,9 +12,16 @@ import {
 } from "@modelcontextprotocol/sdk/types.js";
 
 // Import modularized functionality
-import { WEB_SEARCH_TOOL, READ_URL_TOOL, isSearXNGWebSearchArgs } from "./types.js";
+import {
+  WEB_SEARCH_TOOL,
+  READ_URL_TOOL,
+  INSTANCE_INFO_TOOL,
+  isSearXNGInstanceInfoArgs,
+  isSearXNGWebSearchArgs,
+} from "./types.js";
 import { logMessage, setLogLevel, getCurrentLogLevel } from "./logging.js";
 import { performWebSearch } from "./search.js";
+import { getInstanceInfo } from "./instance-info.js";
 import { fetchAndConvertToMarkdown } from "./url-reader.js";
 import { createConfigResource, createHelpResource } from "./resources.js";
 import { createHttpServer } from "./http-server.js";
@@ -94,7 +101,7 @@ export function createMcpServer(): McpServer {
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     logMessage(mcpServer, "debug", "Handling list_tools request");
     return {
-      tools: [WEB_SEARCH_TOOL, READ_URL_TOOL],
+      tools: [WEB_SEARCH_TOOL, INSTANCE_INFO_TOOL, READ_URL_TOOL],
     };
   });
 
@@ -117,6 +124,31 @@ export function createMcpServer(): McpServer {
           args.language,
           args.safesearch
         );
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: result,
+            },
+          ],
+        };
+      } else if (name === "searxng_instance_info") {
+        if (!isSearXNGInstanceInfoArgs(args)) {
+          throw new Error("Invalid arguments for instance info");
+        }
+
+        const instanceInfoArgs = (args ?? {}) as {
+          includeEngines?: boolean;
+          includeDisabled?: boolean;
+          category?: string;
+        };
+
+        const result = await getInstanceInfo(mcpServer, {
+          includeEngines: instanceInfoArgs.includeEngines,
+          includeDisabled: instanceInfoArgs.includeDisabled,
+          category: instanceInfoArgs.category,
+        });
 
         return {
           content: [

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -1,0 +1,335 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { createDefaultAgent, createProxyAgent, ProxyType } from "./proxy.js";
+import { logMessage } from "./logging.js";
+import {
+  MCPSearXNGError,
+  createJSONError,
+  createNetworkError,
+  createServerError,
+  type ErrorContext,
+  validateEnvironment,
+} from "./error-handler.js";
+import {
+  SearXNGInstanceConfig,
+  SearXNGInstanceEngine,
+  SearXNGInstancePlugin,
+} from "./types.js";
+
+export interface InstanceInfoOptions {
+  includeEngines?: boolean;
+  includeDisabled?: boolean;
+  category?: string;
+}
+
+function normalizeCategory(category?: string): string | undefined {
+  const trimmed = category?.trim();
+  return trimmed ? trimmed.toLowerCase() : undefined;
+}
+
+function normalizeConfig(data: unknown): SearXNGInstanceConfig {
+  if (typeof data !== "object" || data === null) {
+    throw new MCPSearXNGError(
+      "🔍 SearXNG Config Error: Invalid /config response shape"
+    );
+  }
+
+  const typedData = data as Record<string, unknown>;
+
+  const categories = Array.isArray(typedData.categories)
+    ? typedData.categories.filter(
+        (category): category is string => typeof category === "string"
+      )
+    : [];
+
+  const engines = Array.isArray(typedData.engines)
+    ? typedData.engines
+        .filter(
+          (engine): engine is Record<string, unknown> =>
+            typeof engine === "object" && engine !== null
+        )
+        .map(
+          (engine): SearXNGInstanceEngine => ({
+            categories: Array.isArray(engine.categories)
+              ? engine.categories.filter(
+                  (category): category is string => typeof category === "string"
+                )
+              : [],
+            enabled:
+              typeof engine.enabled === "boolean" ? engine.enabled : undefined,
+            name: typeof engine.name === "string" ? engine.name : undefined,
+            shortcut:
+              typeof engine.shortcut === "string" ? engine.shortcut : undefined,
+          })
+        )
+    : [];
+
+  const plugins = Array.isArray(typedData.plugins)
+    ? typedData.plugins
+        .filter(
+          (plugin): plugin is Record<string, unknown> =>
+            typeof plugin === "object" && plugin !== null
+        )
+        .map(
+          (plugin): SearXNGInstancePlugin => ({
+            enabled:
+              typeof plugin.enabled === "boolean" ? plugin.enabled : undefined,
+            name: typeof plugin.name === "string" ? plugin.name : undefined,
+          })
+        )
+    : [];
+
+  const locales =
+    typeof typedData.locales === "object" && typedData.locales !== null
+      ? Object.entries(typedData.locales).reduce<Record<string, string>>(
+          (result, [key, value]) => {
+            if (typeof value === "string") {
+              result[key] = value;
+            }
+            return result;
+          },
+          {}
+        )
+      : {};
+
+  return {
+    autocomplete:
+      typeof typedData.autocomplete === "string"
+        ? typedData.autocomplete
+        : undefined,
+    categories,
+    default_locale:
+      typeof typedData.default_locale === "string"
+        ? typedData.default_locale
+        : undefined,
+    default_theme:
+      typeof typedData.default_theme === "string"
+        ? typedData.default_theme
+        : undefined,
+    engines,
+    instance_name:
+      typeof typedData.instance_name === "string"
+        ? typedData.instance_name
+        : undefined,
+    locales,
+    plugins,
+    safe_search:
+      typeof typedData.safe_search === "number"
+        ? typedData.safe_search
+        : undefined,
+  };
+}
+
+function buildEngineLines(engines: SearXNGInstanceEngine[]): string[] {
+  return engines
+    .filter((engine) => typeof engine.name === "string" && engine.name.length > 0)
+    .map((engine) => {
+      const parts = [engine.name!];
+
+      if (engine.shortcut) {
+        parts.push(`shortcut: ${engine.shortcut}`);
+      }
+
+      if (engine.categories && engine.categories.length > 0) {
+        parts.push(`categories: ${engine.categories.join(", ")}`);
+      }
+
+      parts.push(`enabled: ${engine.enabled === false ? "no" : "yes"}`);
+      return `- ${parts.join(" | ")}`;
+    });
+}
+
+function filterEngines(
+  engines: SearXNGInstanceEngine[],
+  options: InstanceInfoOptions
+): SearXNGInstanceEngine[] {
+  const normalizedCategory = normalizeCategory(options.category);
+
+  return engines.filter((engine) => {
+    if (!options.includeDisabled && engine.enabled === false) {
+      return false;
+    }
+
+    if (!normalizedCategory) {
+      return true;
+    }
+
+    return (
+      engine.categories?.some(
+        (category) => category.toLowerCase() === normalizedCategory
+      ) ?? false
+    );
+  });
+}
+
+function formatPlugins(plugins: SearXNGInstancePlugin[]): string {
+  if (plugins.length === 0) {
+    return "none";
+  }
+
+  const pluginDescriptions = plugins
+    .filter((plugin) => typeof plugin.name === "string" && plugin.name.length > 0)
+    .map(
+      (plugin) =>
+        `${plugin.name} (${plugin.enabled === false ? "disabled" : "enabled"})`
+    );
+
+  return pluginDescriptions.length > 0
+    ? pluginDescriptions.join(", ")
+    : "none";
+}
+
+export function formatInstanceInfo(
+  config: SearXNGInstanceConfig,
+  options: InstanceInfoOptions = {}
+): string {
+  const engines = config.engines ?? [];
+  const enabledEngines = engines.filter((engine) => engine.enabled !== false);
+  const shouldIncludeEngines = options.includeEngines || !!options.category;
+  const matchingEngines = shouldIncludeEngines
+    ? filterEngines(engines, options)
+    : [];
+  const lines = [
+    `Instance Name: ${config.instance_name || "unknown"}`,
+    `Default Locale: ${config.default_locale || "instance default"}`,
+    `Default Theme: ${config.default_theme || "instance default"}`,
+    `Safe Search Default: ${
+      config.safe_search !== undefined ? config.safe_search : "instance default"
+    }`,
+    `Autocomplete Provider: ${config.autocomplete || "disabled"}`,
+    `Categories (${config.categories?.length || 0}): ${
+      config.categories && config.categories.length > 0
+        ? config.categories.join(", ")
+        : "none"
+    }`,
+    `Locales Available: ${Object.keys(config.locales || {}).length}`,
+    `Engines: ${enabledEngines.length} enabled / ${engines.length} total`,
+    `Plugins: ${formatPlugins(config.plugins || [])}`,
+  ];
+
+  if (shouldIncludeEngines) {
+    lines.push("");
+    lines.push(
+      `Matching Engines (${matchingEngines.length})${
+        options.category ? ` for category "${options.category}"` : ""
+      }:`
+    );
+
+    const engineLines = buildEngineLines(matchingEngines);
+    if (engineLines.length === 0) {
+      lines.push("- none");
+    } else {
+      lines.push(...engineLines);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+export async function fetchInstanceConfig(
+  mcpServer: McpServer
+): Promise<SearXNGInstanceConfig> {
+  const validationError = validateEnvironment();
+  if (validationError) {
+    logMessage(mcpServer, "error", "Configuration invalid");
+    throw new MCPSearXNGError(validationError);
+  }
+
+  const searxngUrl = process.env.SEARXNG_URL!;
+  const parsedUrl = new URL(
+    searxngUrl.endsWith("/") ? searxngUrl : `${searxngUrl}/`
+  );
+  const url = new URL("config", parsedUrl);
+
+  const requestOptions: RequestInit = {
+    method: "GET",
+  };
+
+  const proxyAgent = createProxyAgent(url.toString(), ProxyType.SEARCH);
+  const dispatcher = proxyAgent ?? createDefaultAgent();
+  if (dispatcher) {
+    (requestOptions as any).dispatcher = dispatcher;
+  }
+
+  const username = process.env.AUTH_USERNAME;
+  const password = process.env.AUTH_PASSWORD;
+  if (username && password) {
+    const base64Auth = Buffer.from(`${username}:${password}`).toString("base64");
+    requestOptions.headers = {
+      ...requestOptions.headers,
+      Authorization: `Basic ${base64Auth}`,
+    };
+  }
+
+  const userAgent = process.env.USER_AGENT;
+  if (userAgent) {
+    requestOptions.headers = {
+      ...requestOptions.headers,
+      "User-Agent": userAgent,
+    };
+  }
+
+  let response: Response;
+  try {
+    logMessage(mcpServer, "info", `Fetching SearXNG instance config: ${url}`);
+    response = await fetch(url.toString(), requestOptions);
+  } catch (error: any) {
+    logMessage(
+      mcpServer,
+      "error",
+      `Network error during /config request: ${error.message}`,
+      { url: url.toString() }
+    );
+    const context: ErrorContext = {
+      url: url.toString(),
+      searxngUrl,
+      proxyAgent: !!dispatcher,
+      username,
+    };
+    throw createNetworkError(error, context);
+  }
+
+  if (!response.ok) {
+    let responseBody: string;
+    try {
+      responseBody = await response.text();
+    } catch {
+      responseBody = "[Could not read response body]";
+    }
+
+    const context: ErrorContext = {
+      url: url.toString(),
+      searxngUrl,
+    };
+    throw createServerError(
+      response.status,
+      response.statusText,
+      responseBody,
+      context
+    );
+  }
+
+  let data: unknown;
+  try {
+    data = (await response.json()) as unknown;
+  } catch {
+    let responseText: string;
+    try {
+      responseText = await response.text();
+    } catch {
+      responseText = "[Could not read response text]";
+    }
+
+    const context: ErrorContext = { url: url.toString() };
+    throw createJSONError(responseText, context);
+  }
+
+  return normalizeConfig(data);
+}
+
+export async function getInstanceInfo(
+  mcpServer: McpServer,
+  options: InstanceInfoOptions = {}
+): Promise<string> {
+  const config = await fetchInstanceConfig(mcpServer);
+  return formatInstanceInfo(config, options);
+}

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -23,7 +23,7 @@ export function createConfigResource() {
       currentLogLevel: getCurrentLogLevel()
     },
     capabilities: {
-      tools: ["searxng_web_search", "web_url_read"],
+      tools: ["searxng_web_search", "searxng_instance_info", "web_url_read"],
       logging: true,
       resources: true,
       transports: process.env.MCP_HTTP_PORT ? ["stdio", "http"] : ["stdio"]
@@ -51,7 +51,15 @@ Performs web searches using the configured SearXNG instance.
 - \`language\` (optional): Language code like "en", "fr", "de" (default: "all")
 - \`safesearch\` (optional): Safe search level - 0 (none), 1 (moderate), 2 (strict)
 
-### 2. web_url_read
+### 2. searxng_instance_info
+Retrieves live capability data from the configured SearXNG instance using the \`/config\` endpoint.
+
+**Parameters:**
+- \`includeEngines\` (optional): Include matching engine details in the response
+- \`includeDisabled\` (optional): Include disabled engines when returning engine details
+- \`category\` (optional): Filter the engine list to a specific SearXNG category
+
+### 3. web_url_read
 Reads and converts web page content to Markdown format.
 
 **Parameters:**
@@ -89,6 +97,12 @@ For network-exposed HTTP transport, enable:
 \`\`\`
 Tool: searxng_web_search
 Args: {"query": "latest AI developments", "time_range": "day"}
+\`\`\`
+
+### Inspect instance capabilities
+\`\`\`
+Tool: searxng_instance_info
+Args: {"includeEngines": true, "category": "it"}
 \`\`\`
 
 ### Read a specific article

--- a/src/types.ts
+++ b/src/types.ts
@@ -9,6 +9,36 @@ export interface SearXNGWeb {
   }>;
 }
 
+export interface SearXNGInstanceEngine {
+  categories?: string[];
+  enabled?: boolean;
+  name?: string;
+  shortcut?: string;
+}
+
+export interface SearXNGInstancePlugin {
+  enabled?: boolean;
+  name?: string;
+}
+
+export interface SearXNGInstanceConfig {
+  autocomplete?: string;
+  categories?: string[];
+  default_locale?: string;
+  default_theme?: string;
+  engines?: SearXNGInstanceEngine[];
+  instance_name?: string;
+  locales?: Record<string, string>;
+  plugins?: SearXNGInstancePlugin[];
+  safe_search?: number;
+}
+
+export interface SearXNGInstanceInfoArgs {
+  includeEngines?: boolean;
+  includeDisabled?: boolean;
+  category?: string;
+}
+
 export function isSearXNGWebSearchArgs(args: unknown): args is {
   query: string;
   pageno?: number;
@@ -22,6 +52,46 @@ export function isSearXNGWebSearchArgs(args: unknown): args is {
     "query" in args &&
     typeof (args as { query: string }).query === "string"
   );
+}
+
+export function isSearXNGInstanceInfoArgs(
+  args: unknown
+): args is SearXNGInstanceInfoArgs | undefined {
+  if (args === undefined) {
+    return true;
+  }
+
+  if (typeof args !== "object" || args === null) {
+    return false;
+  }
+
+  const typedArgs = args as Record<string, unknown>;
+
+  if (
+    typedArgs.includeEngines !== undefined &&
+    typeof typedArgs.includeEngines !== "boolean"
+  ) {
+    return false;
+  }
+
+  if (
+    typedArgs.includeDisabled !== undefined &&
+    typeof typedArgs.includeDisabled !== "boolean"
+  ) {
+    return false;
+  }
+
+  if (typedArgs.category !== undefined) {
+    if (typeof typedArgs.category !== "string") {
+      return false;
+    }
+
+    if (typedArgs.category.trim() === "") {
+      return false;
+    }
+  }
+
+  return true;
 }
 
 export const WEB_SEARCH_TOOL: Tool = {
@@ -66,6 +136,39 @@ export const WEB_SEARCH_TOOL: Tool = {
       },
     },
     required: ["query"],
+  },
+};
+
+export const INSTANCE_INFO_TOOL: Tool = {
+  name: "searxng_instance_info",
+  description:
+    "Retrieves live configuration details from the configured SearXNG instance using its /config endpoint. " +
+    "Use this before category-specific or engine-specific searches when you need to discover what the instance actually supports.",
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: {
+    type: "object",
+    properties: {
+      includeEngines: {
+        type: "boolean",
+        description:
+          "Include matching engine details in the response. Defaults to false.",
+        default: false,
+      },
+      includeDisabled: {
+        type: "boolean",
+        description:
+          "Include disabled engines when returning engine details. Defaults to false.",
+        default: false,
+      },
+      category: {
+        type: "string",
+        description:
+          "Optional category filter for the engine list. Supplying this also implies engine details should be included.",
+      },
+    },
   },
 };
 


### PR DESCRIPTION
## Summary

Adds a new read-only MCP tool, `searxng_instance_info`, that fetches and summarizes live instance capabilities from the configured SearXNG `/config` endpoint.

## Why

`mcp-searxng` currently exposes server config/help resources, but not live SearXNG instance capabilities. Agents have no way to discover supported categories, enabled engines, locales, plugins, or default safe-search/theme settings before issuing targeted searches.

The official SearXNG administration API documents `GET /config` for exactly this purpose.

## Changes

- add `src/instance-info.ts` to fetch, normalize, and format `/config` responses
- add `SearXNGInstanceConfig` / `SearXNGInstanceInfoArgs` types, a type guard, and the `INSTANCE_INFO_TOOL` schema
- register `searxng_instance_info` in the MCP server and expose it in the config/help resources
- document the new tool in `README.md`
- add focused unit/integration coverage for URL construction, auth headers, payload normalization, engine filtering, and resource/tool exposure

## Tool Shape

`searxng_instance_info({ includeEngines?: boolean, includeDisabled?: boolean, category?: string })`

- `includeEngines`: include engine details in the response
- `includeDisabled`: include disabled engines when listing engines
- `category`: filter the engine list to a specific SearXNG category; providing this also implies engine details

## Scope

This PR intentionally does not add category-search parameters or response-format passthrough to `searxng_web_search`, since that work is already in flight in #65 and #70. This keeps the change non-overlapping and focused on a separate missing capability.

## Verification

- `npm run build`
- `npm test` (`168/168` passed)
- `npm run lint`
- `npm run test:coverage`
  - statements/lines: `86.16%`
  - branches: `82.31%`
  - functions: `98.85%`

## References

- SearXNG Administration API: https://docs.searxng.org/admin/api.html
- SearXNG Search API: https://docs.searxng.org/dev/search_api.html
- SearXNG Configured Engines: https://docs.searxng.org/user/configured_engines.html