### PR TITLE
feat: implement reverse image search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Replace `YOUR_SEARXNG_INSTANCE_URL` with the URL of your SearXNG instance (e.g. 
 ## Features
 
 - **Web Search**: General queries, news, articles, with pagination.
+- **Reverse Image Search**: Find where an image appears on the web using TinEye (the only engine in SearXNG that performs true reverse image search by visual content).
 - **Structured Search Output**: Choose formatted text or raw SearXNG-shaped JSON with `response_format`.
 - **Direct Answers & Metadata**: Text results surface SearXNG answers, corrections, suggestions, and infoboxes before result lists.
 - **Search Suggestions**: Query autocomplete via SearXNG's `/autocompleter` endpoint.
@@ -108,6 +109,21 @@ AI Assistant (e.g. Claude)
     - `includeDisabled` (boolean, optional): Include disabled engine names when `includeEngines` is true. (default: false)
     - `category` (string, optional): Filter categories and engines to a single category name.
     - `refresh` (boolean, optional): Bypass the process cache and fetch fresh `/config` data. (default: false)
+
+- **reverse_image_search**
+  - Find web pages where a given image appears. The image must be publicly accessible via a direct http(s) URL.
+  - **Important:** Only `tineye` performs true reverse image search (searching by visual content). Other image engines such as `google images` or `bing images` are regular image search engines that treat the URL as a text query — they search for the words in the URL, not the image itself. Always pass `engines: "tineye"` for genuine reverse image search. TinEye must be enabled in the SearXNG instance settings.
+  - Inputs:
+    - `image_url` (string): Direct URL of the image to look up (e.g. `https://example.com/photo.jpg`)
+    - `engines` (string, optional): Comma-separated engine names (default: `"tineye"`). Only `tineye` performs true reverse image search by visual content. Other image engines treat the URL as a text query and do not search by image content. Validated case-insensitively against the live `/config`; unknown engines are rejected with available engines listed. If `/config` is unavailable, values are forwarded as-is with a warning.
+    - `pageno` (number, optional): Results page number, starts at 1 (default: 1)
+    - `categories` (string, optional): Comma-separated SearXNG categories (e.g. `"general"`). Same validation behaviour as `engines`.
+    - `time_range` (string, optional): Filter results by time range — `"day"`, `"week"`, `"month"`, or `"year"`. Not supported by TinEye.
+    - `language` (string, optional): Language code for results (e.g. `"en"`, `"es"`) or `"all"` (default: `"all"`).
+    - `safesearch` (number, optional): Safe search filter level (0: None, 1: Moderate, 2: Strict).
+    - `min_score` (number, optional): Minimum relevance score from 0.0 to 1.0. Results below this score are filtered out.
+    - `num_results` (number, optional): Maximum number of results to return, from 1 to 20. `SEARXNG_MAX_RESULTS` applies as an operator ceiling.
+    - `response_format` (string, optional): `"text"` for formatted agent-readable output (includes `img_src` per result) or `"json"` for raw SearXNG JSON with `image_url` added at the top level. (default: `"text"`)
 
 - **web_url_read**
   - Read and convert the content from a URL to markdown with advanced content extraction options

--- a/__tests__/e2e/reverse-image-search.e2e.ts
+++ b/__tests__/e2e/reverse-image-search.e2e.ts
@@ -1,0 +1,164 @@
+#!/usr/bin/env tsx
+
+/**
+ * E2E Tests: reverse_image_search tool against live SearXNG instance.
+ *
+ * Requires: SEARXNG_LIVE_URL env var + built dist/cli.js
+ * Run: SEARXNG_LIVE_URL=http://localhost:8080 npx tsx __tests__/e2e/reverse-image-search.e2e.ts
+ */
+
+import { strict as assert } from 'node:assert';
+import {
+  checkSkipConditions,
+  INIT_PARAMS,
+  spawnWithMessages,
+  LIVE_URL,
+} from './helpers/spawn-server.js';
+import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
+
+const results = createTestResults();
+
+// A stable, publicly accessible image URL used across tests
+const TEST_IMAGE_URL = 'https://upload.wikimedia.org/wikipedia/commons/thumb/4/47/PNG_transparency_demonstration_1.png/280px-PNG_transparency_demonstration_1.png';
+
+async function runTests() {
+  console.log('🖼️  E2E Testing: reverse_image_search (live)\n');
+
+  const skip = checkSkipConditions();
+  if (skip) {
+    console.log(skip);
+    return { passed: 0, failed: 0, errors: [] };
+  }
+
+  await testFunction('basic reverse image search returns results', async () => {
+    const responses = spawnWithMessages([
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'reverse_image_search',
+          arguments: { image_url: TEST_IMAGE_URL },
+        },
+      },
+    ]);
+
+    const r = responses[2];
+    assert.ok(r, 'no response to tools/call id=2');
+    assert.ok(!r.error, `server returned error: ${JSON.stringify(r.error)}`);
+
+    const text: string = r.result?.content?.[0]?.text ?? '';
+    assert.ok(text.length > 0, 'response text should be non-empty');
+  }, results);
+
+  await testFunction('text format includes URL and Title fields', async () => {
+    const responses = spawnWithMessages([
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'reverse_image_search',
+          arguments: { image_url: TEST_IMAGE_URL, response_format: 'text' },
+        },
+      },
+    ]);
+
+    const text: string = responses[2]?.result?.content?.[0]?.text ?? '';
+    // Either results or an explicit no-results message
+    const hasResults = text.includes('URL:') && text.includes('Title:');
+    const hasNoResults = text.includes('No reverse image search results');
+    assert.ok(hasResults || hasNoResults, `unexpected response: ${text.slice(0, 200)}`);
+  }, results);
+
+  await testFunction('json format returns parseable JSON with image_url at top level', async () => {
+    const responses = spawnWithMessages([
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'reverse_image_search',
+          arguments: { image_url: TEST_IMAGE_URL, response_format: 'json' },
+        },
+      },
+    ]);
+
+    const text: string = responses[2]?.result?.content?.[0]?.text ?? '';
+    const parsed = JSON.parse(text);
+    assert.strictEqual(parsed.image_url, TEST_IMAGE_URL, 'image_url should be at top level');
+    assert.ok(Array.isArray(parsed.results), 'results should be an array');
+  }, results);
+
+  await testFunction('explicit tineye engine is forwarded', async () => {
+    const responses = spawnWithMessages([
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'reverse_image_search',
+          arguments: { image_url: TEST_IMAGE_URL, engines: 'tineye', response_format: 'json' },
+        },
+      },
+    ]);
+
+    const r = responses[2];
+    // If tineye isn't enabled in this instance, we get a validation error — that's also acceptable
+    const text: string = r?.result?.content?.[0]?.text ?? '';
+    const isError = r?.error || text.includes('Invalid SearXNG engine');
+    const isJson = !isError && (() => { try { JSON.parse(text); return true; } catch { return false; } })();
+    assert.ok(isError || isJson, `unexpected response: ${text.slice(0, 300)}`);
+  }, results);
+
+  await testFunction('invalid image_url (no http) returns clear error', async () => {
+    const responses = spawnWithMessages([
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'reverse_image_search',
+          arguments: { image_url: 'not-a-url' },
+        },
+      },
+    ]);
+
+    const r = responses[2];
+    const hasError = r?.error || r?.result?.content?.[0]?.text?.includes('http');
+    assert.ok(hasError, 'should return an error for non-http image URL');
+  }, results);
+
+  await testFunction('num_results limits response count', async () => {
+    const responses = spawnWithMessages([
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'reverse_image_search',
+          arguments: { image_url: TEST_IMAGE_URL, num_results: 2, response_format: 'json' },
+        },
+      },
+    ]);
+
+    const text: string = responses[2]?.result?.content?.[0]?.text ?? '';
+    const parsed = JSON.parse(text);
+    assert.ok(parsed.results.length <= 2, `expected ≤2 results, got ${parsed.results.length}`);
+  }, results);
+
+  return results;
+}
+
+runTests().then((r) => {
+  if (r && 'passed' in r) printTestSummary(r as any);
+}).catch((err) => {
+  console.error('Fatal:', err);
+  process.exit(1);
+});

