### PR TITLE
fix(types): safesearch as string enum for Gemini/Antigravity compatibility (BUG-006)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ AI Assistant (e.g. Claude)
     - `pageno` (number, optional): Search page number, starts at 1 (default 1)
     - `time_range` (string, optional): Filter results by time range - one of: "day", "week", "month", "year" (default: none)
     - `language` (string, optional): Language code for results (e.g., "en", "fr", "de") or "all" (default: "all")
-    - `safesearch` (number, optional): Safe search filter level (0: None, 1: Moderate, 2: Strict) (default: instance setting)
+    - `safesearch` (string enum, optional): Safe search filter level, one of `"0"` (None), `"1"` (Moderate), or `"2"` (Strict). Legacy numeric values `0`, `1`, and `2` are still accepted for backward compatibility. (default: instance setting)
     - `min_score` (number, optional): Minimum relevance score from 0.0 to 1.0. Results below this score are filtered out.
     - `num_results` (number, optional): Maximum number of results to return, from 1 to 20. `SEARXNG_MAX_RESULTS` applies as an operator ceiling.
     - `categories` (string, optional): Comma-separated SearXNG categories (e.g. `"news"`, `"it,science"`). When live `/config` is available, values are trimmed and normalized case-insensitively to the instance's canonical category names; unknown values are rejected with available categories listed. If `/config` is unavailable, values are forwarded as-is with a warning. Default: SearXNG instance default.

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -163,7 +163,8 @@ async function runTests() {
     const safesearchSchema = searchProps.safesearch as Record<string, unknown>;
     assert.equal(safesearchSchema.type, 'string');
     assert.deepEqual(safesearchSchema.enum, ['0', '1', '2']);
-    assert.equal(safesearchSchema.default, '0');
+    assert.equal(safesearchSchema.default, undefined);
+    assert.ok(!Object.hasOwn(safesearchSchema, 'default'));
     assert.ok(!(safesearchSchema.enum as unknown[]).some((value) => typeof value === 'number'));
 
     const suggestionsTool = result.tools.find((t) => t.name === 'searxng_search_suggestions');

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -15,7 +15,7 @@ import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { createMcpServer } from '../../src/index.js';
-import { FetchMocker, createMockFetch } from '../helpers/mock-fetch.js';
+import { FetchMocker, createCapturingMockFetch, createMockFetch } from '../helpers/mock-fetch.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 
 const results = createTestResults();
@@ -160,6 +160,11 @@ async function runTests() {
     const searchProps = searchTool!.inputSchema.properties as Record<string, unknown>;
     assert.ok(searchProps.language, 'full search tool must have language');
     assert.ok(searchProps.safesearch, 'full search tool must have safesearch');
+    const safesearchSchema = searchProps.safesearch as Record<string, unknown>;
+    assert.equal(safesearchSchema.type, 'string');
+    assert.deepEqual(safesearchSchema.enum, ['0', '1', '2']);
+    assert.equal(safesearchSchema.default, '0');
+    assert.ok(!(safesearchSchema.enum as unknown[]).some((value) => typeof value === 'number'));
 
     const suggestionsTool = result.tools.find((t) => t.name === 'searxng_search_suggestions');
     assert.ok(suggestionsTool);
@@ -270,6 +275,29 @@ async function runTests() {
     });
 
     assert.equal(result.content[0].type, 'text');
+
+    fetchMocker.restore();
+    delete process.env.SEARXNG_URL;
+    await client.close();
+  }, results);
+
+  await testFunction('tools/call searxng_web_search accepts string safesearch and forwards numeric query param', async () => {
+    process.env.SEARXNG_URL = 'http://localhost:8080';
+    const { mockFetch, getCapturedUrl } = createCapturingMockFetch();
+    fetchMocker.mock(mockFetch);
+    const { client } = await connect();
+
+    const result = await client.callTool({
+      name: 'searxng_web_search',
+      arguments: {
+        query: 'test',
+        safesearch: '2',
+      },
+    });
+
+    assert.equal(result.content[0].type, 'text');
+    const url = new URL(getCapturedUrl());
+    assert.equal(url.searchParams.get('safesearch'), '2');
 
     fetchMocker.restore();
     delete process.env.SEARXNG_URL;

--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -83,7 +83,8 @@ async function runTests() {
     assert.ok(properties.time_range.enum.includes('week'));
     assert.equal(properties.safesearch.type, 'string');
     assert.deepEqual(properties.safesearch.enum, ['0', '1', '2']);
-    assert.equal(properties.safesearch.default, '0');
+    assert.equal(properties.safesearch.default, undefined);
+    assert.ok(!Object.hasOwn(properties.safesearch, 'default'));
     assert.ok(!properties.safesearch.enum.some((value: unknown) => typeof value === 'number'));
     assert.equal(properties.min_score.type, 'number');
     assert.equal(properties.min_score.minimum, 0);

--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -37,6 +37,11 @@ async function runTests() {
     assert.equal(isSearXNGWebSearchArgs({ query: 'test search' }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', pageno: 1, time_range: 'day' }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', pageno: 1, time_range: 'week', safesearch: 2 }), true);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: 0 }), true);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: 1 }), true);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: '0' }), true);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: '1' }), true);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: '2' }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', min_score: 0 }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', min_score: 1 }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', num_results: 1 }), true);
