### PR TITLE
feat(search): multi-instance SEARXNG_URL failover and optional fanout (FEAT-047)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,7 +6,8 @@ All environment variables for `mcp-searxng`, organized by concern. All variables
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `SEARXNG_URL` | Yes | — | URL of your SearXNG instance. Format: `<protocol>://<hostname>[:<port>]` (e.g. `http://localhost:8080`) |
+| `SEARXNG_URL` | Yes | — | URL of your SearXNG instance, or a semicolon-separated list of interchangeable replica base URLs. Single URL behavior is unchanged. Format: `<protocol>://<hostname>[:<port>]` (e.g. `http://localhost:8080` or `https://one.example.com;https://two.example.com`) |
+| `SEARXNG_FANOUT` | No | `false` | Set to `true` to query all healthy configured SearXNG instances in parallel and merge results. Default failover mode tries instances in order until one returns results. |
 
 ## Authentication
 
@@ -43,6 +44,10 @@ Operator-level defaults applied when the caller omits the corresponding per-call
 |---|---|---|---|
 | `SEARXNG_MAX_RESULTS` | No | — | Operator-level maximum number of search results to return per call (1-20). Invalid values are ignored. Recommended: `10` for smaller context windows. |
 | `SEARXNG_MAX_RESULT_CHARS` | No | — | Maximum characters to include in each search result snippet. Longer snippets are truncated and marked with `…`. Invalid values are ignored. Recommended: `500` for smaller context windows. |
+
+When `SEARXNG_URL` contains multiple semicolon-separated URLs, they are treated as interchangeable replicas. Default mode fails over in order when an instance hard-fails or returns no results. A reachable `200 OK` response with an empty `results` array is considered healthy and does not trigger cooldown. Instances with 3 consecutive hard failures are skipped for 60 seconds.
+
+With `SEARXNG_FANOUT=true`, all healthy instances are queried in parallel. Results are deduplicated by canonical URL, the copy with the highest `score` is kept, and merged results are ordered by descending score. Capability discovery, search suggestions, and filter validation use the first configured instance only.
 
 ## Search Compatibility
 
@@ -146,6 +151,7 @@ Complete MCP client configuration with every variable. Mix and match as needed �
       "args": ["-y", "mcp-searxng"],
       "env": {
         "SEARXNG_URL": "YOUR_SEARXNG_INSTANCE_URL",
+        "SEARXNG_FANOUT": "false",
         "SEARXNG_TIMEOUT_MS": "10000",
         "FETCH_TIMEOUT_MS": "10000",
         "SEARXNG_LITE_TOOLS": "false",

--- a/README.md
+++ b/README.md
@@ -38,11 +38,12 @@ Add to your MCP client configuration (e.g. `claude_desktop_config.json`):
 }
 ```
 
-Replace `YOUR_SEARXNG_INSTANCE_URL` with the URL of your SearXNG instance (e.g. `https://searxng.example.com`).
+Replace `YOUR_SEARXNG_INSTANCE_URL` with the URL of your SearXNG instance (e.g. `https://searxng.example.com`). You can also provide interchangeable replicas as a semicolon-separated list, e.g. `https://one.example.com;https://two.example.com`.
 
 ## Features
 
 - **Web Search**: General queries, news, articles, with pagination.
+- **Instance Failover**: Configure multiple interchangeable SearXNG replicas in `SEARXNG_URL`; searches fail over by default and can optionally fan out in parallel.
 - **Structured Search Output**: Choose formatted text or raw SearXNG-shaped JSON with `response_format`.
 - **Direct Answers & Metadata**: Text results surface SearXNG answers, corrections, suggestions, and infoboxes before result lists.
 - **Search Suggestions**: Query autocomplete via SearXNG's `/autocompleter` endpoint.
