### PR TITLE
fix: add mcp-protocol-version to CORS allowedHeaders

### DIFF
--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -47,6 +47,25 @@ async function runTests() {
     assert.ok(res.headers['access-control-allow-origin']);
   }, results);
 
+  await testFunction('CORS allows expected headers', async () => {
+    const app = await createHttpServer(() => createTestMcpServer());
+    const res = await request(app)
+      .options('/mcp')
+      .set('Origin', 'http://example.com')
+      .set('Access-Control-Request-Method', 'POST')
+      .set('Access-Control-Request-Headers', 'Content-Type, mcp-session-id, authorization, mcp-protocol-version');
+
+    assert.equal(res.status, 204, 'OPTIONS preflight should succeed');
+    const allowHeaders = (res.headers['access-control-allow-headers'] || '').toLowerCase();
+    const expected = ['content-type', 'mcp-session-id', 'authorization', 'mcp-protocol-version'];
+    for (const header of expected) {
+      assert.ok(
+        allowHeaders.includes(header),
+        `Expected '${header}' in Access-Control-Allow-Headers, got: ${allowHeaders}`
+      );
+    }
+  }, results);
+
   await testFunction('POST /mcp without sessionId and non-initialize body returns 400', async () => {
     const app = await createHttpServer(() => createTestMcpServer());
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -37,7 +37,7 @@ export async function createHttpServer(
       callback(null, false);
     },
     exposedHeaders: ["Mcp-Session-Id"],
-    allowedHeaders: ["Content-Type", "mcp-session-id", "authorization"],
+    allowedHeaders: ["Content-Type", "mcp-session-id", "authorization", "mcp-protocol-version"],
   }));
 
   function rejectUnauthorized(res: express.Response) {


### PR DESCRIPTION
The MCP SDK sends mcp-protocol-version header for protocol version negotiation in streamable HTTP transport. Without it in the CORS allowedHeaders list, browsers block cross-origin requests, causing 'Failed to fetch' errors.

This fixes browser-based MCP clients connecting to the HTTP transport endpoint.

Seen the error in the llama.cpp chat web in the browser. It fixes it so user can add this mcp to the llama.cpp chat page.