### PR TITLE
docs: improve tool description to prevent LLM using `prompt` instead of `query`

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -27,8 +27,9 @@ export function isSearXNGWebSearchArgs(args: unknown): args is {
 export const WEB_SEARCH_TOOL: Tool = {
   name: "searxng_web_search",
   description:
-    "Performs a web search using the SearXNG API, ideal for general queries, news, articles, and online content. " +
-    "Use this for broad information gathering, recent events, or when you need diverse web sources.",
+    "Searches the web using SearXNG. " +
+    "CRITICAL: The parameter name MUST be exactly `query` (not `prompt`, `q`, or any other name). " +
+    "Pass your search terms as the value of the `query` parameter.",
   annotations: {
     readOnlyHint: true,
     openWorldHint: true,
@@ -39,7 +40,7 @@ export const WEB_SEARCH_TOOL: Tool = {
       query: {
         type: "string",
         description:
-          "The search query. This is the main input for the web search",
+          "The search query string. This is the required parameter name — use exactly `query`, not `prompt` or `q`.",
       },
       pageno: {
         type: "number",


### PR DESCRIPTION
## Problem

When using Qwen Code with local LLMs (tested with **Qwen 3.6-35B-A3B**), the `searxng_web_search` tool is sometimes called with the wrong parameter name:

```json
// Wrong — LLM uses 'prompt' instead of 'query'
{"prompt": "<search terms>"}

// Correct
{"query": "<search terms>"}
```

This causes the error: `params must have required property 'query'`.

## Root Cause

The original tool description used vague terms like "general queries" and "main input" which confused the LLM into mapping the search term to `prompt` (a common LLM concept) instead of the correct `query` parameter name.

## Fix

- Added explicit instruction in the tool `description`: **"CRITICAL: The parameter name MUST be exactly `query` (not `prompt`, `q`, or any other name)."**
- Updated the `query` parameter `description`: **"This is the required parameter name — use exactly `query`, not `prompt` or `q`."**

## Testing

Observed in production use with:
- **Qwen Code** CLI as the MCP client
- **Qwen 3.6-35B-A3B** as the local LLM (running via Ollama / vLLM)