@@ -68,9 +69,9 @@ Replace `YOUR_SEARXNG_INSTANCE_URL` with the URL of your SearXNG instance (e.g. 
 
 ## How It Works
 
-`mcp-searxng` is a standalone MCP server — a separate Node.js process that your AI assistant connects to for web search. It queries any SearXNG instance via its HTTP JSON API.
+`mcp-searxng` is a standalone MCP server — a separate Node.js process that your AI assistant connects to for web search. It queries one SearXNG instance, or a semicolon-separated list of interchangeable SearXNG replicas, via the HTTP JSON API.
 
-> **Not a SearXNG plugin:** This project cannot be installed as a native SearXNG plugin. Point it at any existing SearXNG instance by setting `SEARXNG_URL`.
+> **Not a SearXNG plugin:** This project cannot be installed as a native SearXNG plugin. Point it at any existing SearXNG instance, or interchangeable replica list, by setting `SEARXNG_URL`.
 
 ```
 AI Assistant (e.g. Claude)
@@ -79,7 +80,7 @@ AI Assistant (e.g. Claude)
   mcp-searxng  (this project — Node.js process)
         │  HTTP JSON API  (SEARXNG_URL)
         ▼
-  SearXNG instance
+  SearXNG instance(s)
 ```
 
 ## Tools
@@ -249,7 +250,7 @@ curl http://localhost:3000/health
 
 ## Configuration
 
-Set `SEARXNG_URL` to your SearXNG instance URL. All other variables are optional.
+Set `SEARXNG_URL` to your SearXNG instance URL. For failover, set it to semicolon-separated interchangeable replica URLs. Set `SEARXNG_FANOUT=true` to query all healthy replicas in parallel and merge results. All other variables are optional.
 
 Full environment variable reference: [CONFIGURATION.md](CONFIGURATION.md)
 

--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -14,6 +14,7 @@ import { runTests as runTypesTests } from './unit/types.test.js';
 import { runTests as runCacheTests } from './unit/cache.test.js';
 import { runTests as runProxyTests } from './unit/proxy.test.js';
 import { runTests as runErrorHandlerTests } from './unit/error-handler.test.js';
+import { runTests as runSearxngInstancesTests } from './unit/searxng-instances.test.js';
 import { runTests as runResourcesTests } from './unit/resources.test.js';
 import { runTests as runSearchTests } from './unit/search.test.js';
 import { runTests as runSuggestionsTests } from './unit/suggestions.test.js';
@@ -42,6 +43,7 @@ const testSuites: TestSuite[] = [
   { name: 'Cache', category: 'unit', run: runCacheTests },
   { name: 'Proxy', category: 'unit', run: runProxyTests },
   { name: 'Error Handler', category: 'unit', run: runErrorHandlerTests },
+  { name: 'SearXNG Instances', category: 'unit', run: runSearxngInstancesTests },
   { name: 'Resources', category: 'unit', run: runResourcesTests },
   { name: 'Search', category: 'unit', run: runSearchTests },
   { name: 'Suggestions', category: 'unit', run: runSuggestionsTests },

--- a/__tests__/unit/error-handler.test.ts
+++ b/__tests__/unit/error-handler.test.ts
@@ -133,6 +133,15 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('validateEnvironment accepts valid multi-URL SEARXNG_URL list', () => {
+    envManager.set('SEARXNG_URL', 'https://one.example.com; http://two.example.com:8080 ');
+
+    const result = validateEnvironment();
+    assert.equal(result, null);
+
+    envManager.restore();
+  }, results);
+
   await testFunction('validateEnvironment - missing SEARXNG_URL', () => {
     envManager.delete('SEARXNG_URL');
     
@@ -150,6 +159,17 @@ async function runTests() {
     assert.ok(typeof result === 'string');
     assert.ok(result!.includes('invalid format') || result!.includes('invalid protocol') || result!.includes('Configuration Issues'));
     
+    envManager.restore();
+  }, results);
+
+  await testFunction('validateEnvironment - invalid entry in multi-URL list reports offending entry', () => {
+    envManager.set('SEARXNG_URL', 'https://valid.example.com;not-a-valid-url');
+
+    const result = validateEnvironment();
+    assert.ok(typeof result === 'string');
+    assert.ok(result!.includes('Configuration Issues'));
+    assert.ok(result!.includes('not-a-valid-url'));
+
     envManager.restore();
   }, results);
 
@@ -190,6 +210,17 @@ async function runTests() {
       assert.ok(typeof result === 'string');
     }
     
+    envManager.restore();
+  }, results);
+
+  await testFunction('validateEnvironment - empty-only multi-URL list is treated as not set', () => {
+    for (const emptyList of ['', ';', ' ; ']) {
+      envManager.set('SEARXNG_URL', emptyList);
+      const result = validateEnvironment();
+      assert.ok(typeof result === 'string');
+      assert.ok(result!.includes('SEARXNG_URL not set'));
+    }
+
     envManager.restore();
   }, results);
 

--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -246,6 +246,27 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('multi-URL SEARXNG_URL fetches /config from primary and reports source URL', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://primary.example.com/base;https://secondary.example.com');
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedUrl } = createCapturingMockFetch();
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: makeConfig() })(url, options);
+    });
+
+    const result = JSON.parse(await fetchInstanceInfo(mockServer as any));
+
+    const url = new URL(getCapturedUrl());
+    assert.equal(url.origin, 'https://primary.example.com');
+    assert.ok(url.pathname.includes('/base/config'), `Expected primary /base/config, got ${url.pathname}`);
+    assert.equal(result.sourceUrl, 'https://primary.example.com/base');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('config request uses search proxy dispatcher when configured', async () => {
     clearInstanceInfoCacheForTests();
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -2008,9 +2008,13 @@ async function runTests() {
       await performWebSearch(mockServer as any, 'all cooled');
       assert.fail('Expected all-cooled error');
     } catch (error: any) {
-      assert.ok(error.message.includes('All configured SearXNG instances are in cooldown after repeated failures'), error.message);
-      assert.ok(error.message.includes('https://cooled-one.example.com'), error.message);
-      assert.ok(error.message.includes('https://cooled-two.example.com'), error.message);
+      // Exact-match (not URL substring .includes()) so the assertion also covers
+      // ordering and the absence of double spaces, and avoids CodeQL's
+      // incomplete-url-substring-sanitization false positive on test code.
+      assert.equal(
+        error.message,
+        'All configured SearXNG instances are in cooldown after repeated failures: https://cooled-one.example.com, https://cooled-two.example.com.',
+      );
       assert.ok(!error.message.includes('  '), error.message);
     }
     assert.equal(fetchCalled, false);

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -11,6 +11,10 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { performWebSearch } from '../../src/search.js';
 import { clearInstanceInfoCacheForTests } from '../../src/instance-info.js';
+import {
+  clearSearxngInstanceStateForTests,
+  recordSearxngInstanceFailure,
+} from '../../src/searxng-instances.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 import { createMockServer } from '../helpers/mock-server.js';
 import { FetchMocker, createMockFetch, createCapturingMockFetch, createAbortableMockFetch } from '../helpers/mock-fetch.js';
@@ -1747,6 +1751,264 @@ async function runTests() {
     assert.deepEqual(payload.results, []);
     assert.deepEqual(payload.suggestions, ['broader query']);
     assert.ok(!result.includes('No results found'), result);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('single-instance JSON response has no servedBy provenance', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('SEARXNG_FANOUT');
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(createMockFetch({
+      json: {
+        query: 'single query',
+        results: [
+          { title: 'Single Result', content: 'Only instance', url: 'https://example.com/single', score: 1 },
+        ],
+      },
+    }));
+
+    const result = await performWebSearch(mockServer as any, 'single query', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const payload = JSON.parse(result);
+    assert.equal(payload.servedBy, undefined);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('multi-instance failover tries second after first hard failure and reports servedBy', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://first.example.com;https://second.example.com');
+    envManager.delete('SEARXNG_FANOUT');
+
+    const mockServer = createMockServer();
+    const requestedHosts: string[] = [];
+    fetchMocker.mock(async (url) => {
+      const parsedUrl = new URL(url.toString());
+      requestedHosts.push(parsedUrl.origin);
+      if (parsedUrl.hostname === 'first.example.com') {
+        throw new Error('first down');
+      }
+      return createMockFetch({
+        json: {
+          query: 'failover query',
+          results: [
+            { title: 'Second Result', content: 'Recovered', url: 'https://example.com/recovered', score: 0.9 },
+          ],
+        },
+      })(url);
+    });
+
+    const result = await performWebSearch(mockServer as any, 'failover query', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const payload = JSON.parse(result);
+
+    assert.deepEqual(requestedHosts, ['https://first.example.com', 'https://second.example.com']);
+    assert.deepEqual(payload.servedBy, ['https://second.example.com']);
+    assert.equal(payload.results[0].title, 'Second Result');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('empty multi-instance response is healthy and fails over without cooldown', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://empty.example.com;https://second.example.com');
+
+    const mockServer = createMockServer();
+    const requestedHosts: string[] = [];
+    fetchMocker.mock(async (url) => {
+      const parsedUrl = new URL(url.toString());
+      requestedHosts.push(parsedUrl.origin);
+      if (parsedUrl.hostname === 'empty.example.com') {
+        return createMockFetch({ json: { query: 'empty first', results: [] } })(url);
+      }
+      return createMockFetch({
+        json: {
+          query: 'empty first',
+          results: [
+            { title: 'Second Result', content: 'Has result', url: 'https://example.com/second', score: 0.8 },
+          ],
+        },
+      })(url);
+    });
+
+    const firstResult = await performWebSearch(mockServer as any, 'empty first', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const secondResult = await performWebSearch(mockServer as any, 'empty first again', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+
+    assert.deepEqual(requestedHosts, [
+      'https://empty.example.com',
+      'https://second.example.com',
+      'https://empty.example.com',
+      'https://second.example.com',
+    ]);
+    assert.deepEqual(JSON.parse(firstResult).servedBy, ['https://second.example.com']);
+    assert.deepEqual(JSON.parse(secondResult).servedBy, ['https://second.example.com']);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('all multi-instance responses empty returns existing JSON empty response with provenance', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://empty-one.example.com;https://empty-two.example.com');
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(createMockFetch({ json: { query: 'empty query', number_of_results: 0, results: [] } }));
+
+    const result = await performWebSearch(mockServer as any, 'empty query', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const payload = JSON.parse(result);
+
+    assert.deepEqual(payload.results, []);
+    assert.deepEqual(payload.servedBy, ['https://empty-one.example.com', 'https://empty-two.example.com']);
+    assert.ok(!result.includes('No results found'));
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('all multi-instance responses empty returns existing text no-results message with provenance', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://empty-one.example.com;https://empty-two.example.com');
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(createMockFetch({ json: { query: 'empty text', results: [] } }));
+
+    const result = await performWebSearch(mockServer as any, 'empty text');
+
+    assert.ok(result.includes('Served by SearXNG instances: https://empty-one.example.com, https://empty-two.example.com'), result);
+    assert.ok(result.includes('No results found for "empty text"'), result);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('all multi-instance hard failures throw aggregate error with underlying reason', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://first.example.com;https://second.example.com');
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(async (url) => {
+      const parsedUrl = new URL(url.toString());
+      throw new Error(`${parsedUrl.hostname} failed`);
+    });
+
+    try {
+      await performWebSearch(mockServer as any, 'all fail');
+      assert.fail('Expected aggregate multi-instance failure');
+    } catch (error: any) {
+      assert.ok(error.message.includes('All configured SearXNG instances failed'), error.message);
+      assert.ok(error.message.includes('first.example.com failed'), error.message);
+      assert.ok(error.message.includes('second.example.com failed'), error.message);
+    }
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('cooled down instance is skipped during failover', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://cooled.example.com;https://healthy.example.com');
+
+    recordSearxngInstanceFailure('https://cooled.example.com', Date.now());
+    recordSearxngInstanceFailure('https://cooled.example.com', Date.now());
+    recordSearxngInstanceFailure('https://cooled.example.com', Date.now());
+
+    const mockServer = createMockServer();
+    const requestedHosts: string[] = [];
+    fetchMocker.mock(async (url) => {
+      const parsedUrl = new URL(url.toString());
+      requestedHosts.push(parsedUrl.origin);
+      return createMockFetch({
+        json: {
+          query: 'skip cooled',
+          results: [
+            { title: 'Healthy Result', content: 'Healthy', url: 'https://example.com/healthy', score: 1 },
+          ],
+        },
+      })(url);
+    });
+
+    const result = await performWebSearch(mockServer as any, 'skip cooled');
+
+    assert.deepEqual(requestedHosts, ['https://healthy.example.com']);
+    assert.ok(result.includes('Healthy Result'));
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('fanout dedupes canonical URLs, keeps highest score, and orders descending', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://one.example.com;https://two.example.com');
+    envManager.set('SEARXNG_FANOUT', 'true');
+
+    const mockServer = createMockServer();
+    const requestedHosts: string[] = [];
+    fetchMocker.mock(async (url) => {
+      const parsedUrl = new URL(url.toString());
+      requestedHosts.push(parsedUrl.origin);
+      if (parsedUrl.hostname === 'one.example.com') {
+        return createMockFetch({
+          json: {
+            query: 'fanout',
+            results: [
+              { title: 'Lower Duplicate', content: 'Low', url: 'https://Example.com/same#section', score: 0.2 },
+              { title: 'Missing Score', content: 'No score', url: 'not a url', score: undefined },
+            ],
+          },
+        })(url);
+      }
+      return createMockFetch({
+        json: {
+          query: 'fanout',
+          results: [
+            { title: 'Highest', content: 'High', url: 'https://example.com/high', score: 0.95 },
+            { title: 'Higher Duplicate', content: 'Better', url: 'https://example.com/same', score: 0.7 },
+            { title: 'Raw URL Copy', content: 'Raw tie', url: 'not a url', score: 0.5 },
+          ],
+        },
+      })(url);
+    });
+
+    const result = await performWebSearch(mockServer as any, 'fanout', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const payload = JSON.parse(result);
+
+    assert.deepEqual(requestedHosts.sort(), ['https://one.example.com', 'https://two.example.com']);
+    assert.deepEqual(payload.servedBy, ['https://one.example.com', 'https://two.example.com']);
+    assert.deepEqual(payload.results.map((entry: any) => entry.title), ['Highest', 'Higher Duplicate', 'Raw URL Copy']);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('fanout returns partial successes and excludes failed instances from servedBy', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://down.example.com;https://up.example.com');
+    envManager.set('SEARXNG_FANOUT', 'true');
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(async (url) => {
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.hostname === 'down.example.com') {
+        throw new Error('fanout down');
+      }
+      return createMockFetch({
+        json: {
+          query: 'partial fanout',
+          results: [
+            { title: 'Up Result', content: 'Up', url: 'https://example.com/up', score: 0.6 },
+          ],
+        },
+      })(url);
+    });
+
+    const result = await performWebSearch(mockServer as any, 'partial fanout', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const payload = JSON.parse(result);
+
+    assert.deepEqual(payload.servedBy, ['https://up.example.com']);
+    assert.equal(payload.results[0].title, 'Up Result');
 
     fetchMocker.restore();
     envManager.restore();

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -1953,6 +1953,7 @@ async function runTests() {
         return createMockFetch({
           json: {
             query: 'fanout',
+            number_of_results: 2,
             results: [
               { title: 'Lower Duplicate', content: 'Low', url: 'https://Example.com/same#section', score: 0.2 },
               { title: 'Missing Score', content: 'No score', url: 'not a url', score: undefined },
@@ -1963,6 +1964,7 @@ async function runTests() {
       return createMockFetch({
         json: {
           query: 'fanout',
+          number_of_results: 3,
           results: [
             { title: 'Highest', content: 'High', url: 'https://example.com/high', score: 0.95 },
             { title: 'Higher Duplicate', content: 'Better', url: 'https://example.com/same', score: 0.7 },
@@ -1978,6 +1980,40 @@ async function runTests() {
     assert.deepEqual(requestedHosts.sort(), ['https://one.example.com', 'https://two.example.com']);
     assert.deepEqual(payload.servedBy, ['https://one.example.com', 'https://two.example.com']);
     assert.deepEqual(payload.results.map((entry: any) => entry.title), ['Highest', 'Higher Duplicate', 'Raw URL Copy']);
+    assert.equal(payload.number_of_results, payload.results.length);
+    assert.equal(payload.number_of_results, 3);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('all cooled down instances throw cooldown-specific message without double spaces', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://cooled-one.example.com;https://cooled-two.example.com');
+
+    for (const instanceUrl of ['https://cooled-one.example.com', 'https://cooled-two.example.com']) {
+      recordSearxngInstanceFailure(instanceUrl, Date.now());
+      recordSearxngInstanceFailure(instanceUrl, Date.now());
+      recordSearxngInstanceFailure(instanceUrl, Date.now());
+    }
+
+    const mockServer = createMockServer();
+    let fetchCalled = false;
+    fetchMocker.mock(async () => {
+      fetchCalled = true;
+      return createMockFetch({ json: { results: [] } })('https://unused.example.com');
+    });
+
+    try {
+      await performWebSearch(mockServer as any, 'all cooled');
+      assert.fail('Expected all-cooled error');
+    } catch (error: any) {
+      assert.ok(error.message.includes('All configured SearXNG instances are in cooldown after repeated failures'), error.message);
+      assert.ok(error.message.includes('https://cooled-one.example.com'), error.message);
+      assert.ok(error.message.includes('https://cooled-two.example.com'), error.message);
+      assert.ok(!error.message.includes('  '), error.message);
+    }
+    assert.equal(fetchCalled, false);
 
     fetchMocker.restore();
     envManager.restore();

--- a/__tests__/unit/searxng-instances.test.ts
+++ b/__tests__/unit/searxng-instances.test.ts
@@ -92,6 +92,41 @@ async function runTests() {
     assert.deepEqual(getHealthySearxngInstances(instances, now + 60003), instances);
   }, results);
 
+  await testFunction('expired cooldown resets failure counter before re-cooling', () => {
+    clearSearxngInstanceStateForTests();
+    const instances = ['https://a.example.com'];
+    const now = 1000;
+
+    recordSearxngInstanceFailure('https://a.example.com', now);
+    recordSearxngInstanceFailure('https://a.example.com', now + 1);
+    recordSearxngInstanceFailure('https://a.example.com', now + 2);
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 3), []);
+
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 60001), []);
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 60002), instances);
+
+    recordSearxngInstanceFailure('https://a.example.com', now + 60004);
+    recordSearxngInstanceFailure('https://a.example.com', now + 60005);
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 60006), instances);
+
+    recordSearxngInstanceFailure('https://a.example.com', now + 60007);
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 60008), []);
+  }, results);
+
+  await testFunction('observing cooldown expiry clears stale health entry', () => {
+    clearSearxngInstanceStateForTests();
+    const instances = ['https://a.example.com'];
+    const now = 1000;
+
+    recordSearxngInstanceFailure('https://a.example.com', now);
+    recordSearxngInstanceFailure('https://a.example.com', now + 1);
+    recordSearxngInstanceFailure('https://a.example.com', now + 2);
+
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 60003), instances);
+    recordSearxngInstanceFailure('https://a.example.com', now + 60004);
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 60005), instances);
+  }, results);
+
   await testFunction('successful response resets consecutive failures before cooldown', () => {
     clearSearxngInstanceStateForTests();
     const instances = ['https://a.example.com'];

--- a/__tests__/unit/searxng-instances.test.ts
+++ b/__tests__/unit/searxng-instances.test.ts
@@ -1,0 +1,117 @@
+#!/usr/bin/env tsx
+
+/**
+ * Unit Tests: searxng-instances.ts
+ *
+ * Tests for SearXNG instance list parsing, validation, fanout, and cooldown state.
+ */
+
+import { strict as assert } from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import {
+  clearSearxngInstanceStateForTests,
+  getHealthySearxngInstances,
+  getPrimarySearxngInstance,
+  getSearxngInstances,
+  isSearxngFanoutEnabled,
+  parseSearxngUrls,
+  recordSearxngInstanceFailure,
+  recordSearxngInstanceSuccess,
+  validateSearxngInstanceUrl,
+} from '../../src/searxng-instances.js';
+import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
+import { EnvManager } from '../helpers/env-utils.js';
+
+const results = createTestResults();
+const envManager = new EnvManager();
+
+async function runTests() {
+  console.log('🧪 Testing: searxng-instances.ts\n');
+
+  await testFunction('parseSearxngUrls preserves a single URL unchanged', () => {
+    assert.deepEqual(parseSearxngUrls('https://search.example.com'), ['https://search.example.com']);
+  }, results);
+
+  await testFunction('parseSearxngUrls splits semicolon list, trims, and drops empty segments', () => {
+    assert.deepEqual(
+      parseSearxngUrls(' https://a.example.com ; ; https://b.example.com/ ;  '),
+      ['https://a.example.com', 'https://b.example.com/'],
+    );
+  }, results);
+
+  await testFunction('parseSearxngUrls returns empty list for empty-only values', () => {
+    assert.deepEqual(parseSearxngUrls(''), []);
+    assert.deepEqual(parseSearxngUrls(';'), []);
+    assert.deepEqual(parseSearxngUrls(' ; '), []);
+  }, results);
+
+  await testFunction('getSearxngInstances and getPrimarySearxngInstance read current environment', () => {
+    envManager.set('SEARXNG_URL', 'https://first.example.com;https://second.example.com');
+
+    assert.deepEqual(getSearxngInstances(), ['https://first.example.com', 'https://second.example.com']);
+    assert.equal(getPrimarySearxngInstance(), 'https://first.example.com');
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('validateSearxngInstanceUrl accepts http and https URLs', () => {
+    assert.equal(validateSearxngInstanceUrl('http://localhost:8080'), null);
+    assert.equal(validateSearxngInstanceUrl('https://search.example.com'), null);
+  }, results);
+
+  await testFunction('validateSearxngInstanceUrl rejects invalid and non-http URLs', () => {
+    assert.ok(validateSearxngInstanceUrl('not-a-url')?.includes('not-a-url'));
+    assert.ok(validateSearxngInstanceUrl('ftp://search.example.com')?.includes('ftp:'));
+  }, results);
+
+  await testFunction('isSearxngFanoutEnabled is true only for literal true', () => {
+    envManager.set('SEARXNG_FANOUT', 'true');
+    assert.equal(isSearxngFanoutEnabled(), true);
+
+    envManager.set('SEARXNG_FANOUT', 'TRUE');
+    assert.equal(isSearxngFanoutEnabled(), false);
+
+    envManager.delete('SEARXNG_FANOUT');
+    assert.equal(isSearxngFanoutEnabled(), false);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('third consecutive hard failure cools instance for 60 seconds', () => {
+    clearSearxngInstanceStateForTests();
+    const instances = ['https://a.example.com', 'https://b.example.com'];
+    const now = 1000;
+
+    recordSearxngInstanceFailure('https://a.example.com', now);
+    recordSearxngInstanceFailure('https://a.example.com', now + 1);
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 2), instances);
+
+    recordSearxngInstanceFailure('https://a.example.com', now + 3);
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 4), ['https://b.example.com']);
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 60002), ['https://b.example.com']);
+    assert.deepEqual(getHealthySearxngInstances(instances, now + 60003), instances);
+  }, results);
+
+  await testFunction('successful response resets consecutive failures before cooldown', () => {
+    clearSearxngInstanceStateForTests();
+    const instances = ['https://a.example.com'];
+
+    recordSearxngInstanceFailure('https://a.example.com', 1000);
+    recordSearxngInstanceFailure('https://a.example.com', 1001);
+    recordSearxngInstanceSuccess('https://a.example.com');
+    recordSearxngInstanceFailure('https://a.example.com', 1002);
+
+    assert.deepEqual(getHealthySearxngInstances(instances, 1003), instances);
+  }, results);
+
+  printTestSummary(results, 'SearXNG Instances Module');
+  return results;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runTests().then(results => {
+    process.exit(results.failed > 0 ? 1 : 0);
+  }).catch(console.error);
+}
+
+export { runTests };

--- a/__tests__/unit/suggestions.test.ts
+++ b/__tests__/unit/suggestions.test.ts
@@ -112,6 +112,26 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('multi-URL SEARXNG_URL uses primary instance only for autocomplete', async () => {
+    envManager.set('SEARXNG_URL', 'https://primary.example.com/base;https://secondary.example.com');
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedUrl } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: ['type', ['typescript']] })(url, options);
+    });
+
+    await performSearchSuggestions(mockServer as any, 'type');
+
+    const url = new URL(getCapturedUrl());
+    assert.equal(url.origin, 'https://primary.example.com');
+    assert.ok(url.pathname.includes('/base/autocompleter'), `Expected primary /base/autocompleter, got ${url.pathname}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('language=all omits lang parameter', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
     const mockServer = createMockServer();

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -3,6 +3,8 @@
  * Provides clear, focused error messages that identify the root cause
  */
 
+import { parseSearxngUrls, validateSearxngInstanceUrl } from "./searxng-instances.js";
+
 export interface ErrorContext {
   url?: string;
   searxngUrl?: string;
@@ -174,17 +176,15 @@ export function handleUnhandledRejection(reason: unknown, promise: Promise<unkno
 export function validateEnvironment(): string | null {
   const issues: string[] = [];
   
-  const searxngUrl = process.env.SEARXNG_URL;
-  if (!searxngUrl) {
+  const searxngUrls = parseSearxngUrls();
+  if (searxngUrls.length === 0) {
     issues.push("SEARXNG_URL not set");
   } else {
-    try {
-      const url = new URL(searxngUrl);
-      if (!['http:', 'https:'].includes(url.protocol)) {
-        issues.push(`SEARXNG_URL invalid protocol: ${url.protocol}`);
+    for (const searxngUrl of searxngUrls) {
+      const validationError = validateSearxngInstanceUrl(searxngUrl);
+      if (validationError) {
+        issues.push(validationError);
       }
-    } catch (error) {
-      issues.push(`SEARXNG_URL invalid format: ${searxngUrl}`);
     }
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -30,6 +30,7 @@ import { fetchInstanceInfo } from "./instance-info.js";
 import { fetchAndConvertToMarkdown } from "./url-reader.js";
 import { createConfigResource, createHelpResource } from "./resources.js";
 import { createHttpServer, resolveBindHost } from "./http-server.js";
+import { getSearxngInstances } from "./searxng-instances.js";
 
 import { packageVersion } from "./version.js";
 
@@ -372,8 +373,9 @@ export async function main() {
     // Show helpful message when running in terminal
     if (process.stdin.isTTY) {
       console.error(`🔍 MCP SearXNG Server v${packageVersion} - Ready`);
-      if (process.env.SEARXNG_URL) {
-        console.error(`🌐 SearXNG URL: ${process.env.SEARXNG_URL}`);
+      const searxngInstances = getSearxngInstances();
+      if (searxngInstances.length > 0) {
+        console.error(`🌐 SearXNG URLs: ${searxngInstances.join("; ")}`);
       } else {
         console.error("⚠️  SEARXNG_URL not set — configure it before using search tools");
       }
@@ -387,6 +389,7 @@ export async function main() {
     logMessage(mcpServer, "info", `MCP SearXNG Server v${packageVersion} connected via STDIO`);
     logMessage(mcpServer, "info", `Log level: ${getCurrentLogLevel()}`);
     logMessage(mcpServer, "info", `Environment: ${process.env.NODE_ENV || 'development'}`);
-    logMessage(mcpServer, "info", `SearXNG URL: ${process.env.SEARXNG_URL || 'not configured'}`);
+    const searxngInstances = getSearxngInstances();
+    logMessage(mcpServer, "info", `SearXNG URLs: ${searxngInstances.length > 0 ? searxngInstances.join("; ") : 'not configured'}`);
   }
 }

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -1,18 +1,20 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logMessage } from "./logging.js";
 import { createDefaultAgent, createProxyAgent, ProxyType } from "./proxy.js";
+import { getPrimarySearxngInstance } from "./searxng-instances.js";
 
 type SearXNGConfig = Record<string, any>;
 type ConfigResult =
-  | { available: true; config: SearXNGConfig }
-  | { available: false; message: string; status?: number };
+  | { available: true; config: SearXNGConfig; sourceUrl: string }
+  | { available: false; message: string; status?: number; sourceUrl?: string };
 
 let cachedConfig: SearXNGConfig | null = null;
 let cachedBaseUrl: string | null = null;
 
-function unavailable(message: string, status?: number): string {
+function unavailable(message: string, status?: number, sourceUrl?: string): string {
   return JSON.stringify({
     available: false,
+    ...(sourceUrl !== undefined ? { sourceUrl } : {}),
     message,
     ...(status !== undefined ? { status } : {}),
   }, null, 2);
@@ -113,6 +115,7 @@ function allEngineNames(config: SearXNGConfig): Set<string> {
 
 function formatInstanceInfo(
   config: SearXNGConfig,
+  sourceUrl: string,
   includeEngines: boolean,
   includeDisabled: boolean,
   category?: string,
@@ -123,6 +126,7 @@ function formatInstanceInfo(
 
   const payload: Record<string, unknown> = {
     available: true,
+    sourceUrl,
     categories,
     defaults: {
       safesearch: config.search?.safe_search ?? config.default_safe_search,
@@ -147,7 +151,7 @@ export function clearInstanceInfoCacheForTests(): void {
 }
 
 async function fetchConfig(mcpServer: McpServer, refresh = false): Promise<ConfigResult> {
-  const base = process.env.SEARXNG_URL;
+  const base = getPrimarySearxngInstance();
   if (!base) {
     return {
       available: false,
@@ -160,7 +164,7 @@ async function fetchConfig(mcpServer: McpServer, refresh = false): Promise<Confi
   }
 
   if (cachedConfig && cachedBaseUrl === base) {
-    return { available: true, config: cachedConfig };
+    return { available: true, config: cachedConfig, sourceUrl: base };
   }
 
   const parsedBase = new URL(base.endsWith("/") ? base : `${base}/`);
@@ -182,17 +186,19 @@ async function fetchConfig(mcpServer: McpServer, refresh = false): Promise<Confi
         available: false,
         message: `SearXNG /config is unavailable: HTTP ${response.status} ${response.statusText}`,
         status: response.status,
+        sourceUrl: base,
       };
     }
 
     cachedConfig = await response.json() as SearXNGConfig;
     cachedBaseUrl = base;
-    return { available: true, config: cachedConfig };
+    return { available: true, config: cachedConfig, sourceUrl: base };
   } catch (error) {
     logMessage(mcpServer, "warning", `SearXNG /config fetch failed: ${error instanceof Error ? error.message : String(error)}`);
     return {
       available: false,
       message: "SearXNG /config is unavailable; instance capability discovery could not complete.",
+      sourceUrl: base,
     };
   }
 }
@@ -224,8 +230,8 @@ export async function fetchInstanceInfo(
 ): Promise<string> {
   const result = await fetchConfig(mcpServer, refresh);
   if (!result.available) {
-    return unavailable(result.message, result.status);
+    return unavailable(result.message, result.status, result.sourceUrl);
   }
 
-  return formatInstanceInfo(result.config, includeEngines, includeDisabled, category);
+  return formatInstanceInfo(result.config, result.sourceUrl, includeEngines, includeDisabled, category);
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -438,29 +438,43 @@ function getDefaultSafesearch(mcpServer: McpServer): number | undefined {
   return parsed;
 }
 
+function normalizeTimeRangeParam(value: string | undefined): string | undefined {
+  return value !== undefined && ["day", "week", "month", "year"].includes(value)
+    ? value
+    : undefined;
+}
+
+function normalizeLanguageParam(value: string | undefined): string | undefined {
+  return value && value !== "all" ? value : undefined;
+}
+
+function normalizeSafesearchParam(value: number | undefined): string | undefined {
+  return value !== undefined && [0, 1, 2].includes(value) ? value.toString() : undefined;
+}
+
+function normalizeTruthyParam(value: string | undefined): string | undefined {
+  return value || undefined;
+}
+
 function buildSearchUrl(instanceUrl: string, request: SearchRequest): URL {
   const parsedUrl = new URL(instanceUrl.endsWith('/') ? instanceUrl : instanceUrl + '/');
   const url = new URL('search', parsedUrl);
-  const setOptionalParam = (name: string, value: string | undefined): void => {
+  const params: Array<[string, string | undefined]> = [
+    ["q", request.query],
+    ["format", "json"],
+    ["pageno", request.pageno.toString()],
+    ["time_range", normalizeTimeRangeParam(request.time_range)],
+    ["language", normalizeLanguageParam(request.effectiveLanguage)],
+    ["safesearch", normalizeSafesearchParam(request.effectiveSafesearch)],
+    ["categories", normalizeTruthyParam(request.filters.categories)],
+    ["engines", normalizeTruthyParam(request.filters.engines)],
+  ];
+
+  for (const [name, value] of params) {
     if (value !== undefined) {
       url.searchParams.set(name, value);
     }
-  };
-
-  url.searchParams.set("q", request.query);
-  url.searchParams.set("format", "json");
-  url.searchParams.set("pageno", request.pageno.toString());
-  setOptionalParam("time_range", request.time_range !== undefined && ["day", "week", "month", "year"].includes(request.time_range)
-    ? request.time_range
-    : undefined);
-  setOptionalParam("language", request.effectiveLanguage && request.effectiveLanguage !== "all"
-    ? request.effectiveLanguage
-    : undefined);
-  setOptionalParam("safesearch", request.effectiveSafesearch !== undefined && [0, 1, 2].includes(request.effectiveSafesearch)
-    ? request.effectiveSafesearch.toString()
-    : undefined);
-  setOptionalParam("categories", request.filters.categories || undefined);
-  setOptionalParam("engines", request.filters.engines || undefined);
+  }
 
   return url;
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -441,33 +441,26 @@ function getDefaultSafesearch(mcpServer: McpServer): number | undefined {
 function buildSearchUrl(instanceUrl: string, request: SearchRequest): URL {
   const parsedUrl = new URL(instanceUrl.endsWith('/') ? instanceUrl : instanceUrl + '/');
   const url = new URL('search', parsedUrl);
+  const setOptionalParam = (name: string, value: string | undefined): void => {
+    if (value !== undefined) {
+      url.searchParams.set(name, value);
+    }
+  };
 
   url.searchParams.set("q", request.query);
   url.searchParams.set("format", "json");
   url.searchParams.set("pageno", request.pageno.toString());
-
-  if (
-    request.time_range !== undefined &&
-    ["day", "week", "month", "year"].includes(request.time_range)
-  ) {
-    url.searchParams.set("time_range", request.time_range);
-  }
-
-  if (request.effectiveLanguage && request.effectiveLanguage !== "all") {
-    url.searchParams.set("language", request.effectiveLanguage);
-  }
-
-  if (request.effectiveSafesearch !== undefined && [0, 1, 2].includes(request.effectiveSafesearch)) {
-    url.searchParams.set("safesearch", request.effectiveSafesearch.toString());
-  }
-
-  if (request.filters.categories) {
-    url.searchParams.set("categories", request.filters.categories);
-  }
-
-  if (request.filters.engines) {
-    url.searchParams.set("engines", request.filters.engines);
-  }
+  setOptionalParam("time_range", request.time_range !== undefined && ["day", "week", "month", "year"].includes(request.time_range)
+    ? request.time_range
+    : undefined);
+  setOptionalParam("language", request.effectiveLanguage && request.effectiveLanguage !== "all"
+    ? request.effectiveLanguage
+    : undefined);
+  setOptionalParam("safesearch", request.effectiveSafesearch !== undefined && [0, 1, 2].includes(request.effectiveSafesearch)
+    ? request.effectiveSafesearch.toString()
+    : undefined);
+  setOptionalParam("categories", request.filters.categories || undefined);
+  setOptionalParam("engines", request.filters.engines || undefined);
 
   return url;
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -576,6 +576,12 @@ function hasSearchResults(data: SearXNGWeb): boolean {
 }
 
 function createAllInstancesFailedError(failures: FailedInstanceResult[], skippedInstances: string[]): MCPSearXNGError {
+  if (failures.length === 0 && skippedInstances.length > 0) {
+    return new MCPSearXNGError(
+      `All configured SearXNG instances are in cooldown after repeated failures: ${skippedInstances.join(", ")}.`
+    );
+  }
+
   const failureDetails = failures
     .map(({ instanceUrl, error }) => `${instanceUrl}: ${error instanceof Error ? error.message : String(error)}`)
     .join("; ");
@@ -592,7 +598,8 @@ async function performFailoverSearch(
   request: SearchRequest,
 ): Promise<MultiInstanceSearchResult> {
   const healthyInstances = getHealthySearxngInstances(instances);
-  const skippedInstances = instances.filter((instanceUrl) => !healthyInstances.includes(instanceUrl));
+  const healthySet = new Set(healthyInstances);
+  const skippedInstances = instances.filter((instanceUrl) => !healthySet.has(instanceUrl));
   const failures: FailedInstanceResult[] = [];
   const emptyResults: EmptyInstanceResult[] = [];
 
@@ -656,9 +663,12 @@ function mergeFanoutResults(results: InstanceSearchResult[]): SearXNGWeb {
     }
   }
 
+  const mergedResults = [...byUrl.values()].sort((a, b) => resultScore(b) - resultScore(a));
+
   return {
     ...base,
-    results: [...byUrl.values()].sort((a, b) => resultScore(b) - resultScore(a)),
+    number_of_results: mergedResults.length,
+    results: mergedResults,
   };
 }
 
@@ -668,7 +678,8 @@ async function performFanoutSearch(
   request: SearchRequest,
 ): Promise<MultiInstanceSearchResult> {
   const healthyInstances = getHealthySearxngInstances(instances);
-  const skippedInstances = instances.filter((instanceUrl) => !healthyInstances.includes(instanceUrl));
+  const healthySet = new Set(healthyInstances);
+  const skippedInstances = instances.filter((instanceUrl) => !healthySet.has(instanceUrl));
   const settledResults = await Promise.all(healthyInstances.map(async (instanceUrl) => {
     try {
       const result = await fetchSearchFromInstance(mcpServer, instanceUrl, request);

--- a/src/search.ts
+++ b/src/search.ts
@@ -5,6 +5,13 @@ import { getKnownCategories, getKnownEngines } from "./instance-info.js";
 import { createProxyAgent, createDefaultAgent, ProxyType } from "./proxy.js";
 import { logMessage } from "./logging.js";
 import {
+  getHealthySearxngInstances,
+  getSearxngInstances,
+  isSearxngFanoutEnabled,
+  recordSearxngInstanceFailure,
+  recordSearxngInstanceSuccess,
+} from "./searxng-instances.js";
+import {
   MCPSearXNGError,
   validateEnvironment,
   createNetworkError,
@@ -246,6 +253,36 @@ type NormalizedFilters = {
   validationNote?: string;
 };
 
+type SearchRequest = {
+  query: string;
+  pageno: number;
+  time_range?: string;
+  effectiveLanguage: string;
+  effectiveSafesearch?: number;
+  filters: NormalizedFilters;
+  timeoutMs: number;
+};
+
+type InstanceSearchResult = {
+  instanceUrl: string;
+  data: SearXNGWeb;
+};
+
+type MultiInstanceSearchResult = {
+  data: SearXNGWeb;
+  servedBy: string[];
+};
+
+type EmptyInstanceResult = {
+  instanceUrl: string;
+  data: SearXNGWeb;
+};
+
+type FailedInstanceResult = {
+  instanceUrl: string;
+  error: unknown;
+};
+
 async function normalizeSearchFilters(
   mcpServer: McpServer,
   categories?: string,
@@ -401,6 +438,266 @@ function getDefaultSafesearch(mcpServer: McpServer): number | undefined {
   return parsed;
 }
 
+function buildSearchUrl(instanceUrl: string, request: SearchRequest): URL {
+  const parsedUrl = new URL(instanceUrl.endsWith('/') ? instanceUrl : instanceUrl + '/');
+  const url = new URL('search', parsedUrl);
+
+  url.searchParams.set("q", request.query);
+  url.searchParams.set("format", "json");
+  url.searchParams.set("pageno", request.pageno.toString());
+
+  if (
+    request.time_range !== undefined &&
+    ["day", "week", "month", "year"].includes(request.time_range)
+  ) {
+    url.searchParams.set("time_range", request.time_range);
+  }
+
+  if (request.effectiveLanguage && request.effectiveLanguage !== "all") {
+    url.searchParams.set("language", request.effectiveLanguage);
+  }
+
+  if (request.effectiveSafesearch !== undefined && [0, 1, 2].includes(request.effectiveSafesearch)) {
+    url.searchParams.set("safesearch", request.effectiveSafesearch.toString());
+  }
+
+  if (request.filters.categories) {
+    url.searchParams.set("categories", request.filters.categories);
+  }
+
+  if (request.filters.engines) {
+    url.searchParams.set("engines", request.filters.engines);
+  }
+
+  return url;
+}
+
+function buildSearchRequestOptions(url: URL): RequestInit {
+  const requestOptions: RequestInit = {
+    method: "GET"
+  };
+
+  const proxyAgent = createProxyAgent(url.toString(), ProxyType.SEARCH);
+  const dispatcher = proxyAgent ?? createDefaultAgent();
+  if (dispatcher) {
+    (requestOptions as any).dispatcher = dispatcher;
+  }
+
+  const username = process.env.AUTH_USERNAME;
+  const password = process.env.AUTH_PASSWORD;
+
+  if (username && password) {
+    const base64Auth = Buffer.from(`${username}:${password}`).toString('base64');
+    requestOptions.headers = {
+      ...requestOptions.headers,
+      'Authorization': `Basic ${base64Auth}`
+    };
+  }
+
+  const userAgent = process.env.USER_AGENT;
+  if (userAgent) {
+    requestOptions.headers = {
+      ...requestOptions.headers,
+      'User-Agent': userAgent
+    };
+  }
+
+  return requestOptions;
+}
+
+async function fetchSearchFromInstance(
+  mcpServer: McpServer,
+  instanceUrl: string,
+  request: SearchRequest,
+): Promise<InstanceSearchResult> {
+  const url = buildSearchUrl(instanceUrl, request);
+  const requestOptions = buildSearchRequestOptions(url);
+  const response = await fetchWithSearchTimeout(mcpServer, url, requestOptions, request.timeoutMs, request.query, instanceUrl);
+
+  let data: SearXNGWeb;
+
+  if (!response.ok) {
+    if (isHtmlFallbackEnabled() && shouldFallbackForStatus(response.status)) {
+      data = await fetchHtmlFallbackSearch(mcpServer, url, requestOptions, request.timeoutMs, request.query, instanceUrl);
+    } else {
+      let responseBody: string;
+      try {
+        responseBody = await response.text();
+      } catch {
+        responseBody = '[Could not read response body]';
+      }
+
+      const context: ErrorContext = {
+        url: url.toString(),
+        searxngUrl: instanceUrl
+      };
+      throw createServerError(response.status, response.statusText, responseBody, context);
+    }
+  } else {
+    try {
+      data = (await response.json()) as SearXNGWeb;
+    } catch (error: any) {
+      if (isHtmlFallbackEnabled()) {
+        data = await fetchHtmlFallbackSearch(mcpServer, url, requestOptions, request.timeoutMs, request.query, instanceUrl);
+      } else {
+        let responseText: string;
+        try {
+          responseText = await response.text();
+        } catch {
+          responseText = '[Could not read response text]';
+        }
+
+        const context: ErrorContext = { url: url.toString() };
+        throw createJSONError(responseText, context);
+      }
+    }
+  }
+
+  if (!data.results) {
+    const context: ErrorContext = { url: url.toString(), query: request.query };
+    throw createDataError(data, context);
+  }
+
+  return {
+    instanceUrl,
+    data,
+  };
+}
+
+function hasSearchResults(data: SearXNGWeb): boolean {
+  return data.results.length > 0;
+}
+
+function createAllInstancesFailedError(failures: FailedInstanceResult[], skippedInstances: string[]): MCPSearXNGError {
+  const failureDetails = failures
+    .map(({ instanceUrl, error }) => `${instanceUrl}: ${error instanceof Error ? error.message : String(error)}`)
+    .join("; ");
+  const skippedDetails = skippedInstances.length > 0
+    ? ` Skipped cooled-down instances: ${skippedInstances.join(", ")}.`
+    : "";
+
+  return new MCPSearXNGError(`All configured SearXNG instances failed. ${failureDetails}${skippedDetails}`);
+}
+
+async function performFailoverSearch(
+  mcpServer: McpServer,
+  instances: string[],
+  request: SearchRequest,
+): Promise<MultiInstanceSearchResult> {
+  const healthyInstances = getHealthySearxngInstances(instances);
+  const skippedInstances = instances.filter((instanceUrl) => !healthyInstances.includes(instanceUrl));
+  const failures: FailedInstanceResult[] = [];
+  const emptyResults: EmptyInstanceResult[] = [];
+
+  for (const instanceUrl of healthyInstances) {
+    try {
+      const result = await fetchSearchFromInstance(mcpServer, instanceUrl, request);
+      recordSearxngInstanceSuccess(instanceUrl);
+
+      if (hasSearchResults(result.data)) {
+        return {
+          data: result.data,
+          servedBy: [instanceUrl],
+        };
+      }
+
+      emptyResults.push(result);
+    } catch (error) {
+      recordSearxngInstanceFailure(instanceUrl);
+      failures.push({ instanceUrl, error });
+    }
+  }
+
+  if (emptyResults.length > 0) {
+    return {
+      data: emptyResults[0].data,
+      servedBy: emptyResults.map((result) => result.instanceUrl),
+    };
+  }
+
+  throw createAllInstancesFailedError(failures, skippedInstances);
+}
+
+function canonicalResultUrl(rawUrl: string): string {
+  try {
+    const url = new URL(rawUrl);
+    url.protocol = url.protocol.toLowerCase();
+    url.hostname = url.hostname.toLowerCase();
+    url.hash = "";
+    return url.toString();
+  } catch {
+    return rawUrl;
+  }
+}
+
+function resultScore(result: { score?: number }): number {
+  return result.score ?? 0;
+}
+
+function mergeFanoutResults(results: InstanceSearchResult[]): SearXNGWeb {
+  const firstContributor = results.find((result) => hasSearchResults(result.data));
+  const base = firstContributor?.data ?? results[0].data;
+  const byUrl = new Map<string, SearXNGWeb["results"][number]>();
+
+  for (const result of results) {
+    for (const entry of result.data.results) {
+      const key = canonicalResultUrl(entry.url);
+      const existing = byUrl.get(key);
+      if (!existing || resultScore(entry) > resultScore(existing)) {
+        byUrl.set(key, entry);
+      }
+    }
+  }
+
+  return {
+    ...base,
+    results: [...byUrl.values()].sort((a, b) => resultScore(b) - resultScore(a)),
+  };
+}
+
+async function performFanoutSearch(
+  mcpServer: McpServer,
+  instances: string[],
+  request: SearchRequest,
+): Promise<MultiInstanceSearchResult> {
+  const healthyInstances = getHealthySearxngInstances(instances);
+  const skippedInstances = instances.filter((instanceUrl) => !healthyInstances.includes(instanceUrl));
+  const settledResults = await Promise.all(healthyInstances.map(async (instanceUrl) => {
+    try {
+      const result = await fetchSearchFromInstance(mcpServer, instanceUrl, request);
+      recordSearxngInstanceSuccess(instanceUrl);
+      return { ok: true as const, result };
+    } catch (error) {
+      recordSearxngInstanceFailure(instanceUrl);
+      return { ok: false as const, failure: { instanceUrl, error } };
+    }
+  }));
+
+  const successes = settledResults
+    .filter((entry): entry is { ok: true; result: InstanceSearchResult } => entry.ok)
+    .map((entry) => entry.result);
+  const failures = settledResults
+    .filter((entry): entry is { ok: false; failure: FailedInstanceResult } => !entry.ok)
+    .map((entry) => entry.failure);
+
+  if (successes.length === 0) {
+    throw createAllInstancesFailedError(failures, skippedInstances);
+  }
+
+  const contributing = successes.filter((result) => hasSearchResults(result.data));
+  if (contributing.length === 0) {
+    return {
+      data: successes[0].data,
+      servedBy: successes.map((result) => result.instanceUrl),
+    };
+  }
+
+  return {
+    data: mergeFanoutResults(contributing),
+    servedBy: contributing.map((result) => result.instanceUrl),
+  };
+}
+
 export async function performWebSearch(
   mcpServer: McpServer,
   query: string,
@@ -445,121 +742,32 @@ export async function performWebSearch(
   ].filter(Boolean).join(", ");
   
   logMessage(mcpServer, "info", `Starting web search: "${query}" (${searchParams})`);
-  
-  const searxngUrl = process.env.SEARXNG_URL!;
-  const parsedUrl = new URL(searxngUrl.endsWith('/') ? searxngUrl : searxngUrl + '/');
 
-  const url = new URL('search', parsedUrl);
-
-  url.searchParams.set("q", query);
-  url.searchParams.set("format", "json");
-  url.searchParams.set("pageno", pageno.toString());
-
-  if (
-    time_range !== undefined &&
-    ["day", "week", "month", "year"].includes(time_range)
-  ) {
-    url.searchParams.set("time_range", time_range);
-  }
-
-  if (effectiveLanguage && effectiveLanguage !== "all") {
-    url.searchParams.set("language", effectiveLanguage);
-  }
-
-  if (effectiveSafesearch !== undefined && [0, 1, 2].includes(effectiveSafesearch)) {
-    url.searchParams.set("safesearch", effectiveSafesearch.toString());
-  }
-
-  if (filters.categories) {
-    url.searchParams.set("categories", filters.categories);
-  }
-
-  if (filters.engines) {
-    url.searchParams.set("engines", filters.engines);
-  }
-
-  // Prepare request options with headers
-  const requestOptions: RequestInit = {
-    method: "GET"
+  const SEARCH_TIMEOUT_MS = parseInt(process.env.SEARXNG_TIMEOUT_MS ?? "10000", 10);
+  const instances = getSearxngInstances();
+  const includeProvenance = instances.length > 1;
+  const request: SearchRequest = {
+    query,
+    pageno,
+    time_range,
+    effectiveLanguage,
+    effectiveSafesearch,
+    filters,
+    timeoutMs: SEARCH_TIMEOUT_MS,
   };
 
-  // Add proxy or default dispatcher (includes system CA certs for TLS)
-  const proxyAgent = createProxyAgent(url.toString(), ProxyType.SEARCH);
-  const dispatcher = proxyAgent ?? createDefaultAgent();
-  if (dispatcher) {
-    (requestOptions as any).dispatcher = dispatcher;
-  }
-
-  // Add basic authentication if credentials are provided
-  const username = process.env.AUTH_USERNAME;
-  const password = process.env.AUTH_PASSWORD;
-
-  if (username && password) {
-    const base64Auth = Buffer.from(`${username}:${password}`).toString('base64');
-    requestOptions.headers = {
-      ...requestOptions.headers,
-      'Authorization': `Basic ${base64Auth}`
-    };
-  }
-
-  // Add User-Agent header if configured
-  const userAgent = process.env.USER_AGENT;
-  if (userAgent) {
-    requestOptions.headers = {
-      ...requestOptions.headers,
-      'User-Agent': userAgent
-    };
-  }
-
-  // Fetch with AbortController timeout and enhanced error handling
-  const SEARCH_TIMEOUT_MS = parseInt(process.env.SEARXNG_TIMEOUT_MS ?? "10000", 10);
-
-  let response: Response;
-  response = await fetchWithSearchTimeout(mcpServer, url, requestOptions, SEARCH_TIMEOUT_MS, query, searxngUrl);
-
   let data: SearXNGWeb;
+  let servedBy: string[] = [];
 
-  if (!response.ok) {
-    if (isHtmlFallbackEnabled() && shouldFallbackForStatus(response.status)) {
-      data = await fetchHtmlFallbackSearch(mcpServer, url, requestOptions, SEARCH_TIMEOUT_MS, query, searxngUrl);
-    } else {
-      let responseBody: string;
-      try {
-        responseBody = await response.text();
-      } catch {
-        responseBody = '[Could not read response body]';
-      }
-
-      const context: ErrorContext = {
-        url: url.toString(),
-        searxngUrl
-      };
-      throw createServerError(response.status, response.statusText, responseBody, context);
-    }
+  if (instances.length === 1) {
+    const result = await fetchSearchFromInstance(mcpServer, instances[0], request);
+    data = result.data;
   } else {
-    // Parse JSON response
-    try {
-      data = (await response.json()) as SearXNGWeb;
-    } catch (error: any) {
-      if (isHtmlFallbackEnabled()) {
-        data = await fetchHtmlFallbackSearch(mcpServer, url, requestOptions, SEARCH_TIMEOUT_MS, query, searxngUrl);
-      } else {
-        let responseText: string;
-        try {
-          responseText = await response.text();
-        } catch {
-          responseText = '[Could not read response text]';
-        }
-
-        const context: ErrorContext = { url: url.toString() };
-        throw createJSONError(responseText, context);
-      }
-    }
-  }
-
-  if (!data.results) {
-    const context: ErrorContext = { url: url.toString(), query };
-    throw createDataError(data, context);
+    const multiResult = isSearxngFanoutEnabled()
+      ? await performFanoutSearch(mcpServer, instances, request)
+      : await performFailoverSearch(mcpServer, instances, request);
+    data = multiResult.data;
+    servedBy = multiResult.servedBy;
   }
 
   const results = data.results
@@ -573,11 +781,15 @@ export async function performWebSearch(
       ...data,
       results: slicedResults,
       ...(filters.validationWarning ? { warnings: [filters.validationWarning] } : {}),
+      ...(includeProvenance ? { servedBy } : {}),
     }, null, 2);
   }
 
   const metadata = formatSearchMetadata(data);
   const leadingSections = [
+    includeProvenance
+      ? `Served by SearXNG ${servedBy.length === 1 ? "instance" : "instances"}: ${servedBy.join(", ")}`
+      : null,
     filters.validationNote ?? null,
     data.sourceFormat === "html" ? "Note: Results parsed from SearXNG HTML fallback; metadata is limited." : null,
     metadata || null,

--- a/src/searxng-instances.ts
+++ b/src/searxng-instances.ts
@@ -1,0 +1,75 @@
+const FAILURE_COOLDOWN_THRESHOLD = 3;
+const FAILURE_COOLDOWN_MS = 60_000;
+
+type InstanceHealth = {
+  consecutiveFailures: number;
+  cooledUntil: number;
+};
+
+const healthByInstance = new Map<string, InstanceHealth>();
+
+export function parseSearxngUrls(raw: string | undefined = process.env.SEARXNG_URL): string[] {
+  if (raw === undefined) {
+    return [];
+  }
+
+  return raw
+    .split(";")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== "");
+}
+
+export function getSearxngInstances(): string[] {
+  return parseSearxngUrls();
+}
+
+export function getPrimarySearxngInstance(): string | undefined {
+  return getSearxngInstances()[0];
+}
+
+export function validateSearxngInstanceUrl(value: string): string | null {
+  try {
+    const url = new URL(value);
+    if (!["http:", "https:"].includes(url.protocol)) {
+      return `SEARXNG_URL invalid protocol for "${value}": ${url.protocol}`;
+    }
+  } catch {
+    return `SEARXNG_URL invalid format: ${value}`;
+  }
+
+  return null;
+}
+
+export function isSearxngFanoutEnabled(): boolean {
+  return process.env.SEARXNG_FANOUT === "true";
+}
+
+export function recordSearxngInstanceFailure(instanceUrl: string, now = Date.now()): void {
+  const current = healthByInstance.get(instanceUrl) ?? { consecutiveFailures: 0, cooledUntil: 0 };
+  const consecutiveFailures = current.consecutiveFailures + 1;
+  healthByInstance.set(instanceUrl, {
+    consecutiveFailures,
+    cooledUntil: consecutiveFailures >= FAILURE_COOLDOWN_THRESHOLD ? now + FAILURE_COOLDOWN_MS : current.cooledUntil,
+  });
+}
+
+export function recordSearxngInstanceSuccess(instanceUrl: string): void {
+  healthByInstance.delete(instanceUrl);
+}
+
+export function isSearxngInstanceCooledDown(instanceUrl: string, now = Date.now()): boolean {
+  const state = healthByInstance.get(instanceUrl);
+  if (!state || state.cooledUntil <= now) {
+    return false;
+  }
+
+  return true;
+}
+
+export function getHealthySearxngInstances(instances: string[], now = Date.now()): string[] {
+  return instances.filter((instanceUrl) => !isSearxngInstanceCooledDown(instanceUrl, now));
+}
+
+export function clearSearxngInstanceStateForTests(): void {
+  healthByInstance.clear();
+}

--- a/src/searxng-instances.ts
+++ b/src/searxng-instances.ts
@@ -8,6 +8,20 @@ type InstanceHealth = {
 
 const healthByInstance = new Map<string, InstanceHealth>();
 
+function getActiveHealth(instanceUrl: string, now: number): InstanceHealth | undefined {
+  const state = healthByInstance.get(instanceUrl);
+  if (!state) {
+    return undefined;
+  }
+
+  if (state.cooledUntil > 0 && state.cooledUntil <= now) {
+    healthByInstance.delete(instanceUrl);
+    return undefined;
+  }
+
+  return state;
+}
+
 export function parseSearxngUrls(raw: string | undefined = process.env.SEARXNG_URL): string[] {
   if (raw === undefined) {
     return [];
@@ -45,7 +59,7 @@ export function isSearxngFanoutEnabled(): boolean {
 }
 
 export function recordSearxngInstanceFailure(instanceUrl: string, now = Date.now()): void {
-  const current = healthByInstance.get(instanceUrl) ?? { consecutiveFailures: 0, cooledUntil: 0 };
+  const current = getActiveHealth(instanceUrl, now) ?? { consecutiveFailures: 0, cooledUntil: 0 };
   const consecutiveFailures = current.consecutiveFailures + 1;
   healthByInstance.set(instanceUrl, {
     consecutiveFailures,
@@ -58,12 +72,12 @@ export function recordSearxngInstanceSuccess(instanceUrl: string): void {
 }
 
 export function isSearxngInstanceCooledDown(instanceUrl: string, now = Date.now()): boolean {
-  const state = healthByInstance.get(instanceUrl);
-  if (!state || state.cooledUntil <= now) {
+  const state = getActiveHealth(instanceUrl, now);
+  if (!state) {
     return false;
   }
 
-  return true;
+  return state.cooledUntil > now;
 }
 
 export function getHealthySearxngInstances(instances: string[], now = Date.now()): string[] {

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -1,13 +1,14 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logMessage } from "./logging.js";
 import { createDefaultAgent, createProxyAgent, ProxyType } from "./proxy.js";
+import { getPrimarySearxngInstance } from "./searxng-instances.js";
 
 export async function performSearchSuggestions(
   mcpServer: McpServer,
   query: string,
   language: string = "all",
 ): Promise<string[]> {
-  const base = process.env.SEARXNG_URL;
+  const base = getPrimarySearxngInstance();
   if (!base) {
     return [];
   }


### PR DESCRIPTION
## TODO item

**FEAT-047** — Multiple SearXNG instances via `SEARXNG_URL` list with failover and optional fanout (🟡 Medium, from TODO-features.md)

## Context

The server read a single `SEARXNG_URL` (consumed raw in ~7 files), so a pool of
interchangeable replicas gave no failover when one instance was down, blocked, or
returned nothing. Rather than add a separate variable, `SEARXNG_URL` now accepts a
semicolon-separated list — a single value behaves exactly as today — plus failover
and an optional parallel fanout. Capabilities/filters remain instance-uniform here
(cross-instance aggregation is the separate FEAT-048).

## What changed

- **`src/searxng-instances.ts` (new):** parses `SEARXNG_URL` on `;` (trim, drop
  empties, preserve order); exposes the full list, a `primary` accessor, http/https
  validation, the `SEARXNG_FANOUT` flag, and in-memory per-instance health (3
  consecutive hard failures → 60 s cooldown) with an injectable clock + test reset.
- **`src/search.ts`:** extracted the single-instance request path
  (`buildSearchUrl`/`buildSearchRequestOptions`/`fetchSearchFromInstance`) without
  behavior change, then added ordered failover and optional fanout on top. Fanout
  dedupes by canonical URL keeping the highest `score`, ordered by score descending.
  Adds `servedBy` provenance — text line + JSON field — **only** when more than one
  instance is configured. A single instance keeps the legacy code path: byte-identical
  output and original error objects.
- **`src/error-handler.ts`:** `validateEnvironment()` validates every parsed entry,
  preserving the existing message tokens (`SEARXNG_URL not set`, the
  `⚠️ Configuration Issues:` wrapper) and reporting the offending entry.
- **`src/suggestions.ts` / `src/instance-info.ts`:** use the primary instance only;
  instance-info now labels the `sourceUrl` the `/config` came from.
- **`src/index.ts`:** startup display/logging shows the full parsed instance list.
- **Docs:** `CONFIGURATION.md` documents the semicolon list, `SEARXNG_FANOUT`, the
  empty-is-healthy/cooldown semantics, and the full-example block; `README.md` adds an
  Instance Failover feature note and updates How-It-Works/Configuration.
- `src/resources.ts` was intentionally left unchanged — it echoes the raw configured
  string, which stays accurate for a list, and it is outside the item's scope.

Key invariants enforced and tested: (1) single instance = behavior identical to
today; (2) a `200 OK` with empty `results` is healthy and never triggers cooldown;
(3) all-reachable-but-empty returns the existing no-results message / empty JSON, not
an error — an error is thrown only when every instance hard-fails; (4) provenance only
appears with >1 instance.

## How it was verified

Verified independently by the tech lead (not just the implementer):

- `npm run build` — pass
- `npm test` / `npm run test:coverage` — **384/384 pass**, coverage **95.79% lines /
  91.89% branches** (gate is 90 / 85; new module `searxng-instances.ts` 100%)
- `npm run lint` — clean
- `npm run test:e2e` — local/non-live suites pass (exit 0 when the live instance is
  not required). The 4 live `searxng_web_search` cases could **not** be exercised in
  this environment because the configured live instance (`searxng.ihor.top` →
  `192.168.2.101`, a private LAN address) is currently unreachable; that failure is
  environmental (connection refused at the host) and reproduces identically on `main`.
  This item is pure orchestration logic fully covered by mocked unit/integration tests,
  and single-instance live behavior is unchanged. **Re-run `SEARXNG_LIVE_URL=… npm run
  test:e2e` once the instance is back online to close the live gate before merge.**

## Documentation

- `CONFIGURATION.md`: `SEARXNG_URL` now documents the semicolon-separated replica list;
  new `SEARXNG_FANOUT` row (default `false`); failover/cooldown/fanout semantics
  paragraph; `SEARXNG_FANOUT` added to the full-example JSON.
- `README.md`: new "Instance Failover" feature bullet; How-It-Works and Configuration
  sections mention replica lists and fanout.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
