### PR TITLE
feat(http-server): configurable Express trust proxy for HTTP mode (FEAT-051)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -92,7 +92,7 @@ By default the server communicates over STDIO. Set `MCP_HTTP_PORT` to enable HTT
 |---|---|---|---|
 | `MCP_HTTP_PORT` | No | — | Port number to enable HTTP transport (e.g. `3000`) |
 | `MCP_HTTP_HOST` | No | `127.0.0.1` | Interface address to bind to. Defaults to localhost-only for security. Set `0.0.0.0` for all interfaces (required for Docker and remote deployments), or a specific IP. Works in pair with `MCP_HTTP_PORT` only. **Breaking change from v1.2.1:** previous default was `0.0.0.0`. |
-| `MCP_HTTP_TRUST_PROXY` | No | `false` | Express `trust proxy` setting for deployments behind a trusted reverse proxy. Use `true`, a trusted hop count such as `1`, or a proxy subnet/preset such as `loopback` or `10.0.0.0/8`. |
+| `MCP_HTTP_TRUST_PROXY` | No | `false` | Express `trust proxy` setting for deployments behind a trusted reverse proxy. Use `true`, a trusted hop count such as `1`, or a proxy subnet/preset such as `loopback` or `10.0.0.0/8`. Unset, `false`, or `0` disables it (the secure default). |
 
 **HTTP endpoints (when HTTP mode is active):**
 - `POST/GET/DELETE /mcp` — MCP protocol

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -92,6 +92,7 @@ By default the server communicates over STDIO. Set `MCP_HTTP_PORT` to enable HTT
 |---|---|---|---|
 | `MCP_HTTP_PORT` | No | — | Port number to enable HTTP transport (e.g. `3000`) |
 | `MCP_HTTP_HOST` | No | `127.0.0.1` | Interface address to bind to. Defaults to localhost-only for security. Set `0.0.0.0` for all interfaces (required for Docker and remote deployments), or a specific IP. Works in pair with `MCP_HTTP_PORT` only. **Breaking change from v1.2.1:** previous default was `0.0.0.0`. |
+| `MCP_HTTP_TRUST_PROXY` | No | `false` | Express `trust proxy` setting for deployments behind a trusted reverse proxy. Use `true`, a trusted hop count such as `1`, or a proxy subnet/preset such as `loopback` or `10.0.0.0/8`. |
 
 **HTTP endpoints (when HTTP mode is active):**
 - `POST/GET/DELETE /mcp` — MCP protocol
@@ -112,6 +113,8 @@ Rate limiting is always active in HTTP mode to prevent resource exhaustion. Two 
 Requests exceeding a limit receive HTTP 429 with a JSON-RPC error body (`code: -32029`). `/health` has a fixed limit of 60 requests per minute. Standard `RateLimit-*` headers are included on all responses.
 
 The in-memory store is per-process; for horizontally scaled deployments replace it with a shared Redis store via `express-rate-limit`'s `store` option.
+
+When HTTP mode runs behind a trusted reverse proxy, set `MCP_HTTP_TRUST_PROXY` so Express can resolve the client IP from proxy headers before rate-limit keys and request logs are computed. For a single trusted proxy hop, use `MCP_HTTP_TRUST_PROXY=1`. Leave it unset for direct exposure; enabling it without a trusted proxy lets clients spoof `X-Forwarded-For`. This setting is distinct from outbound `HTTP_PROXY` / `HTTPS_PROXY`, which control this server's requests to SearXNG or URLs.
 
 ## Hardened HTTP Mode
 
@@ -179,6 +182,7 @@ Complete MCP client configuration with every variable. Mix and match as needed �
         "NO_PROXY": "localhost,127.0.0.1,.local,.internal",
         "MCP_HTTP_PORT": "3000",
         "MCP_HTTP_HOST": "0.0.0.0",
+        "MCP_HTTP_TRUST_PROXY": "1",
         "MCP_HTTP_HARDEN": "true",
         "MCP_HTTP_AUTH_TOKEN": "replace-me",
         "MCP_HTTP_ALLOWED_ORIGINS": "https://app.example.com",

