### PR TITLE
security(ci): scope security-events:write to dedicated Docker scan jobs (SEC-014)

### DIFF
--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -9,28 +9,18 @@ permissions:
   contents: read       # checkout only; Docker Hub auth uses secrets, not GITHUB_TOKEN
 
 jobs:
-  push_to_registry:
-    name: Push Docker image to Docker Hub
+  scan_image:
+    name: Scan Docker image for vulnerabilities
     runs-on: ubuntu-latest
     permissions:
-      contents: read       # checkout only; Docker Hub auth uses secrets, not GITHUB_TOKEN
+      contents: read       # checkout only
       security-events: write  # for Trivy SARIF upload to GitHub Security tab
-      id-token: write      # for Cosign keyless signing
     steps:
       - name: Check out the repo
         uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
 
-      - name: Set up QEMU
-        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
-
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
-
-      - name: Log in to Docker Hub
-        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Extract metadata (tags, labels) for Docker
         id: meta
@@ -74,6 +64,45 @@ jobs:
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'
+
+  push_to_registry:
+    name: Push Docker image to Docker Hub
+    needs: scan_image
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read       # checkout only; Docker Hub auth uses secrets, not GITHUB_TOKEN
+      id-token: write      # for Cosign keyless signing
+    steps:
+      - name: Check out the repo
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@06116385d9baf250c9f4dcb4858b16962ea869c3 # v4.1.0
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4.2.0
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@80c7e94dd9b9319bd5eb7a0e0fe9291e23a2a2e9 # v6.1.0
+        with:
+          images: isokoliuk/mcp-searxng
+          tags: |
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=raw,value=latest
+
+      - name: Extract base image digest from Dockerfile
+        id: base
+        run: |
+          DIGEST=$(grep -m1 -oE 'sha256:[a-f0-9]{64}' Dockerfile)
+          echo "digest=$DIGEST" >> "$GITHUB_OUTPUT"
 
       - name: Build and push multi-arch image
         id: publish

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -64,14 +64,61 @@ jobs:
             echo "rebuild=false" >> "$GITHUB_OUTPUT"
           fi
 
-  rebuild_and_publish:
-    name: Rebuild and republish with updated base
+  rebuild_scan:
+    name: Scan rebuilt Docker image
     needs: check_base_image
     if: needs.check_base_image.outputs.rebuild == 'true'
     runs-on: ubuntu-latest
     permissions:
-      contents: read          # checkout only; Docker Hub auth uses secrets, not GITHUB_TOKEN
+      contents: read          # checkout only
       security-events: write  # for Trivy SARIF upload to GitHub Security tab
+    steps:
+      - name: Check out latest release tag
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6.0.3
+        with:
+          ref: ${{ needs.check_base_image.outputs.release_tag }}
+
+      - name: Patch Dockerfile to current upstream base digest
+        run: |
+          sed -i -E "s|node:lts-alpine(@sha256:[a-f0-9]{64})?|node:lts-alpine@${{ needs.check_base_image.outputs.upstream_digest }}|g" Dockerfile
+          echo "Patched FROM lines:"
+          grep -n '^FROM' Dockerfile
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@d7f5e7f509e45cec5c76c4d5afdd7de93d0b3df5 # v4.1.0
+
+      - name: Build image for vulnerability scan (amd64)
+        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
+        with:
+          context: .
+          load: true
+          tags: isokoliuk/mcp-searxng:rebuild-scan
+
+      - name: Scan rebuilt image for vulnerabilities
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
+        with:
+          image-ref: 'isokoliuk/mcp-searxng:rebuild-scan'
+          format: 'sarif'
+          output: 'trivy-results.sarif'
+          severity: 'CRITICAL,HIGH'
+          ignore-unfixed: true
+          exit-code: '1'
+
+      - name: Upload Trivy scan results to Security tab
+        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
+        if: always()
+        with:
+          sarif_file: 'trivy-results.sarif'
+
+  rebuild_and_publish:
+    name: Rebuild and republish with updated base
+    needs:
+      - check_base_image
+      - rebuild_scan
+    if: needs.check_base_image.outputs.rebuild == 'true'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read          # checkout only; Docker Hub auth uses secrets, not GITHUB_TOKEN
       id-token: write         # for Cosign keyless signing
     steps:
       - name: Check out latest release tag
