### PR TITLE
refactor(cleanup): drop duplicate type, dead error params, merge category helpers (BUG-008)

### DIFF
--- a/__tests__/helpers/mock-fetch.ts
+++ b/__tests__/helpers/mock-fetch.ts
@@ -35,7 +35,17 @@ export function createMockFetch(options: FetchMockOptions = {}) {
       ok,
       status,
       statusText,
-      text: async () => body,
+      // text() and json() come from one body on a real Response — mirror json
+      // into text when only json is given so a text-first reader stays consistent.
+      text: async () => {
+        if (body) {
+          return body;
+        }
+        if (json !== null) {
+          return JSON.stringify(json);
+        }
+        return '';
+      },
       json: async () => {
         if (json !== null) {
           return json;
@@ -64,7 +74,7 @@ export function createCapturingMockFetch() {
       ok: true,
       status: 200,
       statusText: 'OK',
-      text: async () => '<html><body>Test</body></html>',
+      text: async () => JSON.stringify({ results: [] }),
       json: async () => ({ results: [] })
     } as Response;
   };

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -187,7 +187,8 @@ async function runTests() {
     let capturedUrl = '';
     fetchMocker.mock(async (url, _opts) => {
       capturedUrl = url as string;
-      return { ok: true, json: async () => ({ results: [{ title: 'R', url: 'https://x.com', content: 'c', score: 1 }] }), text: async () => '' } as any;
+      const body = JSON.stringify({ results: [{ title: 'R', url: 'https://x.com', content: 'c', score: 1 }] });
+      return { ok: true, json: async () => JSON.parse(body), text: async () => body } as any;
     });
     const { client } = await connect();
 

--- a/__tests__/unit/error-handler.test.ts
+++ b/__tests__/unit/error-handler.test.ts
@@ -118,7 +118,12 @@ async function runTests() {
 
   await testFunction('createEmptyContentWarning includes the URL', () => {
     const warning = createEmptyContentWarning('https://test.com');
-    assert.ok(warning.includes('https://test.com'));
+    // Exact-match the full message (not url.includes) — a substring URL check
+    // trips CodeQL's incomplete-URL-sanitization rule and asserts less anyway.
+    assert.equal(
+      warning,
+      '📄 Content Warning: Page fetched but appears empty after conversion (https://test.com). May contain only media or require JavaScript.'
+    );
   }, results);
 
   await testFunction('validateEnvironment success', () => {

--- a/__tests__/unit/error-handler.test.ts
+++ b/__tests__/unit/error-handler.test.ts
@@ -98,11 +98,11 @@ async function runTests() {
   await testFunction('Specialized error creators', () => {
     const context = { searxngUrl: 'https://searx.example.com' };
     
-    assert.ok(createJSONError('invalid json', context) instanceof MCPSearXNGError);
-    assert.ok(createDataError({}, context) instanceof MCPSearXNGError);
+    assert.ok(createJSONError('invalid json') instanceof MCPSearXNGError);
+    assert.ok(createDataError() instanceof MCPSearXNGError);
     assert.ok(createURLFormatError('invalid-url') instanceof MCPSearXNGError);
     assert.ok(createContentError('test error', 'https://example.com') instanceof MCPSearXNGError);
-    assert.ok(createConversionError(new Error('test'), 'https://example.com', '<html>') instanceof MCPSearXNGError);
+    assert.ok(createConversionError('https://example.com') instanceof MCPSearXNGError);
     assert.ok(createTimeoutError(5000, 'https://example.com') instanceof MCPSearXNGError);
     assert.ok(createUnexpectedError(new Error('test'), context) instanceof MCPSearXNGError);
   }, results);
@@ -111,7 +111,7 @@ async function runTests() {
     assert.ok(typeof createNoResultsMessage('test query') === 'string');
     assert.ok(createNoResultsMessage('test').includes('No results found'));
     
-    const warning = createEmptyContentWarning('https://example.com', 100, '<html>');
+    const warning = createEmptyContentWarning('https://example.com');
     assert.ok(typeof warning === 'string');
     assert.ok(warning.includes('Content Warning'));
   }, results);
@@ -119,7 +119,7 @@ async function runTests() {
   await testFunction('createEmptyContentWarning with various content', () => {
     const contents = ['', '<html></html>', '<div>content</div>', 'plain text'];
     for (const content of contents) {
-      const warning = createEmptyContentWarning('https://test.com', content.length, content);
+      const warning = createEmptyContentWarning('https://test.com');
       assert.ok(typeof warning === 'string');
     }
   }, results);

--- a/__tests__/unit/error-handler.test.ts
+++ b/__tests__/unit/error-handler.test.ts
@@ -116,12 +116,9 @@ async function runTests() {
     assert.ok(warning.includes('Content Warning'));
   }, results);
 
-  await testFunction('createEmptyContentWarning with various content', () => {
-    const contents = ['', '<html></html>', '<div>content</div>', 'plain text'];
-    for (const content of contents) {
-      const warning = createEmptyContentWarning('https://test.com');
-      assert.ok(typeof warning === 'string');
-    }
+  await testFunction('createEmptyContentWarning includes the URL', () => {
+    const warning = createEmptyContentWarning('https://test.com');
+    assert.ok(warning.includes('https://test.com'));
   }, results);
 
   await testFunction('validateEnvironment success', () => {

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -245,19 +245,37 @@ async function runTests() {
     
     const mockServer = createMockServer();
     
-    fetchMocker.mock(async () => ({
-      ok: true,
-      json: async () => {
-        throw new Error('Invalid JSON');
-      },
-      text: async () => 'Invalid JSON response'
-    } as any));
+    // Simulate a real single-use body: once json() consumes it, text() fails.
+    // The buggy path (text() after json()) would lose the preview entirely.
+    fetchMocker.mock(async () => {
+      let bodyConsumed = false;
+      return {
+        ok: true,
+        json: async () => {
+          bodyConsumed = true;
+          throw new Error('Invalid JSON');
+        },
+        text: async () => {
+          if (bodyConsumed) {
+            throw new TypeError('Body is unusable: Body has already been read');
+          }
+          return 'Invalid JSON response';
+        }
+      } as any;
+    });
 
     try {
       await performWebSearch(mockServer as any, 'test query');
       assert.fail('Should have thrown JSON parsing error');
     } catch (error: any) {
-      assert.ok(error.message.includes('JSON Error') || error.message.includes('Invalid JSON') || error.name === 'MCPSearXNGError');
+      assert.equal(error.name, 'MCPSearXNGError');
+      // Regression (BUG-008 review): the error must carry the real response
+      // preview, not the '[Could not read response text]' placeholder that the
+      // body-already-consumed bug produced.
+      assert.ok(
+        error.message.includes('Invalid JSON response'),
+        `expected response preview in error message, got: ${error.message}`
+      );
     }
 
     fetchMocker.restore();

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -111,12 +111,12 @@ export function createServerError(status: number, statusText: string, responseBo
   return new MCPSearXNGError(`🚫 ${target} Error (${status}): ${statusText}`);
 }
 
-export function createJSONError(responseText: string, context: ErrorContext): MCPSearXNGError {
+export function createJSONError(responseText: string): MCPSearXNGError {
   const preview = responseText.substring(0, 100).replace(/\n/g, ' ');
   return new MCPSearXNGError(`🔍 SearXNG Response Error: Invalid JSON format. Response: "${preview}..."`);
 }
 
-export function createDataError(data: any, context: ErrorContext): MCPSearXNGError {
+export function createDataError(): MCPSearXNGError {
   return new MCPSearXNGError(`🔍 SearXNG Data Error: Missing results array in response`);
 }
 
@@ -139,7 +139,7 @@ export function createContentError(message: string, url: string): MCPSearXNGErro
   return new MCPSearXNGError(`📄 Content Error: ${message} (${url})`);
 }
 
-export function createConversionError(error: any, url: string, htmlContent: string): MCPSearXNGError {
+export function createConversionError(url: string): MCPSearXNGError {
   return new MCPSearXNGError(`🔄 Conversion Error: Cannot convert HTML to Markdown (${url})`);
 }
 
@@ -148,7 +148,7 @@ export function createTimeoutError(timeout: number, url: string): MCPSearXNGErro
   return new MCPSearXNGError(`⏱️ Timeout Error: ${hostname} took longer than ${timeout}ms to respond`);
 }
 
-export function createEmptyContentWarning(url: string, htmlLength: number, htmlPreview: string): string {
+export function createEmptyContentWarning(url: string): string {
   return `📄 Content Warning: Page fetched but appears empty after conversion (${url}). May contain only media or require JavaScript.`;
 }
 

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -64,23 +64,11 @@ function categoryNamesFromEngines(config: SearXNGConfig): string[] {
   return [...names];
 }
 
-function categoryNamesFromArray(categories: unknown[]): string[] {
+function categoryNamesFromList(values: unknown[]): string[] {
   const names = new Set<string>();
 
-  for (const category of categories) {
+  for (const category of values) {
     if (typeof category === "string" && category.trim() !== "") {
-      names.add(category);
-    }
-  }
-
-  return [...names];
-}
-
-function categoryNamesFromObject(categories: Record<string, unknown>): string[] {
-  const names = new Set<string>();
-
-  for (const category of Object.keys(categories)) {
-    if (category.trim() !== "") {
       names.add(category);
     }
   }
@@ -90,10 +78,10 @@ function categoryNamesFromObject(categories: Record<string, unknown>): string[] 
 
 function configuredCategoryNames(config: SearXNGConfig): string[] {
   if (Array.isArray(config.categories)) {
-    return categoryNamesFromArray(config.categories);
+    return categoryNamesFromList(config.categories);
   }
   if (config.categories && typeof config.categories === "object") {
-    return categoryNamesFromObject(config.categories);
+    return categoryNamesFromList(Object.keys(config.categories));
   }
   return [];
 }

--- a/src/search.ts
+++ b/src/search.ts
@@ -480,19 +480,22 @@ async function fetchSearchFromInstance(
       throw createServerError(response.status, response.statusText, responseBody, context);
     }
   } else {
+    // Read the body as text once, then parse — a Response body is single-use, so
+    // calling response.text() after response.json() consumed it always throws and
+    // would leave the error preview empty.
+    let responseText: string;
     try {
-      data = (await response.json()) as SearXNGWeb;
-    } catch (error: any) {
+      responseText = await response.text();
+    } catch {
+      responseText = '[Could not read response text]';
+    }
+
+    try {
+      data = JSON.parse(responseText) as SearXNGWeb;
+    } catch {
       if (isHtmlFallbackEnabled()) {
         data = await fetchHtmlFallbackSearch(mcpServer, url, requestOptions, request.timeoutMs, request.query, instanceUrl);
       } else {
-        let responseText: string;
-        try {
-          responseText = await response.text();
-        } catch {
-          responseText = '[Could not read response text]';
-        }
-
         throw createJSONError(responseText);
       }
     }

--- a/src/search.ts
+++ b/src/search.ts
@@ -255,11 +255,6 @@ type MultiInstanceSearchResult = {
   servedBy: string[];
 };
 
-type EmptyInstanceResult = {
-  instanceUrl: string;
-  data: SearXNGWeb;
-};
-
 type FailedInstanceResult = {
   instanceUrl: string;
   error: unknown;
@@ -498,15 +493,13 @@ async function fetchSearchFromInstance(
           responseText = '[Could not read response text]';
         }
 
-        const context: ErrorContext = { url: url.toString() };
-        throw createJSONError(responseText, context);
+        throw createJSONError(responseText);
       }
     }
   }
 
   if (!data.results) {
-    const context: ErrorContext = { url: url.toString(), query: request.query };
-    throw createDataError(data, context);
+    throw createDataError();
   }
 
   return {
@@ -545,7 +538,7 @@ async function performFailoverSearch(
   const healthySet = new Set(healthyInstances);
   const skippedInstances = instances.filter((instanceUrl) => !healthySet.has(instanceUrl));
   const failures: FailedInstanceResult[] = [];
-  const emptyResults: EmptyInstanceResult[] = [];
+  const emptyResults: InstanceSearchResult[] = [];
 
   for (const instanceUrl of healthyInstances) {
     try {

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -431,14 +431,14 @@ export async function fetchAndConvertToMarkdown(
     let markdownContent: string;
     try {
       markdownContent = NodeHtmlMarkdown.translate(htmlContent);
-    } catch (error: any) {
-      throw createConversionError(error, url, htmlContent);
+    } catch {
+      throw createConversionError(url);
     }
 
     if (!markdownContent || markdownContent.trim().length === 0) {
       logMessage(mcpServer, "warning", `Empty content after conversion: ${url}`);
       // DON'T cache empty/failed conversions - return warning directly
-      return createEmptyContentWarning(url, htmlContent.length, htmlContent);
+      return createEmptyContentWarning(url);
     }
 
     // Only cache successful markdown conversion


### PR DESCRIPTION
## TODO item

**BUG-008** — Over-engineering cleanup: duplicate type, dead error-factory params, near-duplicate category helpers (🟢 Low, from TODO-bugs.md)

## Context

A repo over-engineering audit (2026-06-23) surfaced three small clarity issues — pure technical-debt cleanups. Only the three findings judged "clarity wins, ~zero risk" were taken; the audit's larger `getProxyUrl` env-chain collapse and single-caller inlining suggestions were deliberately **rejected** (they hurt grep-ability / domain naming) and are out of scope.

## What changed

- **`src/search.ts`** — Deleted `type EmptyInstanceResult` (structurally identical to `InstanceSearchResult`); `performFailoverSearch`'s `emptyResults` now uses `InstanceSearchResult[]`. Updated the `createJSONError` / `createDataError` call sites and removed the two single-use `context` locals that only fed dropped arguments.
- **`src/error-handler.ts`** — Removed never-read params from four factories: `createJSONError(responseText)`, `createDataError()`, `createConversionError(url)`, `createEmptyContentWarning(url)`. Returned strings are byte-identical.
- **`src/url-reader.ts`** — Updated factory calls to the new signatures; dropped the now-unused `catch` binding. `htmlContent` retained (still used for conversion/caching).
- **`src/instance-info.ts`** — Merged `categoryNamesFromArray` + `categoryNamesFromObject` into one `categoryNamesFromList`.
- **`__tests__/unit/error-handler.test.ts`** — Factory call sites updated to the new signatures; the redundant "various content" loop replaced with a full-message exact-equality assertion.

## Review follow-ups (post-open) — all resolved

- **Copilot (Low) + Codacy (Low)** — redundant `createEmptyContentWarning` loop → **df657f3**: replaced with an assertion on the warning message (later hardened to exact equality).
- **Codacy (HIGH)** — `src/search.ts` called `response.text()` in the `catch` *after* `response.json()` had consumed the single-use body, so the JSON-parse error always degraded to `[Could not read response text]` instead of the real preview → **cc6fae6**: read the body as text once, then `JSON.parse`. This is a **real (pre-existing) bug fix**, so the PR is no longer strictly byte-identical — the one behavioural change is that a JSON-parse error now carries the actual response preview. A regression test simulating single-use body consumption was added (the prior mock masked the bug).
- **CodeQL (Analyze TypeScript) + test-mock fallout** → **b331a4b**: the new test's `url.includes()` check tripped CodeQL's incomplete-URL-sanitization rule (false positive) — replaced with full-message exact equality. Separately, the body-read change exposed that the suite's response mocks modelled `json()`/`text()` as independent (often `text: ''`); the shared mock helpers and one inline integration mock now return `text` that mirrors `json` (a real `Response` exposes one body for both).

## How it was verified

Independently re-run by the tech lead at **b331a4b**:
- `npm run build` — pass
- `npm run test:coverage` — all tests pass; c8 90/85 gate passes (95.34% lines / 92.01% branches)
- `npm run test:e2e` — 11/11 pass
- `npm run lint` — clean
- **PR CI**: Analyze TypeScript ✅ · CodeQL ✅ · Codacy ✅ · Lint, Build, Test ✅ — all 4 green.

## Documentation

None. No tool parameter, environment variable, or security behaviour changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
