### PR TITLE
feat(search): make non-JSON search-response error actionable (FEAT-053)

### DIFF
--- a/__tests__/unit/error-handler.test.ts
+++ b/__tests__/unit/error-handler.test.ts
@@ -98,7 +98,12 @@ async function runTests() {
   await testFunction('Specialized error creators', () => {
     const context = { searxngUrl: 'https://searx.example.com' };
     
-    assert.ok(createJSONError('invalid json') instanceof MCPSearXNGError);
+    const jsonError = createJSONError('invalid json');
+    assert.ok(jsonError instanceof MCPSearXNGError);
+    assert.ok(jsonError.message.includes('invalid json'));
+    assert.ok(jsonError.message.includes('- json'));
+    assert.ok(jsonError.message.includes('search.formats'));
+    assert.ok(jsonError.message.includes('SEARXNG_HTML_FALLBACK=true'));
     assert.ok(createDataError() instanceof MCPSearXNGError);
     assert.ok(createURLFormatError('invalid-url') instanceof MCPSearXNGError);
     assert.ok(createContentError('test error', 'https://example.com') instanceof MCPSearXNGError);

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -276,6 +276,18 @@ async function runTests() {
         error.message.includes('Invalid JSON response'),
         `expected response preview in error message, got: ${error.message}`
       );
+      assert.ok(
+        error.message.includes('- json'),
+        `expected SearXNG JSON format remediation in error message, got: ${error.message}`
+      );
+      assert.ok(
+        error.message.includes('search.formats'),
+        `expected SearXNG JSON format remediation in error message, got: ${error.message}`
+      );
+      assert.ok(
+        error.message.includes('SEARXNG_HTML_FALLBACK=true'),
+        `expected HTML fallback remediation in error message, got: ${error.message}`
+      );
     }
 
     fetchMocker.restore();

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -113,7 +113,7 @@ export function createServerError(status: number, statusText: string, responseBo
 
 export function createJSONError(responseText: string): MCPSearXNGError {
   const preview = responseText.substring(0, 100).replace(/\n/g, ' ');
-  return new MCPSearXNGError(`🔍 SearXNG Response Error: Invalid JSON format. Response: "${preview}..."`);
+  return new MCPSearXNGError(`🔍 SearXNG Response Error: Invalid JSON format. Response: "${preview}...". Enable - json under search.formats in your SearXNG settings.yml, or set SEARXNG_HTML_FALLBACK=true.`);
 }
 
 export function createDataError(): MCPSearXNGError {


### PR DESCRIPTION
## TODO item

**FEAT-053** — Make the non-JSON search-response error actionable (name the `format:json` / `SEARXNG_HTML_FALLBACK` fixes) (🟡 Medium, from TODO-features.md)
Refs: https://github.com/ihor-sokoliuk/mcp-searxng/issues/137

## Context

When a SearXNG instance answers a search with a `200` whose body is not JSON — a Cloudflare/WAF interstitial, an HTML error page, or a normal HTML results page because the operator never enabled `format: json` — the search path falls into the `JSON.parse` catch and, when `SEARXNG_HTML_FALLBACK` is off, throws `createJSONError`. The old message was just:

```
🔍 SearXNG Response Error: Invalid JSON format. Response: "<100-char preview>..."
```

with no remediation, so the caller hit an opaque wall even though two documented fixes exist: enable `format: json` on the instance, or set `SEARXNG_HTML_FALLBACK=true`. Neither was named where the user actually fails. Reported in #137.

## What changed

- **`src/error-handler.ts`** — `createJSONError(responseText)` keeps the existing `🔍 SearXNG Response Error: Invalid JSON format.` prefix and the 100-char body preview, then appends one concise remediation sentence naming **both** fixes: enable `- json` under `search.formats` in `settings.yml`, or set `SEARXNG_HTML_FALLBACK=true`. This is the only live throw site (`src/search.ts:508`, the fallback-off branch of the JSON.parse catch), so the hint is correct wherever it appears; `search.ts` itself is unchanged.
- **`__tests__/unit/error-handler.test.ts`** — strengthened the `createJSONError` assertion from a bare `instanceof` check to verifying the preview plus all three remediation tokens (`- json`, `search.formats`, `SEARXNG_HTML_FALLBACK=true`).
- **`__tests__/unit/search.test.ts`** — extended the fallback-off non-JSON regression (which drives the real `performWebSearch` → `createJSONError` path) to assert the remediation text alongside the existing body-preview assertion.

Scope is intentionally message-only (the issue-author-endorsed minimal fix); the optional `Content-Type` pre-check and the one-retry-on-`SyntaxError` were deliberately left out.

## How it was verified

- `npm run build` — pass
- `npm test` — **422/422 pass**
- `npm run test:e2e` — **2/2 pass** (live suites skip without `SEARXNG_LIVE_URL`; this is an internal error-string change, not live-observable)
- `npm run lint` — clean

(verified independently by the tech lead in a clean worktree, not just by the implementer)

## Documentation

No documentation changes. Both fixes are already documented — README Troubleshooting (`### 403 Forbidden`, `### Can't enable JSON? (HTML fallback)`) and CONFIGURATION.md (`SEARXNG_HTML_FALLBACK`, Search Compatibility). The user-visible update here is the inline error text itself, which now points at that existing guidance.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
