### PR TITLE
feat(search): add engines parameter to select specific search engines (FEAT-026)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ AI Assistant (e.g. Claude)
     - `min_score` (number, optional): Minimum relevance score from 0.0 to 1.0. Results below this score are filtered out.
     - `num_results` (number, optional): Maximum number of results to return, from 1 to 20. `SEARXNG_MAX_RESULTS` applies as an operator ceiling.
     - `categories` (string, optional): Comma-separated SearXNG categories (e.g. `"news"`, `"it,science"`). Supported values: `general`, `news`, `images`, `videos`, `it`, `science`, `files`, `social media`. Default: SearXNG instance default (usually `general`).
+    - `engines` (string, optional): Comma-separated SearXNG engine names (e.g. `"google,bing,ddg"`). Names are matched exactly when live `/config` validation is available.
     - `response_format` (string, optional): Response format, either `"text"` for formatted agent-readable output or `"json"` for raw SearXNG JSON with filtered/sliced `results`. (default: `"text"`)
 
 - **searxng_search_suggestions**

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -9,6 +9,7 @@
 import { strict as assert } from 'node:assert';
 import { fileURLToPath } from 'node:url';
 import { performWebSearch } from '../../src/search.js';
+import { clearInstanceInfoCacheForTests } from '../../src/instance-info.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 import { createMockServer } from '../helpers/mock-server.js';
 import { FetchMocker, createMockFetch, createCapturingMockFetch, createAbortableMockFetch } from '../helpers/mock-fetch.js';
@@ -25,6 +26,16 @@ function makeMockSearchResults(count: number) {
     url: `https://example.com/${index + 1}`,
     score: 1 - index * 0.05,
   }));
+}
+
+function makeConfigWithEngines() {
+  return {
+    engines: [
+      { name: 'google', disabled: false },
+      { name: 'ddg', disabled: false },
+      { name: 'bing', disabled: true },
+    ],
+  };
 }
 
 async function runTests() {
@@ -818,6 +829,167 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('engines="google,ddg" validates with /config and adds encoded engines param', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+
+    const mockServer = createMockServer();
+    const requestedUrls: string[] = [];
+
+    fetchMocker.mock(async (url) => {
+      requestedUrls.push(url.toString());
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.pathname.endsWith('/config')) {
+        return createMockFetch({ json: makeConfigWithEngines() })(url);
+      }
+      return createMockFetch({ json: { results: [] } })(url);
+    });
+
+    await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, undefined, 'google,ddg');
+
+    assert.equal(requestedUrls.length, 2, 'Expected /config validation before search');
+    const searchUrl = requestedUrls[1];
+    assert.ok(searchUrl.includes('engines=google%2Cddg'), `Expected encoded engines param in ${searchUrl}`);
+    assert.equal(new URL(searchUrl).searchParams.get('engines'), 'google,ddg');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('invalid engine names from live /config throw helpful validation error', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+
+    const mockServer = createMockServer();
+    let searchCalled = false;
+
+    fetchMocker.mock(async (url) => {
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.pathname.endsWith('/config')) {
+        return createMockFetch({ json: makeConfigWithEngines() })(url);
+      }
+      searchCalled = true;
+      return createMockFetch({ json: { results: [] } })(url);
+    });
+
+    try {
+      await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, undefined, 'google,missing,bad');
+      assert.fail('Expected invalid engine validation error');
+    } catch (error: any) {
+      assert.ok(error.message.includes('Invalid SearXNG engine name(s): missing, bad'), error.message);
+      assert.ok(error.message.includes('searxng_instance_info'), error.message);
+    }
+    assert.equal(searchCalled, false, 'Search should not run after validation failure');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('unavailable /config forwards engines and prepends text warning', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+
+    const mockServer = createMockServer();
+    const requestedUrls: string[] = [];
+
+    fetchMocker.mock(async (url) => {
+      requestedUrls.push(url.toString());
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.pathname.endsWith('/config')) {
+        return createMockFetch({ ok: false, status: 403, statusText: 'Forbidden' })(url);
+      }
+      return createMockFetch({
+        json: {
+          results: [
+            {
+              title: 'Forwarded Result',
+              content: 'Search still ran',
+              url: 'https://example.com/forwarded',
+              score: 0.9,
+            },
+          ],
+        },
+      })(url);
+    });
+
+    const result = await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, undefined, 'unknown');
+
+    assert.ok(result.startsWith('Note: engine names were not validated'), result);
+    assert.ok(result.includes('Forwarded Result'), result);
+    const searchUrl = requestedUrls[1];
+    assert.equal(new URL(searchUrl).searchParams.get('engines'), 'unknown');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('unavailable /config includes warnings in JSON response when engines are provided', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+
+    const mockServer = createMockServer();
+
+    fetchMocker.mock(async (url) => {
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.pathname.endsWith('/config')) {
+        throw new Error('config blocked');
+      }
+      return createMockFetch({ json: { query: 'test query', results: [] } })(url);
+    });
+
+    const result = await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, undefined, 'unknown', 'json');
+    const payload = JSON.parse(result);
+
+    assert.deepEqual(payload.warnings, ['Engine names were not validated because SearXNG /config is unavailable.']);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('omitting engines skips /config validation and sends no engines param', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+
+    const mockServer = createMockServer();
+    const requestedUrls: string[] = [];
+
+    fetchMocker.mock(async (url) => {
+      requestedUrls.push(url.toString());
+      return createMockFetch({ json: { results: [] } })(url);
+    });
+
+    await performWebSearch(mockServer as any, 'test query');
+
+    assert.equal(requestedUrls.length, 1, 'Expected only the search request when engines is omitted');
+    const searchUrl = new URL(requestedUrls[0]);
+    assert.ok(searchUrl.pathname.endsWith('/search'));
+    assert.equal(searchUrl.searchParams.get('engines'), null);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('blank engines string skips /config validation and sends no engines param', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+
+    const mockServer = createMockServer();
+    const requestedUrls: string[] = [];
+
+    fetchMocker.mock(async (url) => {
+      requestedUrls.push(url.toString());
+      return createMockFetch({ json: { results: [] } })(url);
+    });
+
+    await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, undefined, '   ');
+
+    assert.equal(requestedUrls.length, 1, 'Expected only the search request when engines is blank');
+    assert.equal(new URL(requestedUrls[0]).searchParams.get('engines'), null);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('SEARXNG_DEFAULT_LANGUAGE sets language when per-call language is omitted', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
     envManager.set('SEARXNG_DEFAULT_LANGUAGE', 'fr');
@@ -1107,7 +1279,7 @@ async function runTests() {
       },
     }));
 