--- a/README.md
+++ b/README.md
@@ -239,6 +239,8 @@ By default the server uses STDIO. Set `MCP_HTTP_PORT` to enable HTTP mode:
 
 **Endpoints:** `POST/GET/DELETE /mcp` (MCP protocol), `GET /health` (health check)
 
+For reverse-proxy deployments, see [CONFIGURATION.md](CONFIGURATION.md) for `MCP_HTTP_TRUST_PROXY` so rate limiting and logs use the correct client IP.
+
 **Test it:**
 
 ```bash

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -84,7 +84,7 @@ For HTTP mode, bind to `127.0.0.1` unless external access is required:
 MCP_HTTP_HOST=127.0.0.1
 ```
 
-The default bind address is `0.0.0.0` (all interfaces), which exposes the port on the network.
+The default bind address is `127.0.0.1` (loopback only); set `MCP_HTTP_HOST=0.0.0.0` to expose the port on all interfaces.
 
 ### TLS and CA Certificates
 
@@ -118,6 +118,7 @@ MCP_HTTP_PORT=3000
 ```
 MCP_HTTP_HARDEN=true
 MCP_HTTP_HOST=127.0.0.1             # put a reverse proxy in front
+MCP_HTTP_TRUST_PROXY=1              # trust one reverse-proxy hop
 MCP_HTTP_AUTH_TOKEN=<random-256bit>
 MCP_HTTP_ALLOWED_ORIGINS=https://your-app.example.com
 MCP_HTTP_ALLOWED_HOSTS=your-app.example.com
@@ -125,6 +126,8 @@ MCP_HTTP_ALLOW_PRIVATE_URLS=false   # default, keep this off
 ```
 
 Place the server behind a TLS-terminating reverse proxy (nginx, Caddy, Traefik). Do not expose the MCP HTTP port directly to the internet.
+
+Enable `MCP_HTTP_TRUST_PROXY` only when the server is behind a trusted reverse proxy that strips and sets `X-Forwarded-For`. Enabling it on a directly exposed server lets clients spoof their IP address to evade rate limits and forge request IPs in logs.
 
 ### Secrets in Environment Variables
 

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -24,8 +24,87 @@ function createTestMcpServer(): McpServer {
   );
 }
 
