### PR TITLE
[codex] add custom outgoing headers

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -22,6 +22,24 @@ All environment variables for `mcp-searxng`, organized by concern. All variables
 | `USER_AGENT` | No | — | Global User-Agent header for all outgoing requests (e.g. `MyBot/1.0`) |
 | `URL_READER_USER_AGENT` | No | — | User-Agent for `web_url_read` only — overrides `USER_AGENT` for URL reads |
 
+## Custom Headers
+
+Provide additional outgoing HTTP headers as JSON objects with string values.
+
+| Variable | Required | Default | Description |
+|---|---|---|---|
+| `SEARXNG_HEADERS` | No | — | Extra headers for `searxng_web_search` requests to the SearXNG API |
+| `URL_READER_HEADERS` | No | — | Extra headers for `web_url_read` requests |
+
+Example for Cloudflare Access in front of SearXNG:
+
+```json
+{
+  "CF-Access-Client-Id": "your-client-id.access",
+  "CF-Access-Client-Secret": "your-client-secret"
+}
+```
+
 ## Proxy
 
 Interface-specific proxies take priority over global proxies for their respective tools.
@@ -75,6 +93,8 @@ Complete MCP client configuration with every variable. Mix and match as needed �
         "AUTH_PASSWORD": "your_password",
         "USER_AGENT": "MyBot/1.0",
         "URL_READER_USER_AGENT": "Mozilla/5.0 (compatible; MyBot/1.0)",
+        "SEARXNG_HEADERS": "{\"CF-Access-Client-Id\":\"your-client-id.access\",\"CF-Access-Client-Secret\":\"your-client-secret\"}",
+        "URL_READER_HEADERS": "{\"X-Custom-Token\":\"reader-token\"}",
         "SEARCH_HTTP_PROXY": "http://search-proxy.company.com:8080",
         "SEARCH_HTTPS_PROXY": "http://search-proxy.company.com:8080",
         "URL_READER_HTTP_PROXY": "http://reader-proxy.company.com:8080",

--- a/README.md
+++ b/README.md
@@ -202,6 +202,23 @@ curl http://localhost:3000/health
 
 Set `SEARXNG_URL` to your SearXNG instance URL. All other variables are optional.
 