-    const result = await performWebSearch(mockServer as any, 'answer query', 1, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const result = await performWebSearch(mockServer as any, 'answer query', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
     const payload = JSON.parse(result);
     assert.equal(payload.query, 'answer query');
     assert.deepEqual(payload.answers, ['42']);
@@ -1135,7 +1307,7 @@ async function runTests() {
       },
     }));
 
-    const result = await performWebSearch(mockServer as any, 'text query', 1, undefined, undefined, undefined, undefined, undefined, undefined, 'text');
+    const result = await performWebSearch(mockServer as any, 'text query', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'text');
     assert.ok(result.includes('Title: Text Result'));
     assert.throws(() => JSON.parse(result));
 
@@ -1155,7 +1327,7 @@ async function runTests() {
       },
     }));
 
-    const result = await performWebSearch(mockServer as any, 'slice query', 1, undefined, undefined, undefined, undefined, 2, undefined, 'json');
+    const result = await performWebSearch(mockServer as any, 'slice query', 1, undefined, undefined, undefined, undefined, 2, undefined, undefined, 'json');
     const payload = JSON.parse(result);
     assert.equal(payload.results.length, 2);
     assert.equal(payload.results[0].title, 'Result 1');
@@ -1178,7 +1350,7 @@ async function runTests() {
       },
     }));
 
