### PR TITLE
feat(search): validate and normalize categories/engines against live /config (FEAT-043)

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -23,10 +23,6 @@ jobs:
           node-version: '20'
           registry-url: 'https://registry.npmjs.org/'
 
-      - name: Update npm
-        # Keep npm pinned: npm publish --provenance relies on modern trusted publishing support.
-        run: npm install -g npm@11.17.0
-
       - name: Verify npm provenance support
         run: |
           NPM_VERSION="$(npm --version)"

--- a/README.md
+++ b/README.md
@@ -91,8 +91,8 @@ AI Assistant (e.g. Claude)
     - `safesearch` (number, optional): Safe search filter level (0: None, 1: Moderate, 2: Strict) (default: instance setting)
     - `min_score` (number, optional): Minimum relevance score from 0.0 to 1.0. Results below this score are filtered out.
     - `num_results` (number, optional): Maximum number of results to return, from 1 to 20. `SEARXNG_MAX_RESULTS` applies as an operator ceiling.
-    - `categories` (string, optional): Comma-separated SearXNG categories (e.g. `"news"`, `"it,science"`). Supported values: `general`, `news`, `images`, `videos`, `it`, `science`, `files`, `social media`. Default: SearXNG instance default (usually `general`).
-    - `engines` (string, optional): Comma-separated SearXNG engine names (e.g. `"google,bing,ddg"`). Names are matched exactly when live `/config` validation is available.
+    - `categories` (string, optional): Comma-separated SearXNG categories (e.g. `"news"`, `"it,science"`). When live `/config` is available, values are trimmed and normalized case-insensitively to the instance's canonical category names; unknown values are rejected with available categories listed. If `/config` is unavailable, values are forwarded as-is with a warning. Default: SearXNG instance default.
+    - `engines` (string, optional): Comma-separated SearXNG engine names (e.g. `"google,bing,ddg"`, `"semantic scholar"`). When live `/config` is available, values are trimmed and normalized case-insensitively to canonical engine names, including engines disabled by default; unknown values are rejected with available engines listed. If `/config` is unavailable, values are forwarded as-is with a warning.
     - `response_format` (string, optional): Response format, either `"text"` for formatted agent-readable output or `"json"` for raw SearXNG JSON with filtered/sliced `results`. (default: `"text"`)
 
 - **searxng_search_suggestions**

--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -47,6 +47,17 @@ function makeConfig() {
   return config;
 }
 
