### PR TITLE
security(docker): run container as non-root numeric user (SEC-023)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -20,4 +20,6 @@ ENV NODE_ENV=production
 
 RUN npm ci --ignore-scripts --omit=dev && npm uninstall -g npm
 
+USER 1000
+
 ENTRYPOINT ["node", "dist/cli.js"]

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -100,6 +100,8 @@ The `web_url_read` tool manually follows redirects (up to 5 hops). Each intermed
 
 ## Deployment Recommendations
 
+The published container image runs as the non-root numeric user UID 1000, so Kubernetes deployments can use `runAsNonRoot: true` without setting an additional `runAsUser`.
+
 ### Minimal / Local
 
 Use the default STDIO transport. No additional configuration is needed beyond `SEARXNG_URL`.


### PR DESCRIPTION
## TODO item

**SEC-023** — Run the Docker container as a non-root numeric user (Medium, from TODO-security.md)
Refs: https://github.com/ihor-sokoliuk/mcp-searxng/issues/122

## Context

The release stage of the `Dockerfile` never set a `USER`, so the published image ran as `root` (UID 0). Deploying it on Kubernetes with the pod security context `runAsNonRoot: true` was rejected at admission because the container would run as root. Running a network-facing service as root is also a defence-in-depth weakness. The `node:lts-alpine` base image already ships a `node` account at UID 1000, so no `adduser` is needed.

## What changed

- **`Dockerfile`** — add `USER 1000` immediately before the `ENTRYPOINT` in the `release` stage. The UID is **numeric** on purpose: Kubernetes `runAsNonRoot: true` validates the image's configured user at admission and cannot resolve a non-numeric name (`node`) against `/etc/passwd`, so `USER 1000` satisfies the check on its own without a separate `runAsUser`. (The file also gains a trailing newline.)
- **`SECURITY.md`** — add a note under **Deployment Recommendations** that the image runs as the non-root numeric user UID 1000 and is compatible with `runAsNonRoot: true`.

No source, test, workflow, or package-metadata changes. `docker-compose.yml` is unchanged.

## How it was verified

Docker (the meaningful verification for this change), run by the tech lead:
- `docker build -t mcp-searxng:sec-023 .` — success
- `docker run --rm --entrypoint id mcp-searxng:sec-023 -u` → **1000**
- `docker inspect -f '{{.Config.User}}'` → **1000**
- `docker run … -e SEARXNG_URL=… mcp-searxng:sec-023` — server starts cleanly as the non-root user, no `EACCES`/`EPERM`

Regression guard (a Dockerfile/docs change must not break the suite), run independently by the tech lead:
- `npm run build` — pass
- `npm test` — pass (352/352)
- `npm run lint` — clean

(No unit/e2e tests added: a `USER` directive has no unit-testable behavior; verification is the Docker checks above.)

## Documentation

`SECURITY.md` → Deployment Recommendations now states the image runs as UID 1000 and supports `runAsNonRoot: true`. (README intentionally left unchanged — documented in SECURITY.md only.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