-    const result = await performWebSearch(mockServer as any, 'empty query', 1, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const result = await performWebSearch(mockServer as any, 'empty query', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
     const payload = JSON.parse(result);
     assert.equal(payload.query, 'empty query');
     assert.deepEqual(payload.results, []);

--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -41,6 +41,7 @@ async function runTests() {
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', min_score: 1 }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', num_results: 1 }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', num_results: 20 }), true);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', engines: 'google,ddg' }), true);
   }, results);
 
   await testFunction('isSearXNGWebSearchArgs type guard - invalid cases', () => {
@@ -239,6 +240,11 @@ async function runTests() {
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', categories: ['news'] }), false);
   }, results);
 
+  await testFunction('isSearXNGWebSearchArgs rejects non-string engines', () => {
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', engines: 123 }), false);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', engines: ['google'] }), false);
+  }, results);
+
   await testFunction('isSearXNGWebSearchArgs rejects invalid response_format', () => {
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', response_format: 'xml' }), false);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', response_format: 123 }), false);
@@ -248,6 +254,12 @@ async function runTests() {
     const properties = WEB_SEARCH_TOOL.inputSchema.properties as Record<string, any>;
     assert.ok(properties.categories, 'WEB_SEARCH_TOOL must expose categories parameter');
     assert.equal(properties.categories.type, 'string');
+  }, results);
+
+  await testFunction('WEB_SEARCH_TOOL schema includes engines property', () => {
+    const properties = WEB_SEARCH_TOOL.inputSchema.properties as Record<string, any>;
+    assert.ok(properties.engines, 'WEB_SEARCH_TOOL must expose engines parameter');
+    assert.equal(properties.engines.type, 'string');
   }, results);
 
   await testFunction('WEB_SEARCH_TOOL schema includes response_format enum', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -171,6 +171,7 @@ export function createMcpServer(): McpServer {
           args.min_score,
           args.num_results,
           args.categories,
+          args.engines,
           args.response_format,
         );
 

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -3,6 +3,9 @@ import { logMessage } from "./logging.js";
 import { createDefaultAgent, createProxyAgent, ProxyType } from "./proxy.js";
 
 type SearXNGConfig = Record<string, any>;
+type ConfigResult =
+  | { available: true; config: SearXNGConfig }
+  | { available: false; message: string; status?: number };
 
 let cachedConfig: SearXNGConfig | null = null;
 let cachedBaseUrl: string | null = null;
@@ -61,6 +64,20 @@ function collectEngines(config: SearXNGConfig, includeDisabled: boolean, categor
   };
 }
 