@@ -106,30 +153,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build image for vulnerability scan (amd64)
-        uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0
-        with:
-          context: .
-          load: true
-          tags: isokoliuk/mcp-searxng:rebuild-scan
-
-      - name: Scan rebuilt image for vulnerabilities
-        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
-        with:
-          image-ref: 'isokoliuk/mcp-searxng:rebuild-scan'
-          format: 'sarif'
-          output: 'trivy-results.sarif'
-          severity: 'CRITICAL,HIGH'
-          ignore-unfixed: true
-          exit-code: '1'
-
-      - name: Upload Trivy scan results to Security tab
-        uses: github/codeql-action/upload-sarif@8aad20d150bbac5944a9f9d289da16a4b0d87c1e # v4.36.2
-        if: always()
-        with:
-          sarif_file: 'trivy-results.sarif'
-
-      # A failed Trivy scan (exit-code 1) stops the job above, blocking the push below.
+      # A failed Trivy scan (exit-code 1) stops the scan job, blocking the push below.
       - name: Build and push multi-arch image
         id: publish
         uses: docker/build-push-action@f9f3042f7e2789586610d6e8b85c8f03e5195baf # v7.2.0


### PR DESCRIPTION
## TODO item

**SEC-014** — Move Docker workflow `security-events: write` permissions to scan jobs only (🟠 High, from TODO-security.md)
Refs: Code scanning alerts #28 and #37 — Scorecard `Token-Permissions`

## Context

Both Docker workflows granted `security-events: write` (and `id-token: write`) to a single job that *also* built, pushed, and Cosign-signed the image. That permission is only needed by the Trivy SARIF upload step, so holding it on a job that does everything is broader than least privilege — flagged by Scorecard's Token-Permissions check.

## What changed

**`.github/workflows/docker-publish.yml`** — split the single `push_to_registry` job into:
- `scan_image` — `permissions: contents: read, security-events: write`. Builds the image locally (`load`), runs Trivy (`exit-code: 1`), uploads SARIF (`if: always()`).
- `push_to_registry` — `needs: scan_image`, `permissions: contents: read, id-token: write`. Builds+pushes the multi-arch image and Cosign-signs it. No `security-events: write`.

**`.github/workflows/docker-rebuild.yml`** — `check_base_image` stays read-only; the old `rebuild_and_publish` job is split into:
- `rebuild_scan` — `needs: check_base_image`, `security-events: write` only; preserves the `rebuild == 'true'` gate; patches the Dockerfile, builds locally, Trivy scan + SARIF upload.
- `rebuild_and_publish` — `needs: [check_base_image, rebuild_scan]`, `id-token: write` only; patches/builds/pushes/signs.

Net effect: `security-events: write` now lives **only** on the scan jobs; `id-token: write` **only** on the publish/sign jobs; top-level `permissions:` stays `contents: read`. A failed Trivy scan still blocks publish/sign (via `needs:` — the publish job's non-status `if:` is skipped when a needed job fails). Two independent builds (local single-arch scan, multi-arch push) — no artifact passing, matching prior behavior. All action SHA pins preserved.

## How it was verified

Static (these workflows are tag/schedule-triggered and can't run locally):
- `actionlint` (via `rhysd/actionlint` Docker image) on both files — clean
- Manual structural review — every step each job needs is present; permission isolation confirmed by grep (1× `security-events: write` + 1× `id-token: write` per file, on the correct jobs)

Collateral-damage check (run independently by the tech lead, outside any sandbox):
- `npm run build` — pass
- `npm test` — 179 unit + 64 integration pass, 0 fail
- `npm run test:e2e` — 11 passed, 0 failed
- `npm run lint` — clean

## Documentation

None required — this is an internal CI permission-scoping change with no user-visible behavior, tool, or env-var impact.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
