### PR TITLE
fix: handle CLI metadata flags before startup

### DIFF
--- a/__tests__/integration/index.test.ts
+++ b/__tests__/integration/index.test.ts
@@ -11,6 +11,7 @@ import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { 
   packageVersion, 
+  handleCliMetadataRequest,
   isWebUrlReadArgs,
   createMcpServer
 } from '../../src/index.js';
@@ -27,6 +28,23 @@ async function runTests() {
     assert.ok(packageVersion);
     assert.ok(typeof packageVersion === 'string');
     assert.ok(packageVersion.length > 0);
+  }, results);
+
+  await testFunction('CLI metadata flag detection', () => {
+    const captured: unknown[] = [];
+    const originalLog = console.log;
+    console.log = (...args: unknown[]) => captured.push(args);
+
+    try {
+      assert.equal(handleCliMetadataRequest(['--version']), true);
+      assert.equal(handleCliMetadataRequest(['-h']), true);
+      assert.equal(handleCliMetadataRequest([]), false);
+    } finally {
+      console.log = originalLog;
+    }
+
+    assert.equal((captured[0] as unknown[])[0], packageVersion);
+    assert.ok(String((captured[1] as unknown[])[0]).includes('Usage:'));
   }, results);
 
   await testFunction('Call tool handler - unknown tool error', async () => {
@@ -214,6 +232,59 @@ async function runTests() {
 
     assert.equal(result.status, 0, `Import process failed: ${result.stderr}`);
     assert.equal(result.stdout, '');
+    assert.equal(result.stderr, '');
+  }, results);
+
+  await testFunction('CLI --version prints package version without starting server', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        'src/index.ts',
+        '--version',
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          MCP_HTTP_PORT: '',
+          SEARXNG_URL: '',
+        },
+        encoding: 'utf8',
+        timeout: 5000,
+      },
+    );
+
+    assert.equal(result.status, 0, `Version process failed: ${result.stderr}`);
+    assert.equal(result.stdout.trim(), packageVersion);
+    assert.equal(result.stderr, '');
+  }, results);
+
+  await testFunction('CLI --help prints usage without starting server', () => {
+    const result = spawnSync(
+      process.execPath,
+      [
+        '--import',
+        'tsx',
+        'src/index.ts',
+        '--help',
+      ],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          MCP_HTTP_PORT: '',
+          SEARXNG_URL: '',
+        },
+        encoding: 'utf8',
+        timeout: 5000,
+      },
+    );
+
+    assert.equal(result.status, 0, `Help process failed: ${result.stderr}`);
+    assert.ok(result.stdout.includes('Usage:'));
+    assert.ok(result.stdout.includes('MCP_HTTP_PORT'));
     assert.equal(result.stderr, '');
   }, results);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,30 @@ const isMainModule = (() => {
 // Export the version for use in other modules
 export { packageVersion };
 
+export function handleCliMetadataRequest(args: readonly string[] = process.argv.slice(2)): boolean {
+  if (args.includes("--version") || args.includes("-v")) {
+    console.log(packageVersion);
+    return true;
+  }
+
+  if (args.includes("--help") || args.includes("-h")) {
+    console.log(`mcp-searxng v${packageVersion}
+
+Usage:
+  mcp-searxng [--help] [--version]
+
+Environment:
+  SEARXNG_URL        SearXNG instance URL for search requests
+  MCP_HTTP_PORT      Enable HTTP transport on this port
+  MCP_HTTP_HOST      Host to bind when HTTP transport is enabled
+
+Without MCP_HTTP_PORT, the server starts STDIO transport for MCP clients.`);
+    return true;
+  }
+
+  return false;
+}
+
 // Type guard for URL reading args
 export function isWebUrlReadArgs(args: unknown): args is {
   url: string;
@@ -247,6 +271,10 @@ export function createMcpServer(): McpServer {
 
 // Main function
 async function main() {
+  if (handleCliMetadataRequest()) {
+    return;
+  }
+
   // Check for HTTP transport mode
   const httpPort = process.env.MCP_HTTP_PORT;
   if (httpPort) {


### PR DESCRIPTION
## Summary
- handle `--version`/`-v` and `--help`/`-h` before starting any MCP transport
- add integration coverage for direct flag handling and spawned CLI behavior

## Why
The published CLI currently treats metadata flags as a normal server startup. For example, `mcp-searxng --version` starts the STDIO server instead of printing the package version and exiting, which makes automated package/CLI probes hang or receive MCP JSON/log output instead of metadata.

## Validation
- `npm run build`
- `npx tsx __tests__/integration/index.test.ts`
- `npm test` (183 passed)
- `npm run lint` (passes with the existing `security/detect-non-literal-fs-filename` warning in `src/index.ts`)
- `node dist/index.js --version`
- `node dist/index.js --help`