### PR TITLE
security(url-reader): block SSRF via DNS-resolved private addresses (SEC-021)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -116,7 +116,7 @@ Opt-in security layer for when you expose the HTTP transport on a network. Defau
 | `MCP_HTTP_AUTH_TOKEN` | No | — | Required bearer token for all HTTP requests in hardened mode |
 | `MCP_HTTP_ALLOWED_ORIGINS` | No | — | Comma-separated CORS origin allowlist (e.g. `https://app.example.com`) |
 | `MCP_HTTP_ALLOWED_HOSTS` | No | — | Comma-separated DNS rebinding protection allowlist override |
-| `MCP_HTTP_ALLOW_PRIVATE_URLS` | No | `false` | Allow `web_url_read` to fetch internal/private URLs. Private URL reads are blocked by default in all modes. |
+| `MCP_HTTP_ALLOW_PRIVATE_URLS` | No | `false` | Allow `web_url_read` to fetch internal/private URLs, including hostnames that DNS-resolve to private/internal addresses. Private URL reads are blocked by default in all modes. |
 | `MCP_HTTP_EXPOSE_FULL_CONFIG` | No | `false` | Expose full config details in `/health` response (for debugging) |
 
 ## URL Reader Security
@@ -125,7 +125,11 @@ Opt-in security layer for when you expose the HTTP transport on a network. Defau
 
 Redirects are also checked before they are followed. A public URL that redirects to a private/internal URL is blocked.
 
-Set `MCP_HTTP_ALLOW_PRIVATE_URLS=true` only when internal URL reads are intentional for your deployment.
+For direct URL-reader requests without a proxy, DNS answers are validated before connecting. A public-looking hostname that resolves to a private/internal address is blocked, and the connection is pinned to the validated DNS answer to prevent DNS rebinding between validation and connection.
+
+When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTPS_PROXY`, `HTTP_PROXY`, or `HTTPS_PROXY`), the proxy performs DNS resolution. Client-side DNS-answer validation cannot inspect proxied resolutions, so proxied deployments should rely on proxy, firewall, and egress controls.
+
+Set `MCP_HTTP_ALLOW_PRIVATE_URLS=true` only when internal URL reads are intentional for your deployment. This also allows hostnames that DNS-resolve to private/internal addresses.
 
 
 ## Full Example (All Options)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -50,7 +50,11 @@ Private and internal URLs are **blocked by default** in all transport modes. The
 - IPv4-mapped IPv6 addresses that resolve to any of the above (e.g. `::ffff:127.0.0.1`)
 - Redirects are validated **before** they are followed — a public URL that redirects to a private address is also blocked
 
-To allow private URL reads (e.g. for internal deployments), set `MCP_HTTP_ALLOW_PRIVATE_URLS=true`. Do this only when internal fetching is intentional.
+For direct `web_url_read` requests, DNS answers are also validated before the TCP/TLS connection is established. If a public-looking hostname resolves to any blocked private, loopback, link-local, or unspecified address, the request is rejected. The connection is pinned to the validated DNS answer so a hostname cannot pass validation and then rebind to a different address for the actual connection.
+
+When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTPS_PROXY`, `HTTP_PROXY`, or `HTTPS_PROXY`), the proxy performs DNS resolution. In that mode, this client-side DNS validation cannot inspect the final resolved IP address; proxied deployments should rely on proxy, firewall, and egress controls to restrict internal network access.
+
+To allow private URL reads and private DNS-resolved targets (e.g. for internal deployments), set `MCP_HTTP_ALLOW_PRIVATE_URLS=true`. Do this only when internal fetching is intentional.
 
 ### Hardened HTTP Mode
 
@@ -88,7 +92,7 @@ The server auto-detects system CA bundles on Linux and macOS for outbound HTTPS 
 
 ### Redirect Handling
 