+Protected SearXNG instances can receive extra search request headers through `SEARXNG_HEADERS`:
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "command": "npx",
+      "args": ["-y", "mcp-searxng"],
+      "env": {
+        "SEARXNG_URL": "https://search.example.com",
+        "SEARXNG_HEADERS": "{\"CF-Access-Client-Id\":\"your-client-id.access\",\"CF-Access-Client-Secret\":\"your-client-secret\"}"
+      }
+    }
+  }
+}
+```
+
 Full environment variable reference: [CONFIGURATION.md](CONFIGURATION.md)
 
 ## Troubleshooting

--- a/__tests__/unit/resources.test.ts
+++ b/__tests__/unit/resources.test.ts
@@ -102,6 +102,19 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('createConfigResource - custom header env vars are exposed as booleans', () => {
+    envManager.set('SEARXNG_HEADERS', '{"X-Token":"search-secret"}');
+    envManager.set('URL_READER_HEADERS', '{"X-Token":"reader-secret"}');
+
+    const config = JSON.parse(createConfigResource());
+    assert.equal(config.environment.hasSearxngHeaders, true);
+    assert.equal(config.environment.hasUrlReaderHeaders, true);
+    assert.ok(!JSON.stringify(config).includes('search-secret'));
+    assert.ok(!JSON.stringify(config).includes('reader-secret'));
+
+    envManager.restore();
+  }, results);
+
   await testFunction('createConfigResource - transport includes http when MCP_HTTP_PORT set', () => {
     envManager.set('MCP_HTTP_PORT', '3000');
 

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -332,9 +332,9 @@ async function runTests() {
 
     const options = getCapturedOptions();
     const headers = options?.headers as Record<string, string>;
-    assert.equal(headers['User-Agent'], 'MyCustomBot/1.0');
-    assert.equal(headers['CF-Access-Client-Id'], 'client-id.access');
-    assert.equal(headers['CF-Access-Client-Secret'], 'client-secret');
+    assert.equal(headers['user-agent'], 'MyCustomBot/1.0');
+    assert.equal(headers['cf-access-client-id'], 'client-id.access');
+    assert.equal(headers['cf-access-client-secret'], 'client-secret');
 
     fetchMocker.restore();
     envManager.restore();
@@ -352,6 +352,75 @@ async function runTests() {
     } catch (error: any) {
       assert.ok(error.message.includes('Configuration Error'));
       assert.ok(error.message.includes('SEARXNG_HEADERS'));
+    }
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('SEARXNG_HEADERS trims and normalizes header names', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('USER_AGENT', 'MyCustomBot/1.0');
+    envManager.set('SEARXNG_HEADERS', JSON.stringify({
+      ' user-agent ': 'OverrideBot/1.0',
+      ' X-Token ': 'custom-token'
+    }));
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      throw new Error('MOCK_STOP');
+    });
+
+    try {
+      await performWebSearch(mockServer as any, 'test query');
+    } catch {
+      // expected
+    }
+
+    const options = getCapturedOptions();
+    const headers = options?.headers as Record<string, string>;
+    assert.equal(headers['user-agent'], 'OverrideBot/1.0');
+    assert.equal(headers['x-token'], 'custom-token');
+    assert.ok(!headers['User-Agent']);
+    assert.ok(!headers[' X-Token ']);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('Reserved SEARXNG_HEADERS names throw configuration error', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARXNG_HEADERS', '{"__proto__":"polluted"}');
+
+    const mockServer = createMockServer();
+
+    try {
+      await performWebSearch(mockServer as any, 'test query');
+      assert.fail('Expected configuration error');
+    } catch (error: any) {
+      assert.ok(error.message.includes('Configuration Error'));
+      assert.ok(error.message.includes('reserved header name'));
+    }
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('Invalid SEARXNG_HEADERS names throw configuration error', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARXNG_HEADERS', JSON.stringify({
+      'Bad Header': 'value'
+    }));
+
+    const mockServer = createMockServer();
+
+    try {
+      await performWebSearch(mockServer as any, 'test query');
+      assert.fail('Expected configuration error');
+    } catch (error: any) {
+      assert.ok(error.message.includes('Configuration Error'));
+      assert.ok(error.message.includes('invalid header name'));
     }
 
     envManager.restore();

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -308,6 +308,55 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('SEARXNG_HEADERS adds custom headers to search requests', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('USER_AGENT', 'MyCustomBot/1.0');
+    envManager.set('SEARXNG_HEADERS', JSON.stringify({
+      'CF-Access-Client-Id': 'client-id.access',
+      'CF-Access-Client-Secret': 'client-secret'
+    }));
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      throw new Error('MOCK_STOP');
+    });
+
+    try {
+      await performWebSearch(mockServer as any, 'test query');
+    } catch {
+      // expected
+    }
+
+    const options = getCapturedOptions();
+    const headers = options?.headers as Record<string, string>;
+    assert.equal(headers['User-Agent'], 'MyCustomBot/1.0');
+    assert.equal(headers['CF-Access-Client-Id'], 'client-id.access');
+    assert.equal(headers['CF-Access-Client-Secret'], 'client-secret');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('Invalid SEARXNG_HEADERS JSON throws configuration error', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARXNG_HEADERS', '{invalid json');
+
+    const mockServer = createMockServer();
+
+    try {
+      await performWebSearch(mockServer as any, 'test query');
+      assert.fail('Expected configuration error');
+    } catch (error: any) {
+      assert.ok(error.message.includes('Configuration Error'));
+      assert.ok(error.message.includes('SEARXNG_HEADERS'));
+    }
+
+    envManager.restore();
+  }, results);
+
   await testFunction('User-Agent header absent when USER_AGENT env var not set', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
     envManager.delete('USER_AGENT');

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -257,6 +257,32 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('URL_READER_HEADERS adds custom headers to URL reads', async () => {
+    const mockServer = createMockServer();
+    urlCache.clear();
+
+    envManager.set('URL_READER_USER_AGENT', 'ReaderBot/1.0');
+    envManager.set('URL_READER_HEADERS', JSON.stringify({
+      'X-Custom-Token': 'reader-token'
+    }));
+
+    let capturedOptions: RequestInit | undefined;
+    fetchMocker.mock(async (_url, options) => {
+      capturedOptions = options;
+      return createMockFetch({ body: '<html><body><h1>Reader Test</h1></body></html>' })('', undefined);
+    });
+
+    const result = await fetchAndConvertToMarkdown(mockServer as any, 'https://reader-header-test.com');
+    assert.ok(result.includes('Reader Test'));
+
+    const headers = capturedOptions?.headers as Record<string, string>;
+    assert.equal(headers['User-Agent'], 'ReaderBot/1.0');
+    assert.equal(headers['X-Custom-Token'], 'reader-token');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('hardened mode blocks localhost URL reads', async () => {
     const mockServer = createMockServer();
     envManager.set('MCP_HTTP_HARDEN', 'true');

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -276,8 +276,8 @@ async function runTests() {
     assert.ok(result.includes('Reader Test'));
 
     const headers = capturedOptions?.headers as Record<string, string>;
-    assert.equal(headers['User-Agent'], 'ReaderBot/1.0');
-    assert.equal(headers['X-Custom-Token'], 'reader-token');
+    assert.equal(headers['user-agent'], 'ReaderBot/1.0');
+    assert.equal(headers['x-custom-token'], 'reader-token');
 
     fetchMocker.restore();
     envManager.restore();

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -2,26 +2,67 @@ import { createConfigurationError } from "./error-handler.js";
 
 export type HeaderRecord = Record<string, string>;
 
+const HEADER_NAME_REGEX = /^[!#$%&'*+\-.^_`|~0-9A-Za-z]+$/;
+const RESERVED_HEADER_NAMES = new Set(["__proto__", "constructor", "prototype"]);
+
+function createHeaderRecord(): HeaderRecord {
+  return Object.create(null) as HeaderRecord;
+}
+
+function normalizeHeaderName(envVarName: string, name: string): string {
+  const normalizedName = name.trim().toLowerCase();
+
+  if (normalizedName === "") {
+    throw createConfigurationError(`${envVarName} contains an empty header name`);
+  }
+
+  if (!HEADER_NAME_REGEX.test(normalizedName)) {
+    throw createConfigurationError(`${envVarName} contains invalid header name "${name}"`);
+  }
+
+  if (RESERVED_HEADER_NAMES.has(normalizedName)) {
+    throw createConfigurationError(`${envVarName} contains reserved header name "${name}"`);
+  }
+
+  return normalizedName;
+}
+
+function setHeader(headers: HeaderRecord, envVarName: string, name: string, value: string): void {
+  headers[normalizeHeaderName(envVarName, name)] = value;
+}
+
 function normalizeHeaders(headers?: HeadersInit): HeaderRecord {
+  const normalizedHeaders = createHeaderRecord();
+
   if (!headers) {
-    return {};
+    return normalizedHeaders;
   }
 
   if (headers instanceof Headers) {
-    return Object.fromEntries(headers.entries());
+    for (const [name, value] of headers.entries()) {
+      setHeader(normalizedHeaders, "headers", name, value);
+    }
+    return normalizedHeaders;
   }
 
   if (Array.isArray(headers)) {
-    return Object.fromEntries(headers);
+    for (const [name, value] of headers) {
+      setHeader(normalizedHeaders, "headers", name, value);
+    }
+    return normalizedHeaders;
   }
 
-  return { ...headers };
+  for (const [name, value] of Object.entries(headers)) {
+    setHeader(normalizedHeaders, "headers", name, value);
+  }
+
+  return normalizedHeaders;
 }
 
 export function parseHeadersFromEnv(envVarName: string): HeaderRecord {
   const rawHeaders = process.env[envVarName];
   if (!rawHeaders) {
-    return {};
+    return createHeaderRecord();
   }
 
   let parsedHeaders: unknown;
@@ -39,25 +80,24 @@ export function parseHeadersFromEnv(envVarName: string): HeaderRecord {
     throw createConfigurationError(`${envVarName} must be a JSON object`);
   }
 
-  const headers: HeaderRecord = {};
+  const headers = createHeaderRecord();
   for (const [name, value] of Object.entries(parsedHeaders)) {
-    if (name.trim() === "") {
-      throw createConfigurationError(`${envVarName} contains an empty header name`);
-    }
-
     if (typeof value !== "string") {
       throw createConfigurationError(`${envVarName}.${name} must be a string`);
     }
 
-    headers[name] = value;
+    setHeader(headers, envVarName, name, value);
   }
 
   return headers;
 }
 
 export function mergeHeaders(headers: HeadersInit | undefined, additionalHeaders: HeaderRecord): HeaderRecord {
-  return {
-    ...normalizeHeaders(headers),
-    ...additionalHeaders,
-  };
+  const mergedHeaders = normalizeHeaders(headers);
+
+  for (const [name, value] of Object.entries(additionalHeaders)) {
+    setHeader(mergedHeaders, "headers", name, value);
+  }
+
+  return mergedHeaders;
 }