--- a/src/index.ts
+++ b/src/index.ts
@@ -19,15 +19,19 @@ import {
   LITE_SUGGESTIONS_TOOL,
   LITE_INSTANCE_INFO_TOOL,
   LITE_READ_URL_TOOL,
+  REVERSE_IMAGE_SEARCH_TOOL,
+  LITE_REVERSE_IMAGE_SEARCH_TOOL,
   isSearXNGWebSearchArgs,
   isSearXNGSearchSuggestionsArgs,
   isSearXNGInstanceInfoArgs,
+  isReverseImageSearchArgs,
 } from "./types.js";
 import { logMessage, setLogLevel, getCurrentLogLevel } from "./logging.js";
 import { performWebSearch } from "./search.js";
 import { performSearchSuggestions } from "./suggestions.js";
 import { fetchInstanceInfo } from "./instance-info.js";
 import { fetchAndConvertToMarkdown } from "./url-reader.js";
+import { performReverseImageSearch } from "./reverse-image-search.js";
 import { createConfigResource, createHelpResource } from "./resources.js";
 import { createHttpServer, resolveBindHost } from "./http-server.js";
 
@@ -141,12 +145,13 @@ export function createMcpServer(): McpServer {
   const suggestionsTool = useLiteTools ? LITE_SUGGESTIONS_TOOL : SUGGESTIONS_TOOL;
   const instanceInfoTool = useLiteTools ? LITE_INSTANCE_INFO_TOOL : INSTANCE_INFO_TOOL;
   const readUrlTool = useLiteTools ? LITE_READ_URL_TOOL : READ_URL_TOOL;
+  const reverseImageSearchTool = useLiteTools ? LITE_REVERSE_IMAGE_SEARCH_TOOL : REVERSE_IMAGE_SEARCH_TOOL;
 
   // List tools handler
   server.setRequestHandler(ListToolsRequestSchema, async () => {
     logMessage(mcpServer, "debug", "Handling list_tools request");
     return {
-      tools: [searchTool, suggestionsTool, instanceInfoTool, readUrlTool],
+      tools: [searchTool, suggestionsTool, instanceInfoTool, readUrlTool, reverseImageSearchTool],
     };
   });
 
@@ -238,6 +243,33 @@ export function createMcpServer(): McpServer {
         };
 
         const result = await fetchAndConvertToMarkdown(mcpServer, args.url, getFetchTimeoutMs(mcpServer), paginationOptions);
+
+        return {
+          content: [
+            {
+              type: "text",
+              text: result,
+            },
+          ],
+        };
+      } else if (name === "reverse_image_search") {
+        if (!isReverseImageSearchArgs(args)) {
+          throw new Error("Invalid arguments for reverse image search");
+        }
+
+        const result = await performReverseImageSearch(
+          mcpServer,
+          args.image_url,
+          args.pageno,
+          args.engines,
+          args.categories,
+          args.time_range,
+          args.language,
+          args.safesearch,
+          args.min_score,
+          args.num_results,
+          args.response_format,
+        );
 
         return {
           content: [

--- a/src/reverse-image-search.ts
+++ b/src/reverse-image-search.ts
@@ -88,8 +88,28 @@ export async function performReverseImageSearch(
   if (effectiveLanguage && effectiveLanguage !== "all") {
     url.searchParams.set("language", effectiveLanguage);
   }
-  if (safesearch !== undefined && [0, 1, 2].includes(safesearch)) {
-    url.searchParams.set("safesearch", safesearch.toString());
+  const effectiveSafesearch = safesearch !== undefined
+    ? safesearch
+    : (() => {
+        const rawValue = process.env.SEARXNG_DEFAULT_SAFESEARCH;
+        if (rawValue === undefined || rawValue.trim() === "") {
+          return undefined;
+        }
+
+        const parsed = parseInt(rawValue, 10);
+        if (Number.isNaN(parsed) || ![0, 1, 2].includes(parsed)) {
+          logMessage(
+            mcpServer,
+            "warning",
+            `Ignoring invalid SEARXNG_DEFAULT_SAFESEARCH="${rawValue}". Expected 0, 1, or 2.`,
+          );
+          return undefined;
+        }
+
+        return parsed;
+      })();
+  if (effectiveSafesearch !== undefined) {
+    url.searchParams.set("safesearch", effectiveSafesearch.toString());
   }
   if (filters.categories) {
     url.searchParams.set("categories", filters.categories);
@@ -146,7 +166,7 @@ export async function performReverseImageSearch(
 
   let data: SearXNGWeb;
   try {
-    data = (await response.json()) as SearXNGWeb;
+    data = (await response.clone().json()) as SearXNGWeb;
   } catch (error: any) {
     let responseText: string;
     try {

--- a/src/reverse-image-search.ts
+++ b/src/reverse-image-search.ts
@@ -1,0 +1,215 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { SearXNGWeb } from "./types.js";
+import { normalizeSearchFilters } from "./search.js";
+import { createProxyAgent, createDefaultAgent, ProxyType } from "./proxy.js";
+import { logMessage } from "./logging.js";
+import {
+  MCPSearXNGError,
+  validateEnvironment,
+  createNetworkError,
+  createServerError,
+  createJSONError,
+  createDataError,
+  type ErrorContext,
+} from "./error-handler.js";
+
+function getOperatorMaxResults(mcpServer: McpServer): number | undefined {
+  const rawValue = process.env.SEARXNG_MAX_RESULTS;
+  if (rawValue === undefined || rawValue.trim() === "") return undefined;
+  const parsed = parseInt(rawValue, 10);
+  if (Number.isNaN(parsed) || parsed <= 0 || parsed > 20) {
+    logMessage(mcpServer, "warning", `Ignoring invalid SEARXNG_MAX_RESULTS="${rawValue}".`);
+    return undefined;
+  }
+  return parsed;
+}
+
+function getDefaultLanguage(): string {
+  return process.env.SEARXNG_DEFAULT_LANGUAGE ?? "all";
+}
+
+export async function performReverseImageSearch(
+  mcpServer: McpServer,
+  image_url: string,
+  pageno: number = 1,
+  engines?: string,
+  categories?: string,
+  time_range?: string,
+  language?: string,
+  safesearch?: number,
+  min_score?: number,
+  num_results?: number,
+  response_format: "text" | "json" = "text",
+): Promise<string> {
+  if (!/^https?:\/\//i.test(image_url)) {
+    throw new MCPSearXNGError(
+      '🖼️ reverse_image_search requires "image_url" to be a direct http(s) URL to an image.',
+    );
+  }
+
+  const validationError = validateEnvironment();
+  if (validationError) {
+    throw new MCPSearXNGError(validationError);
+  }
+
+  const operatorMax = getOperatorMaxResults(mcpServer);
+  const effectiveMax = operatorMax !== undefined
+    ? (num_results !== undefined ? Math.min(num_results, operatorMax) : operatorMax)
+    : num_results;
+
+  const effectiveLanguage = language ?? getDefaultLanguage();
+
+  const filters = await normalizeSearchFilters(mcpServer, categories, engines ?? "tineye");
+
+  const searchParams = [
+    `page ${pageno}`,
+    `lang: ${effectiveLanguage}`,
+    time_range ? `time: ${time_range}` : null,
+    safesearch !== undefined ? `safesearch: ${safesearch}` : null,
+    min_score !== undefined ? `min_score: ${min_score}` : null,
+    effectiveMax !== undefined ? `num_results: ${effectiveMax}` : null,
+    filters.categories ? `categories: ${filters.categories}` : null,
+    filters.engines ? `engines: ${filters.engines}` : null,
+  ].filter(Boolean).join(", ");
+
+  logMessage(mcpServer, "info", `Starting reverse image search: ${image_url} (${searchParams})`);
+
+  const searxngUrl = process.env.SEARXNG_URL!;
+  const parsedBase = new URL(searxngUrl.endsWith("/") ? searxngUrl : searxngUrl + "/");
+  const url = new URL("search", parsedBase);
+
+  url.searchParams.set("q", image_url);
+  url.searchParams.set("format", "json");
+  url.searchParams.set("pageno", pageno.toString());
+
+  if (time_range !== undefined && ["day", "week", "month", "year"].includes(time_range)) {
+    url.searchParams.set("time_range", time_range);
+  }
+  if (effectiveLanguage && effectiveLanguage !== "all") {
+    url.searchParams.set("language", effectiveLanguage);
+  }
+  if (safesearch !== undefined && [0, 1, 2].includes(safesearch)) {
+    url.searchParams.set("safesearch", safesearch.toString());
+  }
+  if (filters.categories) {
+    url.searchParams.set("categories", filters.categories);
+  }
+  if (filters.engines) {
+    url.searchParams.set("engines", filters.engines);
+  }
+
+  const requestOptions: RequestInit = { method: "GET" };
+
+  const proxyAgent = createProxyAgent(url.toString(), ProxyType.SEARCH);
+  const dispatcher = proxyAgent ?? createDefaultAgent();
+  if (dispatcher) {
+    (requestOptions as any).dispatcher = dispatcher;
+  }
+
+  const username = process.env.AUTH_USERNAME;
+  const password = process.env.AUTH_PASSWORD;
+  if (username && password) {
+    const base64Auth = Buffer.from(`${username}:${password}`).toString("base64");
+    requestOptions.headers = { ...requestOptions.headers, Authorization: `Basic ${base64Auth}` };
+  }
+
+  const userAgent = process.env.USER_AGENT;
+  if (userAgent) {
+    requestOptions.headers = { ...requestOptions.headers, "User-Agent": userAgent };
+  }
+
+  const TIMEOUT_MS = parseInt(process.env.SEARXNG_TIMEOUT_MS ?? "10000", 10);
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MS);
+
+  let response: Response;
+  try {
+    logMessage(mcpServer, "info", `Making request to: ${url.toString()}`);
+    response = await fetch(url.toString(), { ...requestOptions, signal: controller.signal });
+  } catch (error: any) {
+    clearTimeout(timeoutId);
+    const context: ErrorContext = { url: url.toString(), searxngUrl, proxyAgent: !!dispatcher, username };
+    throw createNetworkError(error, context);
+  }
+  clearTimeout(timeoutId);
+
+  if (!response.ok) {
+    let responseBody: string;
+    try {
+      responseBody = await response.text();
+    } catch {
+      responseBody = "[Could not read response body]";
+    }
+    const context: ErrorContext = { url: url.toString(), searxngUrl };
+    throw createServerError(response.status, response.statusText, responseBody, context);
+  }
+
+  let data: SearXNGWeb;
+  try {
+    data = (await response.json()) as SearXNGWeb;
+  } catch (error: any) {
+    let responseText: string;
+    try {
+      responseText = await response.text();
+    } catch {
+      responseText = "[Could not read response text]";
+    }
+    const context: ErrorContext = { url: url.toString() };
+    throw createJSONError(responseText, context);
+  }
+
+  if (!data.results) {
+    const context: ErrorContext = { url: url.toString(), query: image_url };
+    throw createDataError(data, context);
+  }
+
+  const results = data.results.filter(
+    (r) => min_score === undefined || (r.score || 0) >= min_score,
+  );
+  const slicedResults = effectiveMax !== undefined ? results.slice(0, effectiveMax) : results;
+
+  logMessage(mcpServer, "info", `Reverse image search completed: ${slicedResults.length} results`);
+
+  if (response_format === "json") {
+    return JSON.stringify(
+      {
+        image_url,
+        ...data,
+        results: slicedResults,
+        ...(filters.validationWarning ? { warnings: [filters.validationWarning] } : {}),
+      },
+      null,
+      2,
+    );
+  }
+
+  // text format
+  const leadingNote = filters.validationNote ?? null;
+
+  if (slicedResults.length === 0) {
+    const noResults = `No reverse image search results found for: ${image_url}`;
+    return leadingNote ? `${leadingNote}\n\n${noResults}` : noResults;
+  }
+
+  const formatted = slicedResults
+    .map((r) => {
+      const score = r.score || 0;
+      const lines = [
+        `Title: ${r.title || ""}`,
+        `URL: ${r.url || ""}`,
+        `Relevance Score: ${score.toFixed(3)}`,
+      ];
+      if (r.content) lines.push(`Description: ${r.content}`);
+      if (r.img_src) lines.push(`Image: ${r.img_src}`);
+      if (r.engine) lines.push(`Engine: ${r.engine}`);
+      return lines.join("\n");
+    })
+    .join("\n\n");
+
+  const header = `Reverse image search results for: ${image_url}\nTotal results: ${data.number_of_results ?? data.results.length}`;
+  const body = leadingNote
+    ? `${leadingNote}\n\n---\n\n${header}\n\n---\n\n${formatted}`
+    : `${header}\n\n---\n\n${formatted}`;
+
+  return body;
+}

--- a/src/search.ts
+++ b/src/search.ts
@@ -115,14 +115,14 @@ function createValidationError(kind: "category" | "engine", invalid: string[], a
   );
 }
 
-type NormalizedFilters = {
+export type NormalizedFilters = {
   categories?: string;
   engines?: string;
   validationWarning?: string;
   validationNote?: string;
 };
 
-async function normalizeSearchFilters(
+export async function normalizeSearchFilters(
   mcpServer: McpServer,
   categories?: string,
   engines?: string,

--- a/src/types.ts
+++ b/src/types.ts
@@ -352,6 +352,168 @@ export const LITE_READ_URL_TOOL: Tool = {
   },
 };
 
+export function isReverseImageSearchArgs(args: unknown): args is {
+  image_url: string;
+  pageno?: number;
+  engines?: string;
+  categories?: string;
+  time_range?: string;
+  language?: string;
+  safesearch?: number;
+  min_score?: number;
+  num_results?: number;
+  response_format?: "text" | "json";
+} {
+  if (
+    typeof args !== "object" ||
+    args === null ||
+    !("image_url" in args) ||
+    typeof (args as { image_url: string }).image_url !== "string"
+  ) {
+    return false;
+  }
+
+  const imageSearchArgs = args as {
+    pageno?: unknown;
+    engines?: unknown;
+    categories?: unknown;
+    time_range?: unknown;
+    language?: unknown;
+    safesearch?: unknown;
+    min_score?: unknown;
+    num_results?: unknown;
+    response_format?: unknown;
+  };
+
+  if (imageSearchArgs.pageno !== undefined && (typeof imageSearchArgs.pageno !== "number" || imageSearchArgs.pageno < 1)) return false;
+  if (imageSearchArgs.engines !== undefined && typeof imageSearchArgs.engines !== "string") return false;
+  if (imageSearchArgs.categories !== undefined && typeof imageSearchArgs.categories !== "string") return false;
+  if (
+    imageSearchArgs.time_range !== undefined &&
+    (typeof imageSearchArgs.time_range !== "string" || !VALID_TIME_RANGES.includes(imageSearchArgs.time_range as any))
+  ) return false;
+  if (imageSearchArgs.language !== undefined && typeof imageSearchArgs.language !== "string") return false;
+  if (
+    imageSearchArgs.safesearch !== undefined &&
+    (typeof imageSearchArgs.safesearch !== "number" || !VALID_SAFESEARCH_VALUES.includes(imageSearchArgs.safesearch as any))
+  ) return false;
+  if (
+    imageSearchArgs.min_score !== undefined &&
+    (typeof imageSearchArgs.min_score !== "number" || Number.isNaN(imageSearchArgs.min_score) || imageSearchArgs.min_score < 0 || imageSearchArgs.min_score > 1)
+  ) return false;
+  if (
+    imageSearchArgs.num_results !== undefined &&
+    (typeof imageSearchArgs.num_results !== "number" ||
+      Number.isNaN(imageSearchArgs.num_results) ||
+      !Number.isInteger(imageSearchArgs.num_results) ||
+      imageSearchArgs.num_results < 1 ||
+      imageSearchArgs.num_results > 20)
+  ) return false;
+  if (
+    imageSearchArgs.response_format !== undefined &&
+    (typeof imageSearchArgs.response_format !== "string" || !VALID_RESPONSE_FORMATS.includes(imageSearchArgs.response_format as any))
+  ) return false;
+
+  return true;
+}
+
+export const REVERSE_IMAGE_SEARCH_TOOL: Tool = {
+  name: "reverse_image_search",
+  description:
+    "Reverse image search via SearXNG: finds web pages where a given image appears. " +
+    "The input must be a direct public URL to an image (http or https). " +
+    "Only 'tineye' performs true reverse image search (searching by visual content). " +
+    "Other image engines such as 'google images' or 'bing images' are regular image search engines " +
+    "that treat the URL as a text query — they do NOT search by image content. " +
+    "Always pass `engines: \"tineye\"` for genuine reverse image search. " +
+    "Note: TinEye must be enabled in the SearXNG instance settings. " +
+    "Use this to discover where an image originates or where it has been published. " +
+    "Follow up with `web_url_read` to read the full content of individual result URLs.",
+  annotations: {
+    readOnlyHint: true,
+    openWorldHint: true,
+  },
+  inputSchema: {
+    type: "object",
+    properties: {
+      image_url: {
+        type: "string",
+        description: "Direct URL of the image to look up (e.g. https://example.com/photo.jpg)",
+      },
+      pageno: {
+        type: "number",
+        description: "Results page number (starts at 1)",
+        default: 1,
+      },
+      engines: {
+        type: "string",
+        description:
+          "Comma-separated SearXNG engine names (default: 'tineye'). " +
+          "Only 'tineye' performs true reverse image search by visual content. " +
+          "Other image engines (e.g. 'google images', 'bing images') treat the URL as a text query and do NOT search by image content. " +
+          "Values are normalized case-insensitively against live /config; unknown values are rejected with available engines listed. " +
+          "If /config is unavailable, values are forwarded as-is with a warning.",
+      },
+      categories: {
+        type: "string",
+        description:
+          "Comma-separated SearXNG categories (e.g. 'images'). " +
+          "Values are normalized case-insensitively; unknown values are rejected with available categories listed.",
+      },
+      time_range: {
+        type: "string",
+        description: "Time range filter (day, week, month, year). Support varies by engine.",
+        enum: ["day", "week", "month", "year"],
+      },
+      language: {
+        type: "string",
+        description: "Language code for results (e.g. 'en', 'es'). Default is instance-dependent.",
+        default: "all",
+      },
+      safesearch: {
+        type: "number",
+        description: "Safe search filter level (0: None, 1: Moderate, 2: Strict)",
+        enum: [0, 1, 2],
+        default: 0,
+      },
+      min_score: {
+        type: "number",
+        description: "Minimum relevance score threshold (0.0–1.0). Results below this score are filtered out.",
+        minimum: 0,
+        maximum: 1,
+      },
+      num_results: {
+        type: "number",
+        description: "Maximum number of results to return (1–20).",
+        minimum: 1,
+        maximum: 20,
+      },
+      response_format: {
+        type: "string",
+        description: "Response format: formatted text for agents or raw JSON for programmatic clients. Default: text.",
+        enum: ["text", "json"],
+        default: "text",
+      },
+    },
+    required: ["image_url"],
+  },
+};
+
+export const LITE_REVERSE_IMAGE_SEARCH_TOOL: Tool = {
+  name: "reverse_image_search",
+  description: "Reverse image search via SearXNG. Use engines: \"tineye\" for true reverse image search (by visual content). Other image engines search by URL text, not image content.",
+  inputSchema: {
+    type: "object",
+    properties: {
+      image_url: { type: "string", description: "Direct URL of the image." },
+      engines: { type: "string", description: "Use 'tineye' for real reverse image search." },
+      num_results: { type: "number", description: "Max results (1–20)." },
+      response_format: { type: "string", description: "Output format: text or json.", enum: ["text", "json"] },
+    },
+    required: ["image_url"],
+  },
+};
+
 export const READ_URL_TOOL: Tool = {
   name: "web_url_read",
   description:


### PR DESCRIPTION
## Summary

Adds a new reverse_image_search tool to the MCP server, closing #17. The tool accepts a direct image URL and queries SearXNG to find web pages where the image appears. It follows the same conventions as searxng_web_search: engine and category validation against the live /config endpoint, validation warnings when /config is unavailable, min_score and num_results filtering, and a response_format parameter for text or JSON output. 

The default engine is tineye (the only engine in SearXNG that performs true reverse image search by visual content).

## Changes

- src/types.ts: Adds isReverseImageSearchArgs type guard and REVERSE_IMAGE_SEARCH_TOOL / LITE_REVERSE_IMAGE_SEARCH_TOOL tool definitions with full input schema (image_url, engines, categories, time_range, language, safesearch, min_score, num_results, response_format).

- src/search.ts: Exports normalizeSearchFilters and NormalizedFilters so they can be reused by the new tool.

- src/reverse-image-search.ts: New module implementing performReverseImageSearch: validates the image URL, resolves engine/category names via normalizeSearchFilters, builds and executes the SearXNG request with proxy/auth/timeout support, and formats output as text (with img_src per result) or JSON (image_url added at top level).

- src/index.ts: Registers the new tool in ListToolsRequestSchema and CallToolRequestSchema.

- README.md: Documents the new tool under Features and Tools, including the clarification that only TinEye performs true reverse image search.

- __tests__/e2e/reverse-image-search.e2e.ts: E2E test suite covering basic search, text format, JSON format, explicit engine forwarding, invalid URL validation, and num_results capping.

- __tests__/integration/mcp-handlers.test.ts: Updates tool count assertions from 4 to 5 and adds presence check for reverse_image_search.

## Testing

<img width="457" height="529" alt="image" src="https://github.com/user-attachments/assets/40ab68ae-4701-445f-bdc3-1512ff72bd0a" />

**E2E tests against a local SearXNG instance (with TinEye enabled):**

SEARXNG_LIVE_URL=http://localhost:8080 
npx tsx __tests__/e2e/reverse-image-search.e2e.ts

Passed: 6
Failed: 0

## Checklist

- [x] Tests added or updated to cover the change
- [x] Documentation updated, README.md reflects the new tool and its behavior
- [x] Branch is rebased on the latest main
- [x] PR title and description are in English
- [x] No personal branding, badges, or identity changes included