+function makeConfigWithCategoryArray() {
+  const config: any = makeConfig();
+  config.categories = ['general', 'social media', 'science'];
+  config.engines = [
+    { name: 'google', categories: ['general'], disabled: false },
+    { name: 'semantic scholar', categories: ['science'], disabled: false },
+    { name: 'mastodon', category: 'social media', disabled: false },
+  ];
+  return config;
+}
+
 async function runTests() {
   console.log('🧪 Testing: instance-info.ts\n');
 
@@ -66,6 +77,38 @@ async function runTests() {
     assert.equal(payload.defaults.safesearch, 1);
     assert.equal(payload.defaults.theme, 'simple');
     assert.deepEqual(payload.plugins, ['Hash plugin']);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('returns category names when /config categories is an array of strings', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    const mockServer = createMockServer();
+    fetchMocker.mock(createMockFetch({ json: makeConfigWithCategoryArray() }));
+
+    const result = await fetchInstanceInfo(mockServer as any, true, false);
+    const payload = JSON.parse(result);
+
+    assert.equal(payload.available, true);
+    assert.deepEqual(payload.categories, ['general', 'science', 'social media']);
+    assert.deepEqual(payload.engines.enabled, ['google', 'mastodon', 'semantic scholar']);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('category filter works when /config categories is an array of strings', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    const mockServer = createMockServer();
+    fetchMocker.mock(createMockFetch({ json: makeConfigWithCategoryArray() }));
+
+    const result = JSON.parse(await fetchInstanceInfo(mockServer as any, true, false, 'social media'));
+
+    assert.deepEqual(result.categories, ['social media']);
+    assert.deepEqual(result.engines.enabled, ['mastodon']);
 
     fetchMocker.restore();
     envManager.restore();

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -30,10 +30,12 @@ function makeMockSearchResults(count: number) {
 
 function makeConfigWithEngines() {
   return {
+    categories: ['general', 'news', 'social media'],
     engines: [
       { name: 'google', disabled: false },
       { name: 'ddg', disabled: false },
       { name: 'bing', disabled: true },
+      { name: 'semantic scholar', disabled: false },
     ],
   };
 }
@@ -856,6 +858,43 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('mixed-case engines and categories normalize to canonical /config names', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+
+    const mockServer = createMockServer();
+    const requestedUrls: string[] = [];
+
+    fetchMocker.mock(async (url) => {
+      requestedUrls.push(url.toString());
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.pathname.endsWith('/config')) {
+        return createMockFetch({ json: makeConfigWithEngines() })(url);
+      }
+      return createMockFetch({ json: { results: [] } })(url);
+    });
+
+    await performWebSearch(
+      mockServer as any,
+      'test query',
+      1,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      ' News , SOCIAL MEDIA ',
+      ' Google , Semantic Scholar ',
+    );
+
+    const searchUrl = new URL(requestedUrls[1]);
+    assert.equal(searchUrl.searchParams.get('categories'), 'news,social media');
+    assert.equal(searchUrl.searchParams.get('engines'), 'google,semantic scholar');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('invalid engine names from live /config throw helpful validation error', async () => {
     clearInstanceInfoCacheForTests();
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
@@ -885,7 +924,114 @@ async function runTests() {
     envManager.restore();
   }, results);
 
-  await testFunction('unavailable /config forwards engines and prepends text warning', async () => {
+  await testFunction('unknown category from live /config throws validation error with available categories', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+
+    const mockServer = createMockServer();
+    let searchCalled = false;
+
+    fetchMocker.mock(async (url) => {
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.pathname.endsWith('/config')) {
+        return createMockFetch({ json: makeConfigWithEngines() })(url);
+      }
+      searchCalled = true;
+      return createMockFetch({ json: { results: [] } })(url);
+    });
+
+    try {
+      await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, 'unknown');
+      assert.fail('Expected invalid category validation error');
+    } catch (error: any) {
+      assert.ok(error.message.includes('Invalid SearXNG category name(s): unknown'), error.message);
+      assert.ok(error.message.includes('Available categories: general, news, social media'), error.message);
+      assert.ok(error.message.includes('searxng_instance_info'), error.message);
+    }
+    assert.equal(searchCalled, false, 'Search should not run after validation failure');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('unknown engine from live /config throws validation error with available engines', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+
+    const mockServer = createMockServer();
+    let searchCalled = false;
+
+    fetchMocker.mock(async (url) => {
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.pathname.endsWith('/config')) {
+        return createMockFetch({ json: makeConfigWithEngines() })(url);
+      }
+      searchCalled = true;
+      return createMockFetch({ json: { results: [] } })(url);
+    });
+
+    try {
+      await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, undefined, 'missing');
+      assert.fail('Expected invalid engine validation error');
+    } catch (error: any) {
+      assert.ok(error.message.includes('Invalid SearXNG engine name(s): missing'), error.message);
+      assert.ok(error.message.includes('Available engines:'), error.message);
+      assert.ok(error.message.includes('semantic scholar'), error.message);
+    }
+    assert.equal(searchCalled, false, 'Search should not run after validation failure');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('stale config refreshes once and then normalizes newly available value', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+
+    const mockServer = createMockServer();
+    const requestedUrls: string[] = [];
+    let configFetchCount = 0;
+
+    fetchMocker.mock(async (url) => {
+      requestedUrls.push(url.toString());
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.pathname.endsWith('/config')) {
+        configFetchCount++;
+        const config = makeConfigWithEngines();
+        if (configFetchCount === 2) {
+          config.categories.push('software wikis');
+          config.engines.push({ name: 'annas archive', disabled: false });
+        }
+        return createMockFetch({ json: config })(url);
+      }
+      return createMockFetch({ json: { results: [] } })(url);
+    });
+
+    await performWebSearch(
+      mockServer as any,
+      'test query',
+      1,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      'Software Wikis',
+      'Annas Archive',
+    );
+
+    assert.equal(configFetchCount, 2, 'Expected cached config plus one refresh');
+    const configRequests = requestedUrls.filter((url) => new URL(url).pathname.endsWith('/config'));
+    assert.equal(configRequests.length, 2, 'Expected exactly one refresh request');
+    const searchUrl = new URL(requestedUrls[2]);
+    assert.equal(searchUrl.searchParams.get('categories'), 'software wikis');
+    assert.equal(searchUrl.searchParams.get('engines'), 'annas archive');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('unavailable /config forwards engines and categories and prepends text warning', async () => {
     clearInstanceInfoCacheForTests();
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
 
@@ -912,18 +1058,19 @@ async function runTests() {
       })(url);
     });
 
-    const result = await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, undefined, 'unknown');
+    const result = await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, 'Unknown Category', 'Unknown Engine');
 
-    assert.ok(result.startsWith('Note: engine names were not validated'), result);
+    assert.ok(result.startsWith('Note: categories and engines were not validated or normalized'), result);
     assert.ok(result.includes('Forwarded Result'), result);
     const searchUrl = requestedUrls[1];
-    assert.equal(new URL(searchUrl).searchParams.get('engines'), 'unknown');
+    assert.equal(new URL(searchUrl).searchParams.get('categories'), 'Unknown Category');
+    assert.equal(new URL(searchUrl).searchParams.get('engines'), 'Unknown Engine');
 
     fetchMocker.restore();
     envManager.restore();
   }, results);
 
-  await testFunction('unavailable /config includes warnings in JSON response when engines are provided', async () => {
+  await testFunction('unavailable /config includes warnings in JSON response when categories and engines are provided', async () => {
     clearInstanceInfoCacheForTests();
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
 
@@ -937,10 +1084,10 @@ async function runTests() {
       return createMockFetch({ json: { query: 'test query', results: [] } })(url);
     });
 
-    const result = await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, undefined, 'unknown', 'json');
+    const result = await performWebSearch(mockServer as any, 'test query', 1, undefined, undefined, undefined, undefined, undefined, 'Unknown Category', 'Unknown Engine', 'json');
     const payload = JSON.parse(result);
 
-    assert.deepEqual(payload.warnings, ['Engine names were not validated because SearXNG /config is unavailable.']);
+    assert.deepEqual(payload.warnings, ['Categories and engines were not validated or normalized because SearXNG /config is unavailable.']);
 
     fetchMocker.restore();
     envManager.restore();

--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -254,12 +254,16 @@ async function runTests() {
     const properties = WEB_SEARCH_TOOL.inputSchema.properties as Record<string, any>;
     assert.ok(properties.categories, 'WEB_SEARCH_TOOL must expose categories parameter');
     assert.equal(properties.categories.type, 'string');
+    assert.ok(properties.categories.description.includes('case-insensitively'), properties.categories.description);
+    assert.ok(properties.categories.description.includes('/config'), properties.categories.description);
   }, results);
 
   await testFunction('WEB_SEARCH_TOOL schema includes engines property', () => {
     const properties = WEB_SEARCH_TOOL.inputSchema.properties as Record<string, any>;
     assert.ok(properties.engines, 'WEB_SEARCH_TOOL must expose engines parameter');
     assert.equal(properties.engines.type, 'string');
+    assert.ok(properties.engines.description.includes('case-insensitively'), properties.engines.description);
+    assert.ok(!properties.engines.description.includes('matched exactly'), properties.engines.description);
   }, results);
 
   await testFunction('WEB_SEARCH_TOOL schema includes response_format enum', () => {

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -18,11 +18,44 @@ function unavailable(message: string, status?: number): string {
   }, null, 2);
 }
 
-function namesFromCategories(config: SearXNGConfig): string[] {
-  if (!config.categories || typeof config.categories !== "object") {
-    return [];
+function categoryNamesFromEngines(config: SearXNGConfig): string[] {
+  const names = new Set<string>();
+
+  if (Array.isArray(config.engines)) {
+    for (const engine of config.engines) {
+      for (const category of engineCategories(engine)) {
+        if (typeof category === "string" && category.trim() !== "") {
+          names.add(category);
+        }
+      }
+    }
   }
-  return Object.keys(config.categories).sort();
+
+  return [...names];
+}
+
+function namesFromCategories(config: SearXNGConfig): string[] {
+  const names = new Set<string>();
+
+  if (Array.isArray(config.categories)) {
+    for (const category of config.categories) {
+      if (typeof category === "string" && category.trim() !== "") {
+        names.add(category);
+      }
+    }
+  } else if (config.categories && typeof config.categories === "object") {
+    for (const category of Object.keys(config.categories)) {
+      if (category.trim() !== "") {
+        names.add(category);
+      }
+    }
+  }
+
+  for (const category of categoryNamesFromEngines(config)) {
+    names.add(category);
+  }
+
+  return [...names].sort();
 }
 
 function engineCategories(engine: any): string[] {
@@ -113,13 +146,17 @@ export function clearInstanceInfoCacheForTests(): void {
   cachedBaseUrl = null;
 }
 
-async function fetchConfig(mcpServer: McpServer): Promise<ConfigResult> {
+async function fetchConfig(mcpServer: McpServer, refresh = false): Promise<ConfigResult> {
   const base = process.env.SEARXNG_URL;
   if (!base) {
     return {
       available: false,
       message: "SEARXNG_URL is not configured; cannot fetch SearXNG /config.",
     };
+  }
+
+  if (refresh) {
+    cachedConfig = null;
   }
 
   if (cachedConfig && cachedBaseUrl === base) {
@@ -160,13 +197,22 @@ async function fetchConfig(mcpServer: McpServer): Promise<ConfigResult> {
   }
 }
 
-export async function getKnownEngines(mcpServer: McpServer): Promise<Set<string> | null> {
-  const result = await fetchConfig(mcpServer);
+export async function getKnownEngines(mcpServer: McpServer, refresh = false): Promise<Set<string> | null> {
+  const result = await fetchConfig(mcpServer, refresh);
   if (!result.available) {
     return null;
   }
 
   return allEngineNames(result.config);
+}
+
+export async function getKnownCategories(mcpServer: McpServer, refresh = false): Promise<Set<string> | null> {
+  const result = await fetchConfig(mcpServer, refresh);
+  if (!result.available) {
+    return null;
+  }
+
+  return new Set(namesFromCategories(result.config));
 }
 
 export async function fetchInstanceInfo(
@@ -176,11 +222,7 @@ export async function fetchInstanceInfo(
   category?: string,
   refresh = false,
 ): Promise<string> {
-  if (refresh) {
-    cachedConfig = null;
-  }
-
-  const result = await fetchConfig(mcpServer);
+  const result = await fetchConfig(mcpServer, refresh);
   if (!result.available) {
     return unavailable(result.message, result.status);
   }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -57,11 +57,11 @@ Performs web searches using the configured SearXNG instance.
 - \`safesearch\` (optional): Safe search level - 0 (none), 1 (moderate), 2 (strict)
 - \`min_score\` (optional): Minimum relevance score from 0.0 to 1.0
 - \`num_results\` (optional): Maximum result count from 1 to 20
-- \`categories\` (optional): Comma-separated SearXNG categories such as "news" or "it,science"
-- \`engines\` (optional): Comma-separated SearXNG engine names such as "google,bing,ddg"
+- \`categories\` (optional): Comma-separated SearXNG categories such as "news" or "it,science"; live \`/config\` values are normalized case-insensitively when available
+- \`engines\` (optional): Comma-separated SearXNG engine names such as "google,bing,ddg" or "semantic scholar"; live \`/config\` values are normalized case-insensitively when available
 - \`response_format\` (optional): "text" for formatted output or "json" for raw SearXNG-shaped JSON (may include a \`warnings\` array for non-fatal issues)
 
-Text output can include metadata sections for direct answers, spelling corrections, suggestions, and infoboxes before the result list. JSON output preserves the SearXNG response shape with filtered and sliced \`results\`, and may include a \`warnings\` array for non-fatal issues.
+Text output can include metadata sections for direct answers, spelling corrections, suggestions, and infoboxes before the result list. JSON output preserves the SearXNG response shape with filtered and sliced \`results\`, and may include a \`warnings\` array for non-fatal issues. Unknown categories or engines are rejected when live \`/config\` validation is available; if \`/config\` is unavailable, the search proceeds with the supplied values and emits a warning.
 
 ### 2. searxng_search_suggestions
 Returns autocomplete suggestions from the configured SearXNG instance.

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { SearXNGWeb } from "./types.js";
-import { getKnownEngines } from "./instance-info.js";
+import { getKnownCategories, getKnownEngines } from "./instance-info.js";
 import { createProxyAgent, createDefaultAgent, ProxyType } from "./proxy.js";
 import { logMessage } from "./logging.js";
 import {
@@ -14,8 +14,8 @@ import {
   type ErrorContext
 } from "./error-handler.js";
 
-const ENGINE_VALIDATION_WARNING = "Engine names were not validated because SearXNG /config is unavailable.";
-const ENGINE_VALIDATION_NOTE = "Note: engine names were not validated (SearXNG /config unavailable).";
+const FILTER_VALIDATION_WARNING = "Categories and engines were not validated or normalized because SearXNG /config is unavailable.";
+const FILTER_VALIDATION_NOTE = "Note: categories and engines were not validated or normalized (SearXNG /config unavailable).";
 
 function getOperatorMaxResults(mcpServer: McpServer): number | undefined {
   const rawValue = process.env.SEARXNG_MAX_RESULTS;
@@ -65,6 +65,150 @@ function truncateResultContent(content: string, maxResultChars?: number): string
 
 function hasItems<T>(items: T[] | undefined): items is T[] {
   return Array.isArray(items) && items.length > 0;
+}
+
+function splitCommaSeparated(value: string): string[] {
+  return value
+    .split(",")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== "");
+}
+
+function buildCanonicalLookup(knownValues: Set<string>): Map<string, string> {
+  const lookup = new Map<string, string>();
+
+  for (const value of knownValues) {
+    lookup.set(value.trim().toLowerCase(), value);
+  }
+
+  return lookup;
+}
+
+function normalizeCommaSeparated(value: string, knownValues: Set<string>) {
+  const lookup = buildCanonicalLookup(knownValues);
+  const normalized: string[] = [];
+  const invalid: string[] = [];
+
+  for (const requested of splitCommaSeparated(value)) {
+    const canonical = lookup.get(requested.toLowerCase());
+    if (canonical === undefined) {
+      invalid.push(requested);
+    } else {
+      normalized.push(canonical);
+    }
+  }
+
+  return {
+    normalized: normalized.join(","),
+    invalid,
+  };
+}
+
+function formatAvailableValues(label: string, values: Set<string>): string {
+  const available = [...values].sort().join(", ");
+  return available === "" ? "" : ` Available ${label}: ${available}.`;
+}
+
+function createValidationError(kind: "category" | "engine", invalid: string[], available: Set<string>): MCPSearXNGError {
+  const label = kind === "category" ? "categories" : "engines";
+  return new MCPSearXNGError(
+    `🔍 Invalid SearXNG ${kind} name(s): ${invalid.join(", ")}.` +
+    formatAvailableValues(label, available) +
+    ` Use the searxng_instance_info tool to discover available ${label}.`,
+  );
+}
+
+type NormalizedFilters = {
+  categories?: string;
+  engines?: string;
+  validationWarning?: string;
+};
+
+async function normalizeSearchFilters(
+  mcpServer: McpServer,
+  categories?: string,
+  engines?: string,
+): Promise<NormalizedFilters> {
+  const effectiveCategories = categories !== undefined && categories.trim() !== "" ? categories : undefined;
+  const effectiveEngines = engines !== undefined && engines.trim() !== "" ? engines : undefined;
+
+  if (!effectiveCategories && !effectiveEngines) {
+    return {};
+  }
+
+  let knownCategories: Set<string> | null | undefined;
+  let knownEngines: Set<string> | null | undefined;
+
+  if (effectiveCategories) {
+    knownCategories = await getKnownCategories(mcpServer);
+    if (knownCategories === null) {
+      return {
+        categories: effectiveCategories,
+        engines: effectiveEngines,
+        validationWarning: FILTER_VALIDATION_WARNING,
+      };
+    }
+  }
+
+  if (effectiveEngines) {
+    knownEngines = await getKnownEngines(mcpServer);
+    if (knownEngines === null) {
+      return {
+        categories: effectiveCategories,
+        engines: effectiveEngines,
+        validationWarning: FILTER_VALIDATION_WARNING,
+      };
+    }
+  }
+
+  let normalizedCategories = effectiveCategories && knownCategories
+    ? normalizeCommaSeparated(effectiveCategories, knownCategories)
+    : undefined;
+  let normalizedEngines = effectiveEngines && knownEngines
+    ? normalizeCommaSeparated(effectiveEngines, knownEngines)
+    : undefined;
+
+  if (
+    (normalizedCategories && normalizedCategories.invalid.length > 0) ||
+    (normalizedEngines && normalizedEngines.invalid.length > 0)
+  ) {
+    if (effectiveCategories) {
+      knownCategories = await getKnownCategories(mcpServer, true);
+      knownEngines = effectiveEngines && knownCategories !== null
+        ? await getKnownEngines(mcpServer)
+        : knownEngines;
+    } else if (effectiveEngines) {
+      knownEngines = await getKnownEngines(mcpServer, true);
+    }
+
+    if (knownCategories === null || knownEngines === null) {
+      return {
+        categories: effectiveCategories,
+        engines: effectiveEngines,
+        validationWarning: FILTER_VALIDATION_WARNING,
+      };
+    }
+
+    normalizedCategories = effectiveCategories && knownCategories
+      ? normalizeCommaSeparated(effectiveCategories, knownCategories)
+      : undefined;
+    normalizedEngines = effectiveEngines && knownEngines
+      ? normalizeCommaSeparated(effectiveEngines, knownEngines)
+      : undefined;
+  }
+
+  if (normalizedCategories && normalizedCategories.invalid.length > 0 && knownCategories) {
+    throw createValidationError("category", normalizedCategories.invalid, knownCategories);
+  }
+
+  if (normalizedEngines && normalizedEngines.invalid.length > 0 && knownEngines) {
+    throw createValidationError("engine", normalizedEngines.invalid, knownEngines);
+  }
+
+  return {
+    categories: normalizedCategories ? normalizedCategories.normalized : undefined,
+    engines: normalizedEngines ? normalizedEngines.normalized : undefined,
+  };
 }
 
 function formatSearchMetadata(data: SearXNGWeb): string {
@@ -146,7 +290,14 @@ export async function performWebSearch(
 
   const effectiveLanguage = language ?? getDefaultLanguage();
   const effectiveSafesearch = safesearch !== undefined ? safesearch : getDefaultSafesearch(mcpServer);
-  const effectiveEngines = engines !== undefined && engines.trim() !== "" ? engines : undefined;
+
+  const validationError = validateEnvironment();
+  if (validationError) {
+    logMessage(mcpServer, "error", "Configuration invalid");
+    throw new MCPSearXNGError(validationError);
+  }
+
+  const filters = await normalizeSearchFilters(mcpServer, categories, engines);
 
   // Build detailed log message with all parameters
   const searchParams = [
@@ -156,41 +307,14 @@ export async function performWebSearch(
     effectiveSafesearch !== undefined ? `safesearch: ${effectiveSafesearch}` : null,
     min_score !== undefined ? `min_score: ${min_score}` : null,
     effectiveMax !== undefined ? `num_results: ${effectiveMax}` : null,
-    categories ? `categories: ${categories}` : null,
-    effectiveEngines ? `engines: ${effectiveEngines}` : null,
+    filters.categories ? `categories: ${filters.categories}` : null,
+    filters.engines ? `engines: ${filters.engines}` : null,
   ].filter(Boolean).join(", ");
   
   logMessage(mcpServer, "info", `Starting web search: "${query}" (${searchParams})`);
   
-  const validationError = validateEnvironment();
-  if (validationError) {
-    logMessage(mcpServer, "error", "Configuration invalid");
-    throw new MCPSearXNGError(validationError);
-  }
-
   const searxngUrl = process.env.SEARXNG_URL!;
   const parsedUrl = new URL(searxngUrl.endsWith('/') ? searxngUrl : searxngUrl + '/');
-  let engineValidationWarning: string | undefined;
-
-  if (effectiveEngines) {
-    const knownEngines = await getKnownEngines(mcpServer);
-    if (knownEngines === null) {
-      engineValidationWarning = ENGINE_VALIDATION_WARNING;
-    } else {
-      const requestedEngines = effectiveEngines
-        .split(",")
-        .map((engine) => engine.trim())
-        .filter((engine) => engine !== "");
-      const invalidEngines = requestedEngines.filter((engine) => !knownEngines.has(engine));
-
-      if (invalidEngines.length > 0) {
-        throw new MCPSearXNGError(
-          `🔍 Invalid SearXNG engine name(s): ${invalidEngines.join(", ")}. ` +
-          "Use the searxng_instance_info tool to discover available engines.",
-        );
-      }
-    }
-  }
 
   const url = new URL('search', parsedUrl);
 
@@ -213,12 +337,12 @@ export async function performWebSearch(
     url.searchParams.set("safesearch", effectiveSafesearch.toString());
   }
 
-  if (categories) {
-    url.searchParams.set("categories", categories);
+  if (filters.categories) {
+    url.searchParams.set("categories", filters.categories);
   }
 
-  if (effectiveEngines) {
-    url.searchParams.set("engines", effectiveEngines);
+  if (filters.engines) {
+    url.searchParams.set("engines", filters.engines);
   }
 
   // Prepare request options with headers
@@ -325,13 +449,13 @@ export async function performWebSearch(
     return JSON.stringify({
       ...data,
       results: slicedResults,
-      ...(engineValidationWarning ? { warnings: [engineValidationWarning] } : {}),
+      ...(filters.validationWarning ? { warnings: [filters.validationWarning] } : {}),
     }, null, 2);
   }
 
   const metadata = formatSearchMetadata(data);
   const leadingSections = [
-    engineValidationWarning ? ENGINE_VALIDATION_NOTE : null,
+    filters.validationWarning ? FILTER_VALIDATION_NOTE : null,
     metadata || null,
   ].filter(Boolean).join("\n\n");
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -233,12 +233,12 @@ export const WEB_SEARCH_TOOL: Tool = {
       categories: {
         type: "string",
         description:
-          "Comma-separated SearXNG categories. Supported: general, news, images, videos, it, science, files, social media. Default: general (SearXNG instance default).",
+          "Comma-separated SearXNG categories. Values are normalized case-insensitively to canonical names from live /config; unknown values are rejected with available categories listed. If /config is unavailable, values are forwarded as-is with a warning.",
       },
       engines: {
         type: "string",
         description:
-          "Comma-separated SearXNG engine names to query (e.g. 'google,bing,ddg'). Names are matched exactly when live /config validation is available.",
+          "Comma-separated SearXNG engine names to query (e.g. 'google,bing,ddg'). Values are normalized case-insensitively to canonical names from live /config; unknown values are rejected with available engines listed. If /config is unavailable, values are forwarded as-is with a warning.",
       },
       response_format: {
         type: "string",


### PR DESCRIPTION
## TODO item

**FEAT-043** — Validate and normalize `categories` / `engines` against live `/config` (Medium, from TODO-features.md)

## Context

Models often vary casing and spacing for engine/category names (`Google`, `google`, `PubMed`, `semantic scholar`). SearXNG treats engine names **case-sensitively** — confirmed against the live instance, where `engines=Google` is not recognized and SearXNG silently ignores the filter and runs a default multi-engine search instead of querying Google. That silent degradation returns the wrong (or fewer) results with no error. Live `/config` provides the canonical enabled category and engine names we can normalize against.

## What changed

- **`src/search.ts`** — Replaces the previous exact-match engine check with a shared filter-normalization step for both `categories` and `engines`:
  - Trims each comma-separated entry and matches it case-insensitively against the instance's canonical names, sending the **canonical** value to SearXNG (e.g. `News, SOCIAL MEDIA` → `news,social media`; `Semantic Scholar` → `semantic scholar`).
  - Unknown values throw a helpful `MCPSearXNGError` that lists the available values and points at `searxng_instance_info`; the search is not issued.
  - If a value misses the **cached** `/config`, the cache is refreshed **exactly once** and re-checked before erroring (handles a stale capability cache).
  - When `/config` is unavailable, values are forwarded as-is with a non-fatal warning (generalized from the old engine-only warning to cover both filters, surfaced in both `text` and `json` output).
- **`src/instance-info.ts`** — Adds `getKnownCategories()` and makes the config getters refresh-capable. Fixes category extraction to handle `/config.categories` as **either** an array of name strings (newer SearXNG) **or** an object keyed by name, and unions in categories referenced by engines. This also corrects the `searxng_instance_info` output on array-shaped instances (previously returned `"0".."N"`).
- **`src/types.ts`** — Tool schema descriptions for `categories`/`engines` now state the normalization, rejection, and `/config`-unavailable warning behavior (the old "matched exactly" wording was inaccurate).
- **`src/resources.ts`** — Built-in help resource text kept in sync with the new behavior.
- **`README.md`** — Documents the user-visible search-parameter behavior.

> Note: this branch also carries one pre-existing, unrelated commit — `chore: remove npm update step from publish workflow` (`.github/workflows/npm-publish.yml`) — which was an un-pushed local `main` commit picked up when branching. It is not part of FEAT-043.

## How it was verified

Verified independently by the tech lead (not just the implementer), outside any sandbox:

- `npm run build` — pass
- `npm test` — **327/327 pass**
- `npm run test:coverage` — 96.73% statements / 86.81% branch (gate: ≥80%)
- `npm run test:e2e` — **11/11 pass**
- `npm run lint` — clean

New unit tests cover: mixed-case category+engine normalization to canonical (asserted on the outgoing search URL), unknown-category and unknown-engine validation errors (and that the search is not issued), one-refresh-then-succeed on a stale cache, `/config`-unavailable forwarding + warning in both `text` and `json`, and category extraction for array-shaped `/config.categories`.

## Documentation

`README.md`, the `categories`/`engines` tool-schema descriptions in `src/types.ts`, and the built-in help in `src/resources.ts` now describe case-insensitive normalization, rejection of unknown values with available values listed, and the forward-with-warning fallback when `/config` is unavailable. No security-relevant change, so `SECURITY.md` is untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