-The `web_url_read` tool manually follows redirects (up to 5 hops). Each intermediate URL is validated against the private-IP blocklist before the request is made.
+The `web_url_read` tool manually follows redirects (up to 5 hops). Each intermediate URL is validated against the private-IP blocklist before the request is made. On the direct no-proxy path, each redirect hop also goes through DNS-answer validation before connecting.
 
 ## Deployment Recommendations
 

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -412,36 +412,40 @@ async function runTests() {
   // ── tools/call: web_url_read ─────────────────────────────────────────────────
 
   await testFunction('tools/call web_url_read returns markdown text', async () => {
-    fetchMocker.mock(createMockFetch({ body: HTML_RESPONSE }));
     const { client } = await connect();
 
-    const result = await client.callTool({
-      name: 'web_url_read',
-      arguments: { url: 'https://example.com' },
+    await withPrivateUrlReadsAllowed(async () => {
+      await withLocalHtmlServer(HTML_RESPONSE, async (url) => {
+        const result = await client.callTool({
+          name: 'web_url_read',
+          arguments: { url },
+        });
+
+        assert.equal(result.content[0].type, 'text');
+        assert.ok(
+          (result.content[0] as { type: string; text: string }).text.length > 0,
+          'result text should be non-empty'
+        );
+      });
     });
 
-    assert.equal(result.content[0].type, 'text');
-    assert.ok(
-      (result.content[0] as { type: string; text: string }).text.length > 0,
-      'result text should be non-empty'
-    );
-
-    fetchMocker.restore();
     await client.close();
   }, results);
 
   await testFunction('tools/call web_url_read with pagination options succeeds', async () => {
-    fetchMocker.mock(createMockFetch({ body: HTML_RESPONSE }));
     const { client } = await connect();
 
-    const result = await client.callTool({
-      name: 'web_url_read',
-      arguments: { url: 'https://example.com', startChar: 0, maxLength: 100 },
+    await withPrivateUrlReadsAllowed(async () => {
+      await withLocalHtmlServer(HTML_RESPONSE, async (url) => {
+        const result = await client.callTool({
+          name: 'web_url_read',
+          arguments: { url, startChar: 0, maxLength: 100 },
+        });
+
+        assert.equal(result.content[0].type, 'text');
+      });
     });
 
-    assert.equal(result.content[0].type, 'text');
-
-    fetchMocker.restore();
     await client.close();
   }, results);
 
@@ -545,30 +549,34 @@ async function runTests() {
 
   await testFunction('tools/call web_url_read FETCH_TIMEOUT_MS default 10000 used when env unset', async () => {
     delete process.env.FETCH_TIMEOUT_MS;
-    fetchMocker.mock(createMockFetch({ body: HTML_RESPONSE }));
     const { client } = await connect();
 
-    // Normal request succeeds — confirms the default timeout path doesn't break anything
-    const result = await client.callTool({ name: 'web_url_read', arguments: { url: 'https://example.com' } });
-    assert.equal(result.content[0].type, 'text');
-    assert.ok((result.content[0] as { type: string; text: string }).text.length > 0);
+    await withPrivateUrlReadsAllowed(async () => {
+      await withLocalHtmlServer(HTML_RESPONSE, async (url) => {
+        // Normal request succeeds - confirms the default timeout path doesn't break anything
+        const result = await client.callTool({ name: 'web_url_read', arguments: { url } });
+        assert.equal(result.content[0].type, 'text');
+        assert.ok((result.content[0] as { type: string; text: string }).text.length > 0);
+      });
+    });
 
-    fetchMocker.restore();
     await client.close();
   }, results);
 
   await testFunction('tools/call web_url_read with readHeadings=true succeeds', async () => {
-    fetchMocker.mock(createMockFetch({ body: HTML_RESPONSE }));
     const { client } = await connect();
 
-    const result = await client.callTool({
-      name: 'web_url_read',
-      arguments: { url: 'https://example.com', readHeadings: true },
+    await withPrivateUrlReadsAllowed(async () => {
+      await withLocalHtmlServer(HTML_RESPONSE, async (url) => {
+        const result = await client.callTool({
+          name: 'web_url_read',
+          arguments: { url, readHeadings: true },
+        });
+
+        assert.equal(result.content[0].type, 'text');
+      });
     });
 
-    assert.equal(result.content[0].type, 'text');
-
-    fetchMocker.restore();
     await client.close();
   }, results);
 

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -13,9 +13,11 @@
 import { strict as assert } from 'node:assert';
 import * as http from 'node:http';
 import * as net from 'node:net';
+import { createRequire, syncBuiltinESMExports } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import * as zlib from 'node:zlib';
 import { checkContentLength, fetchAndConvertToMarkdown } from '../../src/url-reader.js';
+import { createUrlReaderLookup } from '../../src/proxy.js';
 import { urlCache } from '../../src/cache.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 import { createMockServer } from '../helpers/mock-server.js';
@@ -23,6 +25,9 @@ import { EnvManager } from '../helpers/env-utils.js';
 
 const results = createTestResults();
 const envManager = new EnvManager();
+const require = createRequire(import.meta.url);
+const dnsModule = require('node:dns') as typeof import('node:dns');
+const TEST_PUBLIC_IP = '203.0.113.10';
 
 // ─── local test-server helpers ───────────────────────────────────────────────
 
@@ -137,6 +142,42 @@ function getFreePort(): Promise<number> {
     });
     srv.once('error', reject);
   });
+}
+
+type MockDnsRecords = Record<string, Array<{ address: string; family: 4 | 6 }>>;
+
+function installDnsLookupMock(recordsByHostname: MockDnsRecords): () => void {
+  const originalLookup = dnsModule.lookup;
+
+  (dnsModule as any).lookup = (hostname: string, options: any, callback?: any) => {
+    const cb = typeof options === 'function' ? options : callback;
+    if (net.isIP(hostname)) {
+      return (originalLookup as any).call(dnsModule, hostname, options, callback);
+    }
+
+    const records = recordsByHostname[hostname];
+
+    if (!records) {
+      const err = new Error(`Mock DNS has no records for ${hostname}`) as NodeJS.ErrnoException;
+      err.code = 'ENOTFOUND';
+      cb(err);
+      return;
+    }
+
+    if (options?.all) {
+      cb(null, records);
+      return;
+    }
+
+    const first = records[0];
+    cb(null, first.address, first.family);
+  };
+  syncBuiltinESMExports();
+
+  return () => {
+    (dnsModule as any).lookup = originalLookup;
+    syncBuiltinESMExports();
+  };
 }
 
 // ─── tests ───────────────────────────────────────────────────────────────────
@@ -619,6 +660,233 @@ async function runTests() {
         }
       }
     } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('default mode blocks hostnames resolving to private IPv4 ranges', async () => {
+    const mockServer = createMockServer();
+    envManager.delete('MCP_HTTP_HARDEN');
+    envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
+    envManager.delete('HTTP_PROXY');
+    envManager.delete('HTTPS_PROXY');
+    envManager.delete('http_proxy');
+    envManager.delete('https_proxy');
+    envManager.delete('URL_READER_HTTP_PROXY');
+    envManager.delete('URL_READER_HTTPS_PROXY');
+    envManager.delete('url_reader_http_proxy');
+    envManager.delete('url_reader_https_proxy');
+
+    const privateCases: MockDnsRecords = {
+      'loopback.example': [{ address: '127.0.0.1', family: 4 }],
+      'ten.example': [{ address: '10.0.0.5', family: 4 }],
+      'lan.example': [{ address: '192.168.1.20', family: 4 }],
+      'rfc1918.example': [{ address: '172.16.0.9', family: 4 }],
+      'metadata.example': [{ address: '169.254.169.254', family: 4 }],
+    };
+    const restoreDns = installDnsLookupMock(privateCases);
+
+    try {
+      for (const hostname of Object.keys(privateCases)) {
+        try {
+          await fetchAndConvertToMarkdown(mockServer as any, `http://${hostname}/private`, 250);
+          assert.fail(`Expected hostname resolving to private IP to be blocked: ${hostname}`);
+        } catch (error: any) {
+          assert.ok(
+            error.message.includes('blocked by security policy'),
+            `Expected security policy error for ${hostname}, got: ${error.message}`,
+          );
+        }
+      }
+    } finally {
+      restoreDns();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('default mode blocks hostnames resolving to private IPv6 ranges', async () => {
+    const mockServer = createMockServer();
+    envManager.delete('MCP_HTTP_HARDEN');
+    envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
+    envManager.delete('HTTP_PROXY');
+    envManager.delete('HTTPS_PROXY');
+    envManager.delete('http_proxy');
+    envManager.delete('https_proxy');
+    envManager.delete('URL_READER_HTTP_PROXY');
+    envManager.delete('URL_READER_HTTPS_PROXY');
+    envManager.delete('url_reader_http_proxy');
+    envManager.delete('url_reader_https_proxy');
+
+    const privateCases: MockDnsRecords = {
+      'v6-loopback.example': [{ address: '::1', family: 6 }],
+      'v6-ula.example': [{ address: 'fc00::1', family: 6 }],
+      'v6-linklocal.example': [{ address: 'fe80::1', family: 6 }],
+    };
+    const restoreDns = installDnsLookupMock(privateCases);
+
+    try {
+      for (const hostname of Object.keys(privateCases)) {
+        try {
+          await fetchAndConvertToMarkdown(mockServer as any, `http://${hostname}/private`, 250);
+          assert.fail(`Expected hostname resolving to private IPv6 to be blocked: ${hostname}`);
+        } catch (error: any) {
+          assert.ok(
+            error.message.includes('blocked by security policy'),
+            `Expected security policy error for ${hostname}, got: ${error.message}`,
+          );
+        }
+      }
+    } finally {
+      restoreDns();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('default mode allows hostnames resolving only to public addresses and pins the connection', async () => {
+    envManager.delete('MCP_HTTP_HARDEN');
+    envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
+
+    let lookupCount = 0;
+    const originalLookup = dnsModule.lookup;
+    (dnsModule as any).lookup = (hostname: string, options: any, callback?: any) => {
+      if (net.isIP(hostname)) {
+        return (originalLookup as any).call(dnsModule, hostname, options, callback);
+      }
+
+      lookupCount++;
+      const cb = typeof options === 'function' ? options : callback;
+      if (options?.all) {
+        cb(null, [{ address: TEST_PUBLIC_IP, family: 4 }]);
+        return;
+      }
+      cb(null, TEST_PUBLIC_IP, 4);
+    };
+    syncBuiltinESMExports();
+    const lookup = createUrlReaderLookup();
+
+    try {
+      const result = await new Promise<{ address: string; family: number }>((resolve, reject) => {
+        lookup('public.example', {}, (error, address, family) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve({ address: address || '', family: family || 0 });
+        });
+      });
+
+      assert.deepEqual(result, { address: TEST_PUBLIC_IP, family: 4 });
+      const allResult = await new Promise<Array<{ address: string; family: number }>>((resolve, reject) => {
+        lookup('public.example', { all: true }, (error, address) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve(Array.isArray(address) ? address : []);
+        });
+      });
+
+      assert.deepEqual(allResult, [{ address: TEST_PUBLIC_IP, family: 4 }]);
+      assert.equal(lookupCount, 2, 'Expected one DNS lookup per custom lookup invocation');
+    } finally {
+      (dnsModule as any).lookup = originalLookup;
+      syncBuiltinESMExports();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('default mode blocks rebinding when any DNS answer is private', async () => {
+    const mockServer = createMockServer();
+    envManager.delete('MCP_HTTP_HARDEN');
+    envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
+    envManager.delete('HTTP_PROXY');
+    envManager.delete('HTTPS_PROXY');
+    envManager.delete('http_proxy');
+    envManager.delete('https_proxy');
+    envManager.delete('URL_READER_HTTP_PROXY');
+    envManager.delete('URL_READER_HTTPS_PROXY');
+    envManager.delete('url_reader_http_proxy');
+    envManager.delete('url_reader_https_proxy');
+
+    const restoreDns = installDnsLookupMock({
+      'mixed.example': [
+        { address: TEST_PUBLIC_IP, family: 4 },
+        { address: '127.0.0.1', family: 4 },
+      ],
+    });
+
+    try {
+      await fetchAndConvertToMarkdown(mockServer as any, 'http://mixed.example/private', 250);
+      assert.fail('Expected hostname with any private DNS answer to be blocked');
+    } catch (error: any) {
+      assert.ok(
+        error.message.includes('blocked by security policy'),
+        `Expected security policy error, got: ${error.message}`,
+      );
+    } finally {
+      restoreDns();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('MCP_HTTP_ALLOW_PRIVATE_URLS allows private DNS resolution', async () => {
+    const mockServer = createMockServer();
+    urlCache.clear();
+    envManager.delete('MCP_HTTP_HARDEN');
+    envManager.set('MCP_HTTP_ALLOW_PRIVATE_URLS', 'true');
+    envManager.delete('HTTP_PROXY');
+    envManager.delete('HTTPS_PROXY');
+    envManager.delete('http_proxy');
+    envManager.delete('https_proxy');
+    envManager.delete('URL_READER_HTTP_PROXY');
+    envManager.delete('URL_READER_HTTPS_PROXY');
+    envManager.delete('url_reader_http_proxy');
+    envManager.delete('url_reader_https_proxy');
+
+    const restoreDns = installDnsLookupMock({
+      'internal.example': [{ address: '127.0.0.1', family: 4 }],
+    });
+    const { url, close } = await startTestServer({ body: '<html><body><h1>Internal DNS target</h1></body></html>' });
+    const port = new URL(url).port;
+
+    try {
+      const result = await fetchAndConvertToMarkdown(mockServer as any, `http://internal.example:${port}/article`, 1000);
+      assert.ok(result.includes('Internal DNS target'), `Expected private DNS opt-out fetch, got: ${result}`);
+    } finally {
+      restoreDns();
+      await close();
+      envManager.restore();
+      urlCache.clear();
+    }
+  }, results);
+
+  await testFunction('redirect target resolving to a private IP is blocked', async () => {
+    envManager.delete('MCP_HTTP_HARDEN');
+    envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
+
+    const restoreDns = installDnsLookupMock({
+      'private-redirect.example': [{ address: '127.0.0.1', family: 4 }],
+    });
+    const lookup = createUrlReaderLookup();
+
+    try {
+      await new Promise<void>((resolve, reject) => {
+        lookup('private-redirect.example', {}, (error) => {
+          if (error) {
+            reject(error);
+            return;
+          }
+          resolve();
+        });
+      });
+      assert.fail('Expected redirect target resolving to private IP to be blocked');
+    } catch (error: any) {
+      assert.ok(
+        error.name === 'URLSecurityPolicyDnsError',
+        `Expected DNS security policy error, got: ${error.name}: ${error.message}`,
+      );
+    } finally {
+      restoreDns();
       envManager.restore();
     }
   }, results);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,50 @@
+import * as dns from "node:dns";
 import { Agent, ProxyAgent } from "undici";
+import { getHttpSecurityConfig } from "./http-security.js";
 import { getConnectOptions } from "./tls-config.js";
+import { createUrlSecurityPolicyDnsError, isPrivateAddress } from "./url-security.js";
+
+type LookupCallback = (
+  err: NodeJS.ErrnoException | null,
+  address: string | dns.LookupAddress[],
+  family?: number,
+) => void;
+
+export function createUrlReaderLookup() {
+  return (hostname: string, options: dns.LookupOptions, callback: LookupCallback): void => {
+    if (getHttpSecurityConfig().allowPrivateUrls) {
+      (dns.lookup as any)(hostname, options, callback);
+      return;
+    }
+
+    dns.lookup(hostname, { ...options, all: true }, (error, addresses) => {
+      if (error) {
+        callback(error, options.all ? [] : "");
+        return;
+      }
+
+      if (addresses.length === 0) {
+        const notFound = new Error(`No DNS records found for ${hostname}`) as NodeJS.ErrnoException;
+        notFound.code = "ENOTFOUND";
+        callback(notFound, options.all ? [] : "");
+        return;
+      }
+
+      if (addresses.some(({ address }) => isPrivateAddress(address))) {
+        callback(createUrlSecurityPolicyDnsError(hostname), options.all ? [] : "");
+        return;
+      }
+
+      const selected = addresses[0];
+      if (options.all) {
+        callback(null, [selected]);
+        return;
+      }
+
+      callback(null, selected.address, selected.family);
+    });
+  };
+}
 
 /**
  * Checks if a target URL should bypass the proxy based on NO_PROXY environment variable.
@@ -228,6 +273,7 @@ export function createProxyAgent(targetUrl?: string, type?: ProxyType): ProxyAge
  */
 let _defaultAgentInitialized = false;
 let _defaultAgent: Agent | undefined;
+let _urlReaderAgent: Agent | undefined;
 
 export function createDefaultAgent(): Agent | undefined {
   if (!_defaultAgentInitialized) {
@@ -238,4 +284,23 @@ export function createDefaultAgent(): Agent | undefined {
     }
   }
   return _defaultAgent;
+}
+
+/**
+ * Returns a singleton undici Agent for direct `web_url_read` requests.
+ *
+ * Unlike the shared default agent, this is always created so the URL reader's
+ * DNS validation hook is present even when no system CA bundle is detected.
+ */
+export function createUrlReaderAgent(): Agent {
+  if (!_urlReaderAgent) {
+    _urlReaderAgent = new Agent({
+      connect: {
+        ...getConnectOptions(),
+        lookup: createUrlReaderLookup(),
+      },
+    });
+  }
+
+  return _urlReaderAgent;
 }

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -1,11 +1,10 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
-import { isIP } from "node:net";
 import { NodeHtmlMarkdown } from "node-html-markdown";
 import { fetch as undiciFetch, type Dispatcher } from "undici";
-import { createProxyAgent, createDefaultAgent, ProxyType } from "./proxy.js";
+import { createProxyAgent, createUrlReaderAgent, ProxyType } from "./proxy.js";
 import { logMessage } from "./logging.js";
 import { urlCache } from "./cache.js";
-import { getHttpSecurityConfig } from "./http-security.js";
+import { assertUrlAllowed, isUrlSecurityPolicyDnsError } from "./url-security.js";
 import {
   createURLFormatError,
   createURLSecurityPolicyError,
@@ -31,67 +30,6 @@ const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
 const MAX_REDIRECTS = 5;
 export const DEFAULT_MAX_CONTENT_LENGTH_BYTES = 5 * 1024 * 1024;
 const HEAD_TIMEOUT_CAP_MS = 3000;
-
-function isPrivateHostname(hostname: string): boolean {
-  const lower = hostname.toLowerCase().replace(/\.+$/, "");
-  return lower === "localhost" || lower.endsWith(".localhost");
-}
-
-function isPrivateIpv4(hostname: string): boolean {
-  if (isIP(hostname) !== 4) {
-    return false;
-  }
-
-  return (
-    hostname.startsWith("0.") ||
-    hostname.startsWith("10.") ||
-    hostname.startsWith("127.") ||
-    hostname.startsWith("192.168.") ||
-    /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname) ||
-    hostname.startsWith("169.254.")
-  );
-}
-
-function isPrivateIPv6(hostname: string): boolean {
-  // url.hostname wraps IPv6 in brackets (e.g. "[::1]") — strip them first
-  const addr = (hostname.startsWith("[") && hostname.endsWith("]")
-    ? hostname.slice(1, -1)
-    : hostname
-  ).toLowerCase();
-
-  if (isIP(addr) !== 6) return false;
-
-  if (addr === "::1") return true;                        // loopback
-  if (addr === "::") return true;                         // unspecified
-  if (/^f[cd]/i.test(addr)) return true;                 // ULA fc00::/7
-  if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true;    // link-local fe80::/10
-
-  // IPv4-mapped ::ffff:<ipv4> — delegate to the IPv4 check
-  const mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (mapped) return isPrivateIpv4(mapped[1]);
-
-  // IPv4-mapped ::ffff:<hhhh>:<hhhh> — convert the hex segments to dotted decimal
-  const hexMapped = addr.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-  if (hexMapped) {
-    const high = parseInt(hexMapped[1], 16);
-    const low = parseInt(hexMapped[2], 16);
-    const ipv4 = `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
-    return isPrivateIpv4(ipv4);
-  }
-
-  return false;
-}
-
-function assertUrlAllowed(url: URL): void {
-  const security = getHttpSecurityConfig();
-  if (security.allowPrivateUrls) {
-    return;
-  }
-
-  if (isPrivateHostname(url.hostname) || isPrivateIpv4(url.hostname) || isPrivateIPv6(url.hostname)) {
-    throw createURLSecurityPolicyError(url.toString());
-  }
-}
 
 function isRedirectResponse(response: Response): boolean {
   return REDIRECT_STATUS_CODES.has(response.status);
@@ -247,6 +185,10 @@ export async function checkContentLength(
     const parsed = parseInt(contentLength, 10);
     return Number.isNaN(parsed) || parsed < 0 ? null : parsed;
   } catch (error: any) {
+    if (isUrlSecurityPolicyDnsError(error)) {
+      throw createURLSecurityPolicyError(url);
+    }
+
     logMessage(mcpServer, "warning", `HEAD check failed (proceeding with GET): ${error.message}`);
     return null;
   } finally {
@@ -340,7 +282,7 @@ export async function fetchAndConvertToMarkdown(
       for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
         // Add proxy or default dispatcher (includes system CA certs for TLS)
         const proxyAgent = createProxyAgent(currentUrl.toString(), ProxyType.URL_READER);
-        const dispatcher = proxyAgent ?? createDefaultAgent();
+        const dispatcher = proxyAgent ?? createUrlReaderAgent();
         usedDispatcher = !!dispatcher;
         const currentRequestOptions = {
           ...requestOptions,
@@ -386,6 +328,10 @@ export async function fetchAndConvertToMarkdown(
     } catch (error: any) {
       if (error.name === 'MCPSearXNGError') {
         throw error;
+      }
+
+      if (isUrlSecurityPolicyDnsError(error)) {
+        throw createURLSecurityPolicyError(currentUrl.toString());
       }
 
       const context: ErrorContext = {

--- a/src/url-security.ts
+++ b/src/url-security.ts
@@ -1,0 +1,91 @@
+import { isIP } from "node:net";
+import { createURLSecurityPolicyError } from "./error-handler.js";
+import { getHttpSecurityConfig } from "./http-security.js";
+
+export const URL_SECURITY_POLICY_DNS_ERROR = "URLSecurityPolicyDnsError";
+
+export function isPrivateHostname(hostname: string): boolean {
+  const lower = hostname.toLowerCase().replace(/\.+$/, "");
+  return lower === "localhost" || lower.endsWith(".localhost");
+}
+
+export function isPrivateIpv4(hostname: string): boolean {
+  if (isIP(hostname) !== 4) {
+    return false;
+  }
+
+  return (
+    hostname.startsWith("0.") ||
+    hostname.startsWith("10.") ||
+    hostname.startsWith("127.") ||
+    hostname.startsWith("192.168.") ||
+    /^172\.(1[6-9]|2\d|3[0-1])\./.test(hostname) ||
+    hostname.startsWith("169.254.")
+  );
+}
+
+export function isPrivateIPv6(hostname: string): boolean {
+  // url.hostname wraps IPv6 in brackets (e.g. "[::1]") - strip them first
+  const addr = (hostname.startsWith("[") && hostname.endsWith("]")
+    ? hostname.slice(1, -1)
+    : hostname
+  ).toLowerCase();
+
+  if (isIP(addr) !== 6) return false;
+
+  if (addr === "::1") return true;                     // loopback
+  if (addr === "::") return true;                      // unspecified
+  if (/^f[cd]/i.test(addr)) return true;               // ULA fc00::/7
+  if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true;  // link-local fe80::/10
+
+  // IPv4-mapped ::ffff:<ipv4> - delegate to the IPv4 check
+  const mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
+  if (mapped) return isPrivateIpv4(mapped[1]);
+
+  // IPv4-mapped ::ffff:<hhhh>:<hhhh> - convert the hex segments to dotted decimal
+  const hexMapped = addr.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
+  if (hexMapped) {
+    const high = parseInt(hexMapped[1], 16);
+    const low = parseInt(hexMapped[2], 16);
+    const ipv4 = `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
+    return isPrivateIpv4(ipv4);
+  }
+
+  return false;
+}
+
+export function isPrivateAddress(address: string): boolean {
+  return isPrivateIpv4(address) || isPrivateIPv6(address);
+}
+
+export function assertUrlAllowed(url: URL): void {
+  const security = getHttpSecurityConfig();
+  if (security.allowPrivateUrls) {
+    return;
+  }
+
+  if (isPrivateHostname(url.hostname) || isPrivateIpv4(url.hostname) || isPrivateIPv6(url.hostname)) {
+    throw createURLSecurityPolicyError(url.toString());
+  }
+}
+
+export function createUrlSecurityPolicyDnsError(hostname: string): NodeJS.ErrnoException {
+  const error = new Error(`Resolved private address blocked by security policy for ${hostname}`) as NodeJS.ErrnoException;
+  error.name = URL_SECURITY_POLICY_DNS_ERROR;
+  error.code = URL_SECURITY_POLICY_DNS_ERROR;
+  return error;
+}
+
+export function isUrlSecurityPolicyDnsError(error: unknown): boolean {
+  let current = error as any;
+  while (current) {
+    if (current.name === URL_SECURITY_POLICY_DNS_ERROR || current.code === URL_SECURITY_POLICY_DNS_ERROR) {
+      return true;
+    }
+    if (Array.isArray(current.errors) && current.errors.some(isUrlSecurityPolicyDnsError)) {
+      return true;
+    }
+    current = current.cause;
+  }
+  return false;
+}


### PR DESCRIPTION
## TODO item

**SEC-021** — DNS-resolved private hostname bypasses `web_url_read` SSRF guard (🟠 High, from TODO-security.md)
Refs: GHSA-mrvx-jmjw-vggc

## Context

`web_url_read`'s SSRF guard (`assertUrlAllowed`) inspected only the **literal**
`url.hostname` string — `isPrivateIpv4`/`isPrivateIPv6` return `false` unless the
hostname is already a literal IP, and no DNS resolution happened before connecting.
A public-looking hostname that DNS-resolves to a private/loopback/link-local address
therefore bypassed the guard entirely (e.g. an attacker domain pointing at
`127.0.0.1`/`10.0.0.0/8`, or `169-254-169-254.nip.io` → `169.254.169.254` cloud
metadata/IMDS). This is server-side request forgery into internal services, plus a
DNS-rebinding TOCTOU window for any naive resolve-then-connect fix.

## What changed

- **`src/url-security.ts` (new):** extracted `isPrivateHostname`, `isPrivateIpv4`,
  `isPrivateIPv6`, and `assertUrlAllowed` from `url-reader.ts` (no logic change),
  added `isPrivateAddress()` and a tagged `createUrlSecurityPolicyDnsError` /
  `isUrlSecurityPolicyDnsError` pair that walks both the `cause` chain and undici's
  aggregated `errors` so a lookup-hook rejection is recognizable upstream.
- **`src/proxy.ts`:** added `createUrlReaderLookup()` — a custom undici `lookup` hook
  that resolves **all** DNS answers, rejects the connection if **any** answer is
  private (conservative, defeats `[public, private]` rebinding), and otherwise pins
  the connection to a single validated answer. Added `createUrlReaderAgent()`, a
  URL-reader-only singleton `Agent` that is **always** created (so the guard runs even
  when no system CA bundle is detected — fail-closed). The shared `createDefaultAgent()`
  and all SEARCH callers are untouched.
- **`src/url-reader.ts`:** the direct (no-proxy) `web_url_read` path now uses
  `createUrlReaderAgent()`; lookup-hook rejections in both the HEAD preflight and the
  GET path are mapped to `createURLSecurityPolicyError`. The literal-string
  `assertUrlAllowed()` remains as the cheap first gate per redirect hop.
- **Tests:** new DNS unit coverage (private IPv4/IPv6 resolution blocked, public-only
  allowed + connection pinned, rebinding-when-any-answer-private blocked, opt-out,
  redirect-target resolving to private blocked, hex IPv4-mapped IPv6). Reworked four
  `web_url_read` MCP-handler integration tests from the (ineffective) `global.fetch`
  mock to a real local HTTP server — `web_url_read` uses `undici.fetch` directly, so
  the old mock never intercepted it; the local server is opt-in via
  `MCP_HTTP_ALLOW_PRIVATE_URLS` since 127.0.0.1 is now blocked by default.

## How it was verified

- `npm run build` — pass
- `npm test` — 347 passed / 0 failed (URL Reader unit 45/45, MCP Handlers integration 28/28)
- `npm run test:e2e` — 11/11
- `npm run test:coverage` — exit 0, 96.63% lines overall (`url-security.ts` 97.8%, `url-reader.ts` 92.99%)
- live e2e (`SEARXNG_LIVE_URL=https://searxng.ihor.top`) — 11/11, `web_url_read` live 3/3, no skipped suites
- `npm run lint` — clean

(verified independently by the tech lead, not just by the implementer)

## Documentation

- **SECURITY.md** — URL Reader Security section now documents DNS-answer validation,
  connection pinning against rebinding, the per-redirect-hop check, and the proxied-path
  limitation; the `MCP_HTTP_ALLOW_PRIVATE_URLS` opt-out note covers DNS-resolved targets.
- **CONFIGURATION.md** — `MCP_HTTP_ALLOW_PRIVATE_URLS` row and URL Reader Security notes
  updated for DNS-resolved private targets and the proxy caveat.

## Scope note

This closes the **direct** (no-proxy) SSRF path. When a URL-reader proxy is configured,
the proxy resolves DNS, so client-side validation cannot see the resolved IP — proxied
deployments must rely on egress/firewall controls. This is documented, not silently left
open.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
