### PR TITLE
fix(http-server): recover HTTP session after server restart (BUG-010)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -97,6 +97,8 @@ By default the server communicates over STDIO. Set `MCP_HTTP_PORT` to enable HTT
 - `POST/GET/DELETE /mcp` — MCP protocol
 - `GET /health` — health check
 
+HTTP sessions are stored in memory per process. A stale or unknown `mcp-session-id` on a non-initialize `POST /mcp` receives HTTP 404 with JSON-RPC error code `-32001` and message `"Session not found"`. Clients should recover by running `initialize` again; initialize requests are accepted even when they still carry a stale session header.
+
 ## Rate Limiting (HTTP mode)
 
 Rate limiting is always active in HTTP mode to prevent resource exhaustion. Two separate limits protect different request types.

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -79,9 +79,10 @@ async function runTests() {
     assert.equal(res.body.jsonrpc, '2.0');
     assert.ok(res.body.error);
     assert.equal(res.body.error.code, -32000);
+    assert.equal(res.body.error.message, 'Bad Request: No valid session ID provided');
   }, results);
 
-  await testFunction('POST /mcp with unknown sessionId and non-initialize body returns 400', async () => {
+  await testFunction('POST /mcp with unknown sessionId and non-initialize body returns 404 Session not found', async () => {
     const app = await createHttpServer(() => createTestMcpServer());
 
     const res = await request(app)
@@ -90,8 +91,11 @@ async function runTests() {
       .set('mcp-session-id', 'unknown-session-abc')
       .send({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
 
-    // mcp-session-id is set but transport not found — falls through to invalid request
-    assert.equal(res.status, 400);
+    assert.equal(res.status, 404);
+    assert.equal(res.body.jsonrpc, '2.0');
+    assert.ok(res.body.error);
+    assert.equal(res.body.error.code, -32001);
+    assert.equal(res.body.error.message, 'Session not found');
   }, results);
 
   await testFunction('GET /mcp without sessionId returns 400', async () => {
@@ -157,6 +161,29 @@ async function runTests() {
     assert.ok(res.headers['mcp-session-id'], 'Expected mcp-session-id header in response');
   }, results);
 
+  await testFunction('POST /mcp with stale sessionId and initialize request creates new session', async () => {
+    const app = await createHttpServer(() => createTestMcpServer());
+
+    const res = await request(app)
+      .post('/mcp')
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('mcp-session-id', 'stale-session-abc')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' }
+        }
+      });
+
+    assert.equal(res.status, 200);
+    assert.ok(res.headers['mcp-session-id'], 'Expected new mcp-session-id header in response');
+  }, results);
+
   await testFunction('compatibility mode still allows health and init flow', async () => {
     envManager.delete('MCP_HTTP_HARDEN');
     envManager.delete('MCP_HTTP_AUTH_TOKEN');
@@ -205,6 +232,7 @@ async function runTests() {
       });
 
     assert.equal(res.status, 401);
+    assert.equal(res.body.error.code, -32001);
     envManager.restore();
   }, results);
 
@@ -282,7 +310,9 @@ async function runTests() {
       .set('Accept', 'application/json, text/event-stream')
       .set('mcp-session-id', sessionId)
       .send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
-    assert.equal(postRes.status, 400, 'request after DELETE should be rejected');
+    assert.equal(postRes.status, 404, 'request after DELETE should be rejected');
+    assert.equal(postRes.body.error.code, -32001);
+    assert.equal(postRes.body.error.message, 'Session not found');
   }, results);
 
   // --- Rate Limiting ---

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -182,6 +182,11 @@ async function runTests() {
 
     assert.equal(res.status, 200);
     assert.ok(res.headers['mcp-session-id'], 'Expected new mcp-session-id header in response');
+    assert.notEqual(
+      res.headers['mcp-session-id'],
+      'stale-session-abc',
+      'Server should mint a fresh session id, not echo the stale client-supplied one'
+    );
   }, results);
 
   await testFunction('compatibility mode still allows health and init flow', async () => {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -124,7 +124,7 @@ export async function createHttpServer(
       transport = session.transport;
       mcpServer = session.mcpServer;
       logMessage(mcpServer, "debug", `Reusing session: ${sessionId}`);
-    } else if (!sessionId && isInitializeRequest(req.body)) {
+    } else if (isInitializeRequest(req.body)) {
       // New initialization request — create fresh McpServer and transport
       mcpServer = createMcpServer();
 
@@ -158,11 +158,12 @@ export async function createHttpServer(
         contentType: req.headers['content-type'],
         accept: req.headers['accept']
       });
-      res.status(400).json({
+      const sessionNotFound = Boolean(sessionId);
+      res.status(sessionNotFound ? 404 : 400).json({
         jsonrpc: '2.0',
         error: {
-          code: -32000,
-          message: 'Bad Request: No valid session ID provided',
+          code: sessionNotFound ? -32001 : -32000,
+          message: sessionNotFound ? 'Session not found' : 'Bad Request: No valid session ID provided',
         },
         id: null,
       });


### PR DESCRIPTION
## TODO item

**BUG-010** — HTTP transport: client is stuck after a server restart (stale session ID not handled) (🟡 Medium, from TODO-bugs.md)
Refs: fork commit [`3ee7794`](https://github.com/TheRealChickenlegs/mcp-searxng/commit/3ee77945cd85481b211c5d96a8c6f3b3c5c66d5b8) (Ryan McFadden)

## Context

On the Streamable HTTP transport, `sessions` is an in-memory `Map` that is lost when the process restarts. A client that keeps its `mcp-session-id` header across the restart could never recover:

- `sessionId && sessions.has(sessionId)` is false (the map is empty after restart), and
- `!sessionId && isInitializeRequest(req.body)` is also false (the header **is** present),

so even a fresh `initialize` fell through to the `else` branch and was rejected with `400 / -32000` "Bad Request: No valid session ID provided". The client stayed wedged until it manually dropped its session header. This affects HTTP-transport users only (stdio is the default), but within that mode it is a hard stuck state.

## What changed

- **`src/http-server.ts`** — In the `POST /mcp` handler:
  - The initialize branch guard changed from `!sessionId && isInitializeRequest(req.body)` to `isInitializeRequest(req.body)`, so an `initialize` is accepted even when a stale `mcp-session-id` header is still present. The live-session reuse branch is still checked first, so a re-initialize on a still-live session is unaffected; a fresh transport ignores the stale header (SDK-verified) and generates a new session ID.
  - The invalid-request `else` branch now distinguishes the two cases: a truthy-but-unknown `sessionId` (non-initialize) returns `404 / -32001 / "Session not found"`; an absent session id still returns `400 / -32000 / "Bad Request: No valid session ID provided"`. The `-32001` code intentionally mirrors the MCP SDK's own `validateSession` shape; it overlaps with the `401 Unauthorized` code, but the HTTP status disambiguates.
- **`__tests__/integration/http-server.test.ts`** — Updated the unknown-session POST test to expect `404 / -32001 / "Session not found"`; added a stale-session-header `initialize` recovery test (expects `200` + a new `mcp-session-id`); strengthened the no-session `400` test and the hardened-auth `401` test with explicit code/message assertions; updated the post-`DELETE` follow-up POST to the same `404` contract (a deleted session is now an unknown session).
- **`CONFIGURATION.md`** — Added an HTTP Transport operational note documenting the in-memory session lifetime and the `404 / -32001 "Session not found"` behavior with initialize-based recovery.

`SECURITY.md` and `README.md` are unchanged: this is an HTTP transport error-shape/recovery fix, not a change to auth, CORS, DNS-rebinding, credentials, or the exposure model.

## How it was verified

Verified independently by the tech lead in a clean checkout, not just by the implementer:

- `npm run build` — pass
- `npm test` — pass (all suites; HTTP Server integration 22/22)
- `npm run test:coverage` — pass, 95.81% lines overall (gate 80%); `http-server.ts` 87.21%
- `npm run test:e2e` — pass (2/2 local timeout suite; live suites skip without `SEARXNG_LIVE_URL`, N/A to this transport-only fix)
- `npm run lint` — clean

## Documentation

`CONFIGURATION.md` HTTP Transport section now states that HTTP sessions are in-memory per process, that a stale/unknown `mcp-session-id` on a non-initialize POST returns `404 / -32001 "Session not found"`, and that clients recover by re-running `initialize` (which is accepted even with a stale session header).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