--- a/src/headers.ts
+++ b/src/headers.ts
@@ -1,0 +1,63 @@
+import { createConfigurationError } from "./error-handler.js";
+
+export type HeaderRecord = Record<string, string>;
+
+function normalizeHeaders(headers?: HeadersInit): HeaderRecord {
+  if (!headers) {
+    return {};
+  }
+
+  if (headers instanceof Headers) {
+    return Object.fromEntries(headers.entries());
+  }
+
+  if (Array.isArray(headers)) {
+    return Object.fromEntries(headers);
+  }
+
+  return { ...headers };
+}
+
+export function parseHeadersFromEnv(envVarName: string): HeaderRecord {
+  const rawHeaders = process.env[envVarName];
+  if (!rawHeaders) {
+    return {};
+  }
+
+  let parsedHeaders: unknown;
+  try {
+    parsedHeaders = JSON.parse(rawHeaders);
+  } catch {
+    throw createConfigurationError(`${envVarName} must be valid JSON`);
+  }
+
+  if (
+    typeof parsedHeaders !== "object" ||
+    parsedHeaders === null ||
+    Array.isArray(parsedHeaders)
+  ) {
+    throw createConfigurationError(`${envVarName} must be a JSON object`);
+  }
+
+  const headers: HeaderRecord = {};
+  for (const [name, value] of Object.entries(parsedHeaders)) {
+    if (name.trim() === "") {
+      throw createConfigurationError(`${envVarName} contains an empty header name`);
+    }
+
+    if (typeof value !== "string") {
+      throw createConfigurationError(`${envVarName}.${name} must be a string`);
+    }
+
+    headers[name] = value;
+  }
+
+  return headers;
+}
+
+export function mergeHeaders(headers: HeadersInit | undefined, additionalHeaders: HeaderRecord): HeaderRecord {
+  return {
+    ...normalizeHeaders(headers),
+    ...additionalHeaders,
+  };
+}

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -17,6 +17,8 @@ export function createConfigResource() {
         ? { searxngUrl: process.env.SEARXNG_URL || "(not configured)" }
         : { searxngUrlConfigured: !!process.env.SEARXNG_URL }),
       hasAuth: !!(process.env.AUTH_USERNAME && process.env.AUTH_PASSWORD),