@@ -60,7 +65,9 @@ async function runTests() {
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', time_range: 'last week' }), false);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', language: 123 }), false);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: 3 }), false);
-    assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: '1' }), false);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: '3' }), false);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: 'none' }), false);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: 1.5 }), false);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', min_score: -0.1 }), false);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', min_score: 1.1 }), false);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', min_score: Number.NaN }), false);
@@ -74,6 +81,10 @@ async function runTests() {
   await testFunction('WEB_SEARCH_TOOL schema includes week, min_score, and num_results', () => {
     const properties = WEB_SEARCH_TOOL.inputSchema.properties as Record<string, any>;
     assert.ok(properties.time_range.enum.includes('week'));
+    assert.equal(properties.safesearch.type, 'string');
+    assert.deepEqual(properties.safesearch.enum, ['0', '1', '2']);
+    assert.equal(properties.safesearch.default, '0');
+    assert.ok(!properties.safesearch.enum.some((value: unknown) => typeof value === 'number'));
     assert.equal(properties.min_score.type, 'number');
     assert.equal(properties.min_score.minimum, 0);
     assert.equal(properties.min_score.maximum, 1);

--- a/src/index.ts
+++ b/src/index.ts
@@ -168,7 +168,7 @@ export function createMcpServer(): McpServer {
           args.pageno,
           args.time_range,
           args.language,
-          args.safesearch,
+          args.safesearch === undefined ? undefined : Number(args.safesearch),
           args.min_score,
           args.num_results,
           args.categories,

--- a/src/types.ts
+++ b/src/types.ts
@@ -32,7 +32,7 @@ export interface SearXNGWeb {
 }
 
 const VALID_TIME_RANGES = ["day", "week", "month", "year"] as const;
-const VALID_SAFESEARCH_VALUES = [0, 1, 2] as const;
+const VALID_SAFESEARCH_VALUES = [0, 1, 2, "0", "1", "2"] as const;
 const VALID_RESPONSE_FORMATS = ["text", "json"] as const;
 
 export function isSearXNGWebSearchArgs(args: unknown): args is {
@@ -40,7 +40,7 @@ export function isSearXNGWebSearchArgs(args: unknown): args is {
   pageno?: number;
   time_range?: string;
   language?: string;
-  safesearch?: number;
+  safesearch?: number | string;
   min_score?: number;
   num_results?: number;
   categories?: string;
@@ -82,7 +82,8 @@ export function isSearXNGWebSearchArgs(args: unknown): args is {
   }
   if (
     searchArgs.safesearch !== undefined &&
-    (typeof searchArgs.safesearch !== "number" || !VALID_SAFESEARCH_VALUES.includes(searchArgs.safesearch as any))
+    ((typeof searchArgs.safesearch !== "number" && typeof searchArgs.safesearch !== "string") ||
+      !VALID_SAFESEARCH_VALUES.includes(searchArgs.safesearch as any))
   ) {
     return false;
   }
@@ -211,11 +212,11 @@ export const WEB_SEARCH_TOOL: Tool = {
         default: "all",
       },
       safesearch: {
-        type: "number",
+        type: "string",
         description:
           "Safe search filter level (0: None, 1: Moderate, 2: Strict)",
-        enum: [0, 1, 2],
-        default: 0,
+        enum: ["0", "1", "2"],
+        default: "0",
       },
       min_score: {
         type: "number",

--- a/src/types.ts
+++ b/src/types.ts
@@ -216,7 +216,6 @@ export const WEB_SEARCH_TOOL: Tool = {
         description:
           "Safe search filter level (0: None, 1: Moderate, 2: Strict)",
         enum: ["0", "1", "2"],
-        default: "0",
       },
       min_score: {
         type: "number",


### PR DESCRIPTION
## TODO item

**BUG-006** — Declare `safesearch` as a string enum so Gemini/Antigravity clients stop getting HTTP 400 (🟠 High, from TODO-bugs.md)
Refs: https://github.com/ihor-sokoliuk/mcp-searxng/issues/89

## Context

The `searxng_web_search` tool declared `safesearch` as a numeric enum
(`{ type: "number", enum: [0, 1, 2], default: 0 }`). This is valid JSON Schema
and is accepted by OpenAI- and Anthropic-based MCP clients, but the Gemini
tool-calling API validates function declarations against its own
OpenAPI-3.0-subset `Schema`, which only permits `enum` on `STRING` type. When a
Gemini-backed client (Gemini CLI, and its successor Google Antigravity — IDE and
CLI) registers our tools, the API rejects the request with HTTP 400
`...properties[safesearch].enum: only allowed for STRING type`, making the
server unusable with that entire client family.

## What changed

- **`src/types.ts`** — `WEB_SEARCH_TOOL` now declares `safesearch` as
  `{ type: "string", enum: ["0", "1", "2"] }` (string enum, **no schema
  default** — see the post-review note below). The `isSearXNGWebSearchArgs` guard
  accepts both the new string form and the legacy numeric form
  (`VALID_SAFESEARCH_VALUES = [0,1,2,"0","1","2"]`, `safesearch?: number |
  string`), and still rejects out-of-range/invalid values.
- **`src/index.ts`** — coerces the incoming value with `Number(...)` before
  calling `performWebSearch`, so the numeric membership check and the emitted
  query string are unchanged. **The outbound SearXNG request is byte-for-byte
  identical (still `safesearch=0`).**
- **`__tests__/unit/types.test.ts`** — guard accepts `0,1,2,"0","1","2"`; rejects
  `3,"3","none",1.5`; schema assertions confirm `type:"string"`,
  `enum:["0","1","2"]`, that **no `default` is present**, and a regression guard
  that the enum contains no numeric value.
- **`__tests__/integration/mcp-handlers.test.ts`** — `tools/list` schema
  assertions (including that the emitted `safesearch` schema has no `default`),
  plus a `tools/call` test that passes `safesearch: "2"` and captures the
  upstream URL to prove `safesearch=2` is still forwarded.
- **`README.md`** — `safesearch` parameter documented as a string enum with a
  note that legacy numeric values remain accepted.

`CONFIGURATION.md` (`SEARXNG_DEFAULT_SAFESEARCH`) is intentionally unchanged — the
operator env var still takes numeric `0/1/2` and is parsed server-side.

## Post-review adjustment (commit 37d1b47)

Codacy and Copilot flagged that a schema-level `default: "0"` could cause some
MCP clients to auto-fill `"0"` and override the operator/instance default. Since
the server already falls back to the operator/instance default when `safesearch`
is omitted (`performWebSearch` → `getDefaultSafesearch` →
`SEARXNG_DEFAULT_SAFESEARCH`, else the SearXNG instance default), the schema
**intentionally carries no `default`**: an omitted `safesearch` reaches the
server as `undefined` and the instance/operator default applies, matching the
documented "default: instance setting" behaviour. `type: "string"` and
`enum: ["0","1","2"]` are unchanged. Codacy's separate suggestion to also patch
`LITE_WEB_SEARCH_TOOL` does not apply — that tool declares only `query` and has
no `safesearch` parameter (no enums at all), so it is already Gemini-safe.

## How it was verified

Verified independently by the tech lead (not only by the implementer):
- `npm run build` — pass
- `npm run test:coverage` — **362/362 pass**, 95.69% lines / 91.82% branches
  (gate ≥90/85)
- `npm run lint` — clean
- `npm run test:e2e` — **7/7 non-live suites pass.** The 4 live-search suites
  fail with `Network Error: fetch failed` because this environment cannot reach
  the live SearXNG instance (`SEARXNG_LIVE_URL`). Confirmed environmental, not a
  regression: the **identical** 4 failures occur on clean `main` with this diff
  stashed. This change leaves the SearXNG request unchanged, so live behavior is
  unaffected.

## Documentation

`README.md` Tools section now describes `safesearch` as `(string enum, optional)`
with values `"0"`/`"1"`/`"2"` and a backward-compatibility note for numeric
values. Default behaviour (omitted → instance/operator setting) is preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)