### PR TITLE
docs(configuration): document NODE_EXTRA_CA_CERTS for Windows/corporate-proxy TLS (FEAT-054)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -84,6 +84,39 @@ Interface-specific proxies take priority over global proxies for their respectiv
 | `URL_READER_HTTP_PROXY` / `URL_READER_HTTPS_PROXY` | No | — | Proxy for `web_url_read` only |
 | `NO_PROXY` | No | — | Comma-separated bypass list (e.g. `localhost,.internal,example.com`) |
 
+## TLS / Corporate CA
+
+Proxy variables route traffic through a proxy. Corporate TLS inspection is a separate trust problem: the proxy re-signs upstream certificates, so Node.js must trust the proxy's root CA.
+
+On Linux and macOS, `mcp-searxng` auto-detects the first readable system CA bundle from these paths:
+
+- `/etc/ssl/certs/ca-certificates.crt` — Debian/Ubuntu/WSL2
+- `/etc/pki/tls/certs/ca-bundle.crt` — RHEL/CentOS/Fedora
+- `/etc/ssl/ca-bundle.pem` — OpenSUSE
+- `/etc/ssl/cert.pem` — Alpine, macOS
+
+If your deployment needs an additional corporate CA, set the standard Node.js `NODE_EXTRA_CA_CERTS` environment variable to a PEM file. This is a Node.js TLS setting, not an `mcp-searxng` configuration variable.
+
+Windows has no universal CA bundle file path, so system CA auto-detection is skipped. If you are behind a TLS-inspecting corporate proxy (for example Zscaler, Netskope, Palo Alto, or Blue Coat) and see errors such as `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` or `self signed certificate in certificate chain`, export the proxy root CA to PEM and point `NODE_EXTRA_CA_CERTS` at it.
+
+```powershell
+# Export from Windows cert store (adjust the subject match to your proxy CA):
+$cert = Get-ChildItem Cert:\LocalMachine\Root | Where-Object { $_.Subject -match "YourCorp" } | Select-Object -First 1
+[System.IO.File]::WriteAllBytes("$env:USERPROFILE\corp-ca.cer", $cert.RawData)
+certutil -encode "$env:USERPROFILE\corp-ca.cer" "$env:USERPROFILE\corp-ca.pem"
+```
+
+Example MCP client environment block:
+
+```json
+"env": {
+  "SEARXNG_URL": "https://searxng.example.com",
+  "NODE_EXTRA_CA_CERTS": "C:\\Users\\you\\corp-ca.pem"
+}
+```
+
+Never set `NODE_TLS_REJECT_UNAUTHORIZED=0`. It disables all TLS certificate validation for the Node.js process and makes HTTPS connections vulnerable to interception.
+
 ## HTTP Transport
 
 By default the server communicates over STDIO. Set `MCP_HTTP_PORT` to enable HTTP mode instead.

--- a/README.md
+++ b/README.md
@@ -264,6 +264,8 @@ Full environment variable reference: [CONFIGURATION.md](CONFIGURATION.md)
 
 ## Troubleshooting
 
+If HTTPS requests fail behind a TLS-inspecting corporate proxy with certificate errors, see [TLS / Corporate CA](CONFIGURATION.md#tls--corporate-ca).
+
 ### 403 Forbidden from SearXNG
 
 Your SearXNG instance likely has JSON format disabled. Edit `settings.yml` (usually `/etc/searxng/settings.yml`):


### PR DESCRIPTION
## TODO item

**FEAT-054** — Document `NODE_EXTRA_CA_CERTS` for Windows / corporate-proxy TLS (🟢 Low, from TODO-features.md)
Refs: https://github.com/ihor-sokoliuk/mcp-searxng/issues/138

## Context

`getSystemCACerts` (`src/tls-config.ts`) auto-loads the system CA bundle on Linux/macOS from well-known paths, but returns `null` on Windows because there is no universal bundle path. A source comment tells developers to set `NODE_EXTRA_CA_CERTS`, but that guidance was **not** in `CONFIGURATION.md` or `README.md`. Windows users behind a TLS-inspecting corporate proxy (Zscaler, Netskope, Palo Alto, Blue Coat) hit `UNABLE_TO_GET_ISSUER_CERT_LOCALLY` / `self signed certificate in certificate chain` with no documented remedy, and often reach for the insecure `NODE_TLS_REJECT_UNAUTHORIZED=0` foot-gun instead. Reported in #138.

## What changed (docs only — no code)

- **`CONFIGURATION.md`** — new `## TLS / Corporate CA` section (between Proxy and HTTP Transport) that:
  - distinguishes proxy *routing* from proxy *TLS trust*;
  - lists the exact Linux/macOS CA bundle paths that are auto-detected (mirroring `src/tls-config.ts`);
  - frames `NODE_EXTRA_CA_CERTS` as a standard **Node.js** env var (not an mcp-searxng-parsed option), with the Windows PEM-export PowerShell steps and an MCP-client env example;
  - warns explicitly that `NODE_TLS_REJECT_UNAUTHORIZED=0` disables all TLS validation.
- **`README.md`** — a Troubleshooting cross-link to the new section (`CONFIGURATION.md#tls--corporate-ca`).

No new environment variable is introduced or parsed; `NODE_EXTRA_CA_CERTS` is already honored by Node/undici. Pure documentation.

## How it was verified

- `npm run build` — pass
- `npm test` — **439/439 pass** (unchanged; no code touched)
- `npm run lint` — clean
- Anchor check: the README link `CONFIGURATION.md#tls--corporate-ca` resolves to the new `## TLS / Corporate CA` heading (GitHub slug verified).

(verified independently by the tech lead in a clean worktree)

## Documentation

This PR *is* the documentation change — see the two files above. `SECURITY.md` unchanged (the guidance steers users away from the insecure TLS-off workaround, which is a net security improvement, but introduces no new attack surface to model).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