+async function captureConsoleOutput(action: () => Promise<void>): Promise<string[]> {
+  const originalError = console.error;
+  const originalWarn = console.warn;
+  const output: string[] = [];
+  const capture = (...args: unknown[]) => {
+    output.push(args.map(arg => {
+      if (arg instanceof Error) {
+        return `${arg.name}: ${arg.message}`;
+      }
+      return String(arg);
+    }).join(' '));
+  };
+
+  console.error = capture;
+  console.warn = capture;
+
+  try {
+    await action();
+  } finally {
+    console.error = originalError;
+    console.warn = originalWarn;
+  }
+
+  return output;
+}
+
 async function runTests() {
   console.log('🧪 Integration Testing: http-server.ts\n');
+
+  await testFunction('default trust proxy setting remains disabled', async () => {
+    envManager.delete('MCP_HTTP_TRUST_PROXY');
+
+    const app = await createHttpServer(() => createTestMcpServer());
+    assert.equal(app.get('trust proxy'), false);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('GET /health accepts X-Forwarded-For when trust proxy is unset', async () => {
+    envManager.delete('MCP_HTTP_TRUST_PROXY');
+
+    const app = await createHttpServer(() => createTestMcpServer());
+    let status: number | undefined;
+    await captureConsoleOutput(async () => {
+      const res = await request(app)
+        .get('/health')
+        .set('X-Forwarded-For', '203.0.113.10');
+      status = res.status;
+    });
+
+    assert.equal(status, 200);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('MCP_HTTP_TRUST_PROXY=true sets Express trust proxy to true', async () => {
+    envManager.set('MCP_HTTP_TRUST_PROXY', 'true');
+
+    const app = await createHttpServer(() => createTestMcpServer());
+    assert.equal(app.get('trust proxy'), true);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('MCP_HTTP_TRUST_PROXY=1 sets Express trust proxy to one hop', async () => {
+    envManager.set('MCP_HTTP_TRUST_PROXY', '1');
+
+    const app = await createHttpServer(() => createTestMcpServer());
+    assert.equal(app.get('trust proxy'), 1);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('MCP_HTTP_TRUST_PROXY subnet value passes through to Express', async () => {
+    envManager.set('MCP_HTTP_TRUST_PROXY', '10.0.0.0/8');
+
+    const app = await createHttpServer(() => createTestMcpServer());
+    assert.equal(app.get('trust proxy'), '10.0.0.0/8');
+
+    envManager.restore();
+  }, results);
 
   await testFunction('GET /health returns healthy status', async () => {
     const app = await createHttpServer(() => createTestMcpServer());
@@ -417,6 +496,41 @@ async function runTests() {
       res.headers['ratelimit-remaining'] || res.headers['x-ratelimit-remaining'],
       'RateLimit-Remaining header should be present on /health'
     );
+  }, results);
+
+  await testFunction('Rate limiting: trust proxy suppresses X-Forwarded-For validation warning', async () => {
+    envManager.delete('MCP_HTTP_TRUST_PROXY');
+
+    const defaultApp = await createHttpServer(() => createTestMcpServer());
+    const defaultOutput = await captureConsoleOutput(async () => {
+      await request(defaultApp)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('X-Forwarded-For', '203.0.113.10')
+        .send({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
+    });
+    assert.ok(
+      defaultOutput.some(line => line.includes('ERR_ERL_UNEXPECTED_X_FORWARDED_FOR')),
+      'negative control should emit express-rate-limit X-Forwarded-For validation warning'
+    );
+
+    envManager.set('MCP_HTTP_TRUST_PROXY', 'true');
+
+    const trustedApp = await createHttpServer(() => createTestMcpServer());
+    const trustedOutput = await captureConsoleOutput(async () => {
+      await request(trustedApp)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('X-Forwarded-For', '203.0.113.10')
+        .send({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
+    });
+    assert.equal(trustedApp.get('trust proxy'), true);
+    assert.ok(
+      !trustedOutput.some(line => line.includes('ERR_ERL_UNEXPECTED_X_FORWARDED_FOR')),
+      'trusted proxy should suppress express-rate-limit X-Forwarded-For validation warning'
+    );
+
+    envManager.restore();
   }, results);
 
   await testFunction('Rate limiting: POST /mcp limit resets after window expires', async () => {

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -31,7 +31,13 @@ async function captureConsoleOutput(action: () => Promise<void>): Promise<string
   const capture = (...args: unknown[]) => {
     output.push(args.map(arg => {
       if (arg instanceof Error) {
-        return `${arg.name}: ${arg.message}`;
+        // Include `.code` explicitly: express-rate-limit logs a ValidationError
+        // whose code (e.g. ERR_ERL_UNEXPECTED_X_FORWARDED_FOR) lives on `.code`,
+        // so the assertion should not rely on it also appearing in `.message`.
+        const code = (arg as { code?: unknown }).code;
+        return code !== undefined
+          ? `${arg.name}[${String(code)}]: ${arg.message}`
+          : `${arg.name}: ${arg.message}`;
       }
       return String(arg);
     }).join(' '));

--- a/__tests__/unit/http-security.test.ts
+++ b/__tests__/unit/http-security.test.ts
@@ -21,11 +21,58 @@ async function runTests() {
     envManager.delete('MCP_HTTP_HARDEN');
     envManager.delete('MCP_HTTP_AUTH_TOKEN');
     envManager.delete('MCP_HTTP_ALLOWED_ORIGINS');
+    envManager.delete('MCP_HTTP_TRUST_PROXY');
 
     const config = getHttpSecurityConfig();
     assert.equal(config.harden, false);
     assert.equal(config.requireAuth, false);
     assert.equal(config.restrictOrigins, false);
+    assert.equal(config.trustProxy, false);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('MCP_HTTP_TRUST_PROXY=false keeps trust proxy disabled', () => {
+    envManager.set('MCP_HTTP_TRUST_PROXY', 'false');
+
+    const config = getHttpSecurityConfig();
+    assert.equal(config.trustProxy, false);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('MCP_HTTP_TRUST_PROXY=true enables boolean trust proxy', () => {
+    envManager.set('MCP_HTTP_TRUST_PROXY', 'true');
+
+    const config = getHttpSecurityConfig();
+    assert.equal(config.trustProxy, true);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('MCP_HTTP_TRUST_PROXY=1 enables single-hop trust proxy', () => {
+    envManager.set('MCP_HTTP_TRUST_PROXY', '1');
+
+    const config = getHttpSecurityConfig();
+    assert.equal(config.trustProxy, 1);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('MCP_HTTP_TRUST_PROXY subnet value passes through unchanged', () => {
+    envManager.set('MCP_HTTP_TRUST_PROXY', '10.0.0.0/8');
+
+    const config = getHttpSecurityConfig();
+    assert.equal(config.trustProxy, '10.0.0.0/8');
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('MCP_HTTP_TRUST_PROXY trims surrounding whitespace', () => {
+    envManager.set('MCP_HTTP_TRUST_PROXY', '  loopback  ');
+
+    const config = getHttpSecurityConfig();
+    assert.equal(config.trustProxy, 'loopback');
 
     envManager.restore();
   }, results);

--- a/__tests__/unit/http-security.test.ts
+++ b/__tests__/unit/http-security.test.ts
@@ -41,6 +41,15 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('MCP_HTTP_TRUST_PROXY=0 disables trust proxy (not a bogus subnet)', () => {
+    envManager.set('MCP_HTTP_TRUST_PROXY', '0');
+
+    const config = getHttpSecurityConfig();
+    assert.equal(config.trustProxy, false);
+
+    envManager.restore();
+  }, results);
+
   await testFunction('MCP_HTTP_TRUST_PROXY=true enables boolean trust proxy', () => {
     envManager.set('MCP_HTTP_TRUST_PROXY', 'true');
 

--- a/src/http-security.ts
+++ b/src/http-security.ts
@@ -6,6 +6,7 @@ export interface HttpSecurityConfig {
   allowedOrigins: string[];
   enableDnsRebindingProtection: boolean;
   allowedHosts: string[];
+  trustProxy: boolean | number | string;
   exposeFullConfig: boolean;
   allowPrivateUrls: boolean;
 }
@@ -19,6 +20,20 @@ function parseCsv(value: string | undefined): string[] {
     .split(",")
     .map((item) => item.trim())
     .filter(Boolean);
+}
+
+function parseTrustProxy(value: string | undefined): boolean | number | string {
+  const trimmed = value?.trim();
+  if (!trimmed || trimmed === "false") {
+    return false;
+  }
+  if (trimmed === "true") {
+    return true;
+  }
+  if (/^[1-9]\d*$/.test(trimmed)) {
+    return Number(trimmed);
+  }
+  return trimmed;
 }
 
 export function getHttpSecurityConfig(): HttpSecurityConfig {
@@ -35,6 +50,7 @@ export function getHttpSecurityConfig(): HttpSecurityConfig {
     allowedOrigins,
     enableDnsRebindingProtection: harden,
     allowedHosts: allowedHosts.length > 0 ? allowedHosts : ["127.0.0.1", "localhost"],
+    trustProxy: parseTrustProxy(process.env.MCP_HTTP_TRUST_PROXY),
     exposeFullConfig: isEnabled(process.env.MCP_HTTP_EXPOSE_FULL_CONFIG),
     allowPrivateUrls: isEnabled(process.env.MCP_HTTP_ALLOW_PRIVATE_URLS),
   };

--- a/src/http-security.ts
+++ b/src/http-security.ts
@@ -24,7 +24,9 @@ function parseCsv(value: string | undefined): string[] {
 
 function parseTrustProxy(value: string | undefined): boolean | number | string {
   const trimmed = value?.trim();
-  if (!trimmed || trimmed === "false") {
+  // Treat "0" as disabled (false): operators use 0 to turn numeric knobs off,
+  // and Express would otherwise mis-parse the string "0" as a bogus trust subnet.
+  if (!trimmed || trimmed === "false" || trimmed === "0") {
     return false;
   }
   if (trimmed === "true") {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -75,6 +75,9 @@ export async function createHttpServer(
   const app = express();
   const security = getHttpSecurityConfig();
   validateHttpSecurityConfig(security);
+  if (security.trustProxy !== false) {
+    app.set('trust proxy', security.trustProxy);
+  }
 
   app.use(express.json());
   


### PR DESCRIPTION
## TODO item

**FEAT-051** — Configurable Express `trust proxy` for HTTP mode behind a reverse proxy (🟠 High, from TODO-features.md)
Refs: https://github.com/ihor-sokoliuk/mcp-searxng/issues/132

## Context

In HTTP transport mode the Express app is created with `const app = express();` and never calls `app.set('trust proxy', …)`, so it keeps Express's default `trust proxy = false`. When deployed behind a reverse proxy / gateway / load balancer (Docker, Toolhive, nginx, Traefik), incoming requests carry `X-Forwarded-For`, and because we attach `express-rate-limit`, the library emits a repeated validation error on every request:

```
ValidationError: The 'X-Forwarded-For' header is set but the Express 'trust proxy'
setting is false (default). ... code: 'ERR_ERL_UNEXPECTED_X_FORWARDED_FOR'
```

Two real consequences: (1) log spam, and (2) rate limiting keys on `req.ip`, which with `trust proxy` off is the **proxy's** IP for every client — so all clients share one bucket and the rate-limit control becomes effectively global and inaccurate. Reported against v1.8.0 (issue #132); the only workaround today is switching that deployment to stdio mode.

## What changed

- **`src/http-security.ts`** — added `trustProxy: boolean | number | string` to `HttpSecurityConfig` and a `parseTrustProxy()` helper wired into `getHttpSecurityConfig()`. It reads `MCP_HTTP_TRUST_PROXY`: unset / empty / `"false"` → `false` (secure default); `"true"` → `true`; a positive-integer string (`^[1-9]\d*$`, e.g. `"1"`) → the hop-count number; any other non-empty string (e.g. `loopback`, `10.0.0.0/8`) → passed through trimmed. Housed in the security config alongside `MCP_HTTP_HARDEN`/auth rather than read inline, since it controls whose IP rate limiting and logging believe.
- **`src/http-server.ts`** — in `createHttpServer()`, apply `app.set('trust proxy', security.trustProxy)` right after the security config is loaded, guarded by `security.trustProxy !== false` so the default (`false`) path and all existing behavior are byte-identical.
- **`__tests__/unit/http-security.test.ts`** — parser coverage: unset→`false`, `false`→`false`, `true`→`true`, `1`→`1`, `10.0.0.0/8`→passthrough, and whitespace trimming.
- **`__tests__/integration/http-server.test.ts`** — Express-level behavior via supertest: default `app.get('trust proxy')` is `false`; `X-Forwarded-For` still returns 200 when unset; `true`/`1`/subnet resolve to the expected values; plus a rate-limit test with a **negative control** — unset + `X-Forwarded-For` emits `ERR_ERL_UNEXPECTED_X_FORWARDED_FOR`, and enabling trust proxy suppresses it (so the assertion can't pass trivially).
- **`CONFIGURATION.md`** — new `MCP_HTTP_TRUST_PROXY` row in the HTTP Transport table, an explanatory paragraph in the Rate Limiting section (client-IP interplay + distinction from outbound `HTTP_PROXY`/`HTTPS_PROXY`), and a Full Example entry.
- **`SECURITY.md`** — trust-proxy line in the Public/Internet-Facing recipe and a spoofing caveat (only enable behind a proxy that strips/sets `X-Forwarded-For`). Also fixes an adjacent doc bug: the default bind address is `127.0.0.1` (loopback), not `0.0.0.0`.
- **`README.md`** — brief reverse-proxy pointer to the new setting.

## How it was verified

Verified independently by the tech lead (not just the implementer), in a clean worktree outside any sandbox:

- `npm run build` — pass
- `npm test` — pass, 421/421
- `npm run test:coverage` — pass, 95.83% lines / 92% branches (gate: 90 / 85); `http-security.ts` 100% lines
- `npm run test:e2e` — pass, 2/2 (live suites skip; unchanged stdio transport)
- `npm run lint` — clean

## Documentation

- `CONFIGURATION.md`: documents `MCP_HTTP_TRUST_PROXY`, its rate-limit/client-IP effect, the outbound-proxy distinction, and a Full Example value.
- `SECURITY.md`: reverse-proxy deployment guidance + the `X-Forwarded-For` spoofing caveat; corrected default-bind-address statement.
- `README.md`: reverse-proxy pointer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