+function allEngineNames(config: SearXNGConfig): Set<string> {
+  const names = new Set<string>();
+
+  if (Array.isArray(config.engines)) {
+    for (const engine of config.engines) {
+      if (engine && typeof engine.name === "string") {
+        names.add(engine.name);
+      }
+    }
+  }
+
+  return names;
+}
+
 function formatInstanceInfo(
   config: SearXNGConfig,
   includeEngines: boolean,
@@ -96,24 +113,17 @@ export function clearInstanceInfoCacheForTests(): void {
   cachedBaseUrl = null;
 }
 
-export async function fetchInstanceInfo(
-  mcpServer: McpServer,
-  includeEngines = false,
-  includeDisabled = false,
-  category?: string,
-  refresh = false,
-): Promise<string> {
+async function fetchConfig(mcpServer: McpServer): Promise<ConfigResult> {
   const base = process.env.SEARXNG_URL;
   if (!base) {
-    return unavailable("SEARXNG_URL is not configured; cannot fetch SearXNG /config.");
-  }
-
-  if (refresh) {
-    cachedConfig = null;
+    return {
+      available: false,
+      message: "SEARXNG_URL is not configured; cannot fetch SearXNG /config.",
+    };
   }
 
   if (cachedConfig && cachedBaseUrl === base) {
-    return formatInstanceInfo(cachedConfig, includeEngines, includeDisabled, category);
+    return { available: true, config: cachedConfig };
   }
 
   const parsedBase = new URL(base.endsWith("/") ? base : `${base}/`);
@@ -131,14 +141,49 @@ export async function fetchInstanceInfo(
 
     const response = await fetch(url.toString(), requestOptions);
     if (!response.ok) {
-      return unavailable(`SearXNG /config is unavailable: HTTP ${response.status} ${response.statusText}`, response.status);
+      return {
+        available: false,
+        message: `SearXNG /config is unavailable: HTTP ${response.status} ${response.statusText}`,
+        status: response.status,
+      };
     }
 
     cachedConfig = await response.json() as SearXNGConfig;
     cachedBaseUrl = base;
-    return formatInstanceInfo(cachedConfig, includeEngines, includeDisabled, category);
+    return { available: true, config: cachedConfig };
   } catch (error) {
     logMessage(mcpServer, "warning", `SearXNG /config fetch failed: ${error instanceof Error ? error.message : String(error)}`);
-    return unavailable("SearXNG /config is unavailable; instance capability discovery could not complete.");
+    return {
+      available: false,
+      message: "SearXNG /config is unavailable; instance capability discovery could not complete.",
+    };
   }
+}
+
+export async function getKnownEngines(mcpServer: McpServer): Promise<Set<string> | null> {
+  const result = await fetchConfig(mcpServer);
+  if (!result.available) {
+    return null;
+  }
+
+  return allEngineNames(result.config);
+}
+
+export async function fetchInstanceInfo(
+  mcpServer: McpServer,
+  includeEngines = false,
+  includeDisabled = false,
+  category?: string,
+  refresh = false,
+): Promise<string> {
+  if (refresh) {
+    cachedConfig = null;
+  }
+
+  const result = await fetchConfig(mcpServer);
+  if (!result.available) {
+    return unavailable(result.message, result.status);
+  }
+
+  return formatInstanceInfo(result.config, includeEngines, includeDisabled, category);
 }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -58,6 +58,7 @@ Performs web searches using the configured SearXNG instance.
 - \`min_score\` (optional): Minimum relevance score from 0.0 to 1.0
 - \`num_results\` (optional): Maximum result count from 1 to 20
 - \`categories\` (optional): Comma-separated SearXNG categories such as "news" or "it,science"
+- \`engines\` (optional): Comma-separated SearXNG engine names such as "google,bing,ddg"
 - \`response_format\` (optional): "text" for formatted output or "json" for raw SearXNG-shaped JSON
 
 Text output can include metadata sections for direct answers, spelling corrections, suggestions, and infoboxes before the result list. JSON output preserves the SearXNG response shape with filtered and sliced \`results\`.

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -59,9 +59,9 @@ Performs web searches using the configured SearXNG instance.
 - \`num_results\` (optional): Maximum result count from 1 to 20
 - \`categories\` (optional): Comma-separated SearXNG categories such as "news" or "it,science"
 - \`engines\` (optional): Comma-separated SearXNG engine names such as "google,bing,ddg"
-- \`response_format\` (optional): "text" for formatted output or "json" for raw SearXNG-shaped JSON
+- `response_format` (optional): "text" for formatted output or "json" for raw SearXNG-shaped JSON (may include a `warnings` array for non-fatal issues)
 
-Text output can include metadata sections for direct answers, spelling corrections, suggestions, and infoboxes before the result list. JSON output preserves the SearXNG response shape with filtered and sliced \`results\`.
+Text output can include metadata sections for direct answers, spelling corrections, suggestions, and infoboxes before the result list. JSON output preserves the SearXNG response shape with filtered and sliced `results`, and may include a `warnings` array for non-fatal issues.
 
 ### 2. searxng_search_suggestions
 Returns autocomplete suggestions from the configured SearXNG instance.

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -59,9 +59,9 @@ Performs web searches using the configured SearXNG instance.
 - \`num_results\` (optional): Maximum result count from 1 to 20
 - \`categories\` (optional): Comma-separated SearXNG categories such as "news" or "it,science"
 - \`engines\` (optional): Comma-separated SearXNG engine names such as "google,bing,ddg"
-- `response_format` (optional): "text" for formatted output or "json" for raw SearXNG-shaped JSON (may include a `warnings` array for non-fatal issues)
+- \`response_format\` (optional): "text" for formatted output or "json" for raw SearXNG-shaped JSON (may include a \`warnings\` array for non-fatal issues)
 
-Text output can include metadata sections for direct answers, spelling corrections, suggestions, and infoboxes before the result list. JSON output preserves the SearXNG response shape with filtered and sliced `results`, and may include a `warnings` array for non-fatal issues.
+Text output can include metadata sections for direct answers, spelling corrections, suggestions, and infoboxes before the result list. JSON output preserves the SearXNG response shape with filtered and sliced \`results\`, and may include a \`warnings\` array for non-fatal issues.
 
 ### 2. searxng_search_suggestions
 Returns autocomplete suggestions from the configured SearXNG instance.

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,5 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SearXNGWeb } from "./types.js";
+import { getKnownEngines } from "./instance-info.js";
 import { createProxyAgent, createDefaultAgent, ProxyType } from "./proxy.js";
 import { logMessage } from "./logging.js";
 import {
@@ -12,6 +13,9 @@ import {
   createNoResultsMessage,
   type ErrorContext
 } from "./error-handler.js";
+
+const ENGINE_VALIDATION_WARNING = "Engine names were not validated because SearXNG /config is unavailable.";
+const ENGINE_VALIDATION_NOTE = "Note: engine names were not validated (SearXNG /config unavailable).";
 
 function getOperatorMaxResults(mcpServer: McpServer): number | undefined {
   const rawValue = process.env.SEARXNG_MAX_RESULTS;
@@ -130,6 +134,7 @@ export async function performWebSearch(
   min_score?: number,
   num_results?: number,
   categories?: string,
+  engines?: string,
   response_format: "text" | "json" = "text",
 ) {
   const startTime = Date.now();
@@ -141,6 +146,7 @@ export async function performWebSearch(
 
   const effectiveLanguage = language ?? getDefaultLanguage();
   const effectiveSafesearch = safesearch !== undefined ? safesearch : getDefaultSafesearch(mcpServer);
+  const effectiveEngines = engines !== undefined && engines.trim() !== "" ? engines : undefined;
 
   // Build detailed log message with all parameters
   const searchParams = [
@@ -151,6 +157,7 @@ export async function performWebSearch(
     min_score !== undefined ? `min_score: ${min_score}` : null,
     effectiveMax !== undefined ? `num_results: ${effectiveMax}` : null,
     categories ? `categories: ${categories}` : null,
+    effectiveEngines ? `engines: ${effectiveEngines}` : null,
   ].filter(Boolean).join(", ");
   
   logMessage(mcpServer, "info", `Starting web search: "${query}" (${searchParams})`);
@@ -163,6 +170,27 @@ export async function performWebSearch(
 
   const searxngUrl = process.env.SEARXNG_URL!;
   const parsedUrl = new URL(searxngUrl.endsWith('/') ? searxngUrl : searxngUrl + '/');
+  let engineValidationWarning: string | undefined;
+
+  if (effectiveEngines) {
+    const knownEngines = await getKnownEngines(mcpServer);
+    if (knownEngines === null) {
+      engineValidationWarning = ENGINE_VALIDATION_WARNING;
+    } else {
+      const requestedEngines = effectiveEngines
+        .split(",")
+        .map((engine) => engine.trim())
+        .filter((engine) => engine !== "");
+      const invalidEngines = requestedEngines.filter((engine) => !knownEngines.has(engine));
+
+      if (invalidEngines.length > 0) {
+        throw new MCPSearXNGError(
+          `🔍 Invalid SearXNG engine name(s): ${invalidEngines.join(", ")}. ` +
+          "Use the searxng_instance_info tool to discover available engines.",
+        );
+      }
+    }
+  }
 
   const url = new URL('search', parsedUrl);
 
@@ -187,6 +215,10 @@ export async function performWebSearch(
 
   if (categories) {
     url.searchParams.set("categories", categories);
+  }
+
+  if (effectiveEngines) {
+    url.searchParams.set("engines", effectiveEngines);
   }
 
   // Prepare request options with headers
@@ -290,10 +322,18 @@ export async function performWebSearch(
     : results;
 
   if (response_format === "json") {
-    return JSON.stringify({ ...data, results: slicedResults }, null, 2);
+    return JSON.stringify({
+      ...data,
+      results: slicedResults,
+      ...(engineValidationWarning ? { warnings: [engineValidationWarning] } : {}),
+    }, null, 2);
   }
 
   const metadata = formatSearchMetadata(data);
+  const leadingSections = [
+    engineValidationWarning ? ENGINE_VALIDATION_NOTE : null,
+    metadata || null,
+  ].filter(Boolean).join("\n\n");
 
   if (slicedResults.length === 0) {
     const appliedFilters = [
@@ -303,7 +343,7 @@ export async function performWebSearch(
     const filterNote = appliedFilters ? ` after applying ${appliedFilters}` : "";
     logMessage(mcpServer, "info", `No results found for query: "${query}"${filterNote}`);
     const noResultsMessage = createNoResultsMessage(query);
-    return metadata ? `${metadata}\n\n---\n\n${noResultsMessage}` : noResultsMessage;
+    return leadingSections ? `${leadingSections}\n\n---\n\n${noResultsMessage}` : noResultsMessage;
   }
 
   const duration = Date.now() - startTime;
@@ -316,5 +356,5 @@ export async function performWebSearch(
     })
     .join("\n\n");
 
-  return metadata ? `${metadata}\n\n---\n\n${formattedResults}` : formattedResults;
+  return leadingSections ? `${leadingSections}\n\n---\n\n${formattedResults}` : formattedResults;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -43,6 +43,7 @@ export function isSearXNGWebSearchArgs(args: unknown): args is {
   min_score?: number;
   num_results?: number;
   categories?: string;
+  engines?: string;
   response_format?: "text" | "json";
 } {
   if (
@@ -62,6 +63,7 @@ export function isSearXNGWebSearchArgs(args: unknown): args is {
     min_score?: unknown;
     num_results?: unknown;
     categories?: unknown;
+    engines?: unknown;
     response_format?: unknown;
   };
 
@@ -103,6 +105,9 @@ export function isSearXNGWebSearchArgs(args: unknown): args is {
     return false;
   }
   if (searchArgs.categories !== undefined && typeof searchArgs.categories !== "string") {
+    return false;
+  }
+  if (searchArgs.engines !== undefined && typeof searchArgs.engines !== "string") {
     return false;
   }
   if (
@@ -229,6 +234,11 @@ export const WEB_SEARCH_TOOL: Tool = {
         type: "string",
         description:
           "Comma-separated SearXNG categories. Supported: general, news, images, videos, it, science, files, social media. Default: general (SearXNG instance default).",
+      },
+      engines: {
+        type: "string",
+        description:
+          "Comma-separated SearXNG engine names to query (e.g. 'google,bing,ddg'). Names are matched exactly when live /config validation is available.",
       },
       response_format: {
         type: "string",


### PR DESCRIPTION
## TODO item

**FEAT-026** — Add `engines` parameter to select specific search engines (🟢 Low, from `TODO-features.md`)

## Context

SearXNG accepts an `engines` parameter (comma-separated, e.g. `google,bing,ddg`) to restrict which backends are queried. This is useful for deterministic results or when specific engines are known to be better for a given query type. This PR exposes that capability on the existing `searxng_web_search` tool (no new tool added, per the TODO's guidance).

## What changed

- **`src/types.ts`** — added `engines?: string` to the `isSearXNGWebSearchArgs` type guard (rejects non-string values) and to the `WEB_SEARCH_TOOL` input schema. The minimal `LITE_*` tool variants are intentionally left unchanged.
- **`src/instance-info.ts`** — refactored the `/config` fetch into a shared `fetchConfig()` helper (preserving the module-level cache, 5s timeout, and `refresh` semantics) now reused by both the existing `fetchInstanceInfo()` and a new exported `getKnownEngines()`, which returns the set of all engine names (enabled **and** disabled), or `null` when `/config` is unavailable.
- **`src/search.ts`** — `performWebSearch` gained an `engines` parameter. When provided and non-blank: if `/config` is reachable, requested names are validated against the known set and unknown names raise a helpful `MCPSearXNGError` (naming the bad engines, pointing at `searxng_instance_info`) **before** any search request; if `/config` is unavailable, the names are forwarded as-is and a "validation skipped" warning is surfaced. The raw value is sent via `engines=` and the param is included in the search log line. Blank/whitespace-only input is ignored.
- **`src/index.ts`** — threads `args.engines` through the MCP call handler.
- **`src/resources.ts`** — documents `engines` in the built-in help resource.
- **`README.md`** — documents the `engines` parameter in the Tools section.
- No `CONFIGURATION.md` change: no new environment variable was introduced.

## How it was verified

Independently re-run by the tech lead (not just the implementer):

- `npm run build` — pass
- `npm test` — 321 passed / 0 failed
- `npm run test:coverage` — pass, 96.73% lines (gate is 80%); `search.ts` 100%, `types.ts` 100%, `instance-info.ts` 96.29%
- `npm run test:e2e` (local) — 11 passed / 0 failed
- `SEARXNG_LIVE_URL=https://searxng.ihor.top npm run test:e2e` (live) — 11 passed / 0 failed
- `npm run lint` — clean

New unit tests cover: encoded forwarding with live `/config`, the invalid-engine validation error (and that the search is *not* issued), `/config`-unavailable warnings in both text and JSON formats, omitted `engines`, and blank `engines`. The pre-existing positional-argument call sites shifted by inserting `engines` before `response_format` were all updated.

## Documentation

- `README.md` Tools section gained a bullet for `engines`.
- `src/resources.ts` help resource lists `engines`.

## Follow-up (already tracked)

Internal whitespace such as `"google, ddg"` validates per-trimmed-token but forwards the raw string (with the space) to SearXNG, which may drop the spaced token. Engine-name normalization is intentionally deferred to **FEAT-043**, so this PR does not normalize.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
