### PR TITLE
Fix Hono runtime audit findings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -591,9 +591,9 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.12",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.12.tgz",
-            "integrity": "sha512-txsUW4SQ1iilgE0l9/e9VQWmELXifEFvmdA1j6WFh/aFPj99hIntrSsq/if0UWyGVkmrRPKA1wCeP+UCr1B9Uw==",
+            "version": "1.19.14",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
+            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
             "license": "MIT",
             "engines": {
                 "node": ">=18.14.1"
@@ -2818,9 +2818,9 @@
             }
         },
         "node_modules/hono": {
-            "version": "4.12.9",
-            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.9.tgz",
-            "integrity": "sha512-wy3T8Zm2bsEvxKZM5w21VdHDDcwVS1yUFFY6i8UobSsKfFceT7TOwhbhfKsDyx7tYQlmRM5FLpIuYvNFyjctiA==",
+            "version": "4.12.16",
+            "resolved": "https://registry.npmjs.org/hono/-/hono-4.12.16.tgz",
+            "integrity": "sha512-jN0ZewiNAWSe5khM3EyCmBb250+b40wWbwNILNfEvq84VREWwOIkuUsFONk/3i3nqkz7Oe1PcpM2mwQEK2L9Kg==",
             "license": "MIT",
             "engines": {
                 "node": ">=16.9.0"

--- a/package.json
+++ b/package.json
@@ -53,6 +53,10 @@
         "node-html-markdown": "^2.0.0",
         "undici": "^7.24.0"
     },
+    "overrides": {
+        "@hono/node-server": "1.19.14",
+        "hono": "4.12.16"
+    },
     "devDependencies": {
         "@types/node": "^22.17.2",
         "@types/supertest": "^7.2.0",


### PR DESCRIPTION
## Summary
- add targeted npm overrides for vulnerable Hono transitives used by the MCP SDK HTTP stack
- refresh `package-lock.json` so `hono` resolves to 4.12.16 and `@hono/node-server` resolves to 1.19.14

## Verification
- `npm audit --omit=dev --json` reports 0 production vulnerabilities
- `npm ci --ignore-scripts`
- `npm run build`
- `npm test` (156 tests)

This addresses the public Hono and @hono/node-server advisories reported by npm audit.