### PR TITLE
ci: add CI workflow running lint + tests on PRs and main (FEAT-046)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,40 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  test:
+    name: Lint, Build, and Test
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Setup Node.js
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
+        with:
+          node-version: '20'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Lint
+        run: npm run lint
+
+      - name: Build
+        run: npm run build
+
+      - name: Test coverage
+        run: npm run test:coverage


### PR DESCRIPTION
## TODO item

**FEAT-046** — CI workflow: run unit/integration tests + lint on every pull request and push to `main` (no e2e) (🟠 High, from `TODO-features.md`)
Refs: SEC-017 (branch protection awaiting a required status check), BUG-005 (integration test needs a prior `npm run build`)

## Context

The repository had no CI workflow that runs the test suite or the linter on incoming changes. The existing workflows cover other concerns only — `codeql.yml`, `scorecard.yml`, `fuzz.yml`, `docker-publish.yml`, `docker-rebuild.yml`, and `npm-publish.yml` (which only runs `npm run build` before publishing, never `npm test`/`npm run lint`). Nothing mechanically verified that a PR kept the tests green or the lint clean before merge. SEC-017 explicitly deferred requiring a status check on `main` until "the test CI workflow is in place" — this PR is that prerequisite.

## What changed

A single new file, `.github/workflows/ci.yml`:

- **Triggers:** `pull_request` and `push` to `main`.
- **Permissions:** workflow-level `contents: read` (least privilege).
- **Concurrency:** `ci-${{ github.ref }}` with `cancel-in-progress` so superseded runs are cancelled.
- **One job** (`Lint, Build, and Test`) on `ubuntu-latest`, steps in order:
  `checkout` → `setup-node` (v20, npm cache) → `npm ci` → `npm run lint` → `npm run build` → `npm run test:coverage`.
- **Build precedes `test:coverage` on purpose:** BUG-005 — the integration test "Running cli.js responds to MCP initialize" spawns `dist/cli.js`, which does not exist on a fresh checkout until `npm run build` runs.
- **No e2e in CI:** `npm run test:e2e` and the `SEARXNG_LIVE_URL` live layer are intentionally excluded (environment-sensitive / external-instance-dependent → flaky). E2e remains a local-only check.
- Actions pinned to the exact SHAs already used elsewhere in this repo:
  `actions/checkout@df4cb1c…` (v6.0.3), `actions/setup-node@48b55a0…` (v6.4.0).

## How it was verified

The workflow YAML was parsed/validated, and the exact commands it invokes were run independently by the tech lead, outside any sandbox, on this checkout:

- YAML parse — valid; structure confirmed (triggers, `contents: read`, concurrency, node 20 + npm cache, correct step order, pinned SHAs).
- `npm run lint` — pass
- `npm run build` — pass
- `npm run test:coverage` — pass, all tests green, **96.73% lines** (gate is 80%); the `cli.js` integration test passes because build runs first.
- Confirmed there is **no** `test:e2e`/`SEARXNG_LIVE_URL` step anywhere in the workflow.

## Documentation

None. Per this project's convention, lint/build/CI changes are not documented in README / CONFIGURATION / SECURITY.

## Follow-up

Unblocks **SEC-017 step 5**: once this check is running on PRs, add it as a required status check in `main` branch protection.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