+      hasSearxngHeaders: !!process.env.SEARXNG_HEADERS,
+      hasUrlReaderHeaders: !!process.env.URL_READER_HEADERS,
       hasProxy: !!(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy),
       hasNoProxy: !!(process.env.NO_PROXY || process.env.no_proxy),
       nodeVersion: process.version,
@@ -64,6 +66,9 @@ Reads and converts web page content to Markdown format.
 
 ### Optional Environment Variables
 - \`AUTH_USERNAME\` & \`AUTH_PASSWORD\`: Basic authentication for SearXNG
+- \`USER_AGENT\`: Global User-Agent header for outgoing requests
+- \`SEARXNG_HEADERS\`: Extra JSON headers for SearXNG search requests
+- \`URL_READER_HEADERS\`: Extra JSON headers for URL read requests
 - \`HTTP_PROXY\` / \`HTTPS_PROXY\`: Proxy server configuration
 - \`NO_PROXY\` / \`no_proxy\`: Comma-separated list of hosts to bypass proxy
 - \`MCP_HTTP_PORT\`: Enable HTTP transport on specified port

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -67,6 +67,7 @@ Reads and converts web page content to Markdown format.
 ### Optional Environment Variables
 - \`AUTH_USERNAME\` & \`AUTH_PASSWORD\`: Basic authentication for SearXNG
 - \`USER_AGENT\`: Global User-Agent header for outgoing requests
+- \`URL_READER_USER_AGENT\`: User-Agent for \`web_url_read\`, overrides \`USER_AGENT\`
 - \`SEARXNG_HEADERS\`: Extra JSON headers for SearXNG search requests
 - \`URL_READER_HEADERS\`: Extra JSON headers for URL read requests
 - \`HTTP_PROXY\` / \`HTTPS_PROXY\`: Proxy server configuration

--- a/src/search.ts
+++ b/src/search.ts
@@ -2,6 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SearXNGWeb } from "./types.js";
 import { createProxyAgent, createDefaultAgent, ProxyType } from "./proxy.js";
 import { logMessage } from "./logging.js";
+import { mergeHeaders, parseHeadersFromEnv } from "./headers.js";
 import {
   MCPSearXNGError,
   validateEnvironment,
@@ -94,6 +95,11 @@ export async function performWebSearch(
       ...requestOptions.headers,
       'User-Agent': userAgent
     };
+  }
+
+  const additionalHeaders = parseHeadersFromEnv("SEARXNG_HEADERS");
+  if (Object.keys(additionalHeaders).length > 0) {
+    requestOptions.headers = mergeHeaders(requestOptions.headers, additionalHeaders);
   }
 
   // Fetch with enhanced error handling

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -5,6 +5,7 @@ import { createProxyAgent, createDefaultAgent, ProxyType } from "./proxy.js";
 import { logMessage } from "./logging.js";
 import { urlCache } from "./cache.js";
 import { getHttpSecurityConfig } from "./http-security.js";
+import { mergeHeaders, parseHeadersFromEnv } from "./headers.js";
 import {
   createURLFormatError,
   createURLSecurityPolicyError,
@@ -253,6 +254,11 @@ export async function fetchAndConvertToMarkdown(
         ...requestOptions.headers,
         'User-Agent': userAgent
       };
+    }
+
+    const additionalHeaders = parseHeadersFromEnv("URL_READER_HEADERS");
+    if (Object.keys(additionalHeaders).length > 0) {
+      requestOptions.headers = mergeHeaders(requestOptions.headers, additionalHeaders);
     }
 
     let response: Response;


### PR DESCRIPTION
## Summary
- Add a shared helper for parsing JSON header env vars.
- Apply `SEARXNG_HEADERS` to `searxng_web_search` requests and `URL_READER_HEADERS` to `web_url_read` requests.
- Document Cloudflare Access service-token usage and expose redacted config booleans.

## Why
Protected SearXNG deployments often require service-token headers such as `CF-Access-Client-Id` and `CF-Access-Client-Secret`. Separate env vars keep search API headers scoped to search traffic and URL reader headers scoped to URL fetches.

## Validation
- `npm run build`
- `npm run lint`
- `npm test` (160 passed)