### PR TITLE
fix(tests): make cache TTL tests deterministic to fix wall-clock flake (BUG-011)

### DIFF
--- a/__tests__/unit/cache.test.ts
+++ b/__tests__/unit/cache.test.ts
@@ -13,6 +13,32 @@ import { testFunction, createTestResults, printTestSummary } from '../helpers/te
 
 const results = createTestResults();
 
+/**
+ * Run `fn` with a controllable clock: `Date.now()` returns a value the test
+ * moves forward via `advance(ms)`, and the real `Date.now` is ALWAYS restored
+ * afterward — even if `fn` (including cache construction) throws — so a failure
+ * can never leak a patched clock into later tests.
+ *
+ * This is the deterministic, instant replacement for real `setTimeout` sleeps
+ * when asserting TTL expiry. `SimpleCache` decides expiry via `Date.now()`
+ * (src/cache.ts), and `setTimeout` (timer clock) vs `Date.now()` (wall clock)
+ * are not guaranteed to advance in lockstep — notably on WSL2, where the wall
+ * clock drifts/resyncs — which is what made the sleep-based versions flaky
+ * (BUG-011).
+ */
+async function withControlledClock(
+  fn: (advance: (ms: number) => void) => void | Promise<void>,
+): Promise<void> {
+  const realNow = Date.now;
+  let now = realNow();
+  Date.now = () => now;
+  try {
+    await fn((ms) => { now += ms; });
+  } finally {
+    Date.now = realNow;
+  }
+}
+
 async function runTests() {
   console.log('🧪 Testing: cache.ts\n');
 
@@ -49,16 +75,10 @@ async function runTests() {
     testCache.destroy();
   }, results);
 
-  await testFunction('Cache TTL expiration', () => {
-    // Drive expiry with a controlled clock instead of sleeping real time:
-    // get() decides expiry via Date.now() (src/cache.ts), and setTimeout vs
-    // Date.now() are not guaranteed to advance in lockstep (notably on WSL2),
-    // which made the wall-clock version flaky. This is deterministic and instant.
-    const realNow = Date.now;
-    let now = realNow();
-    Date.now = () => now;
+  await testFunction('Cache TTL expiration', () => withControlledClock((advance) => {
+    let testCache: SimpleCache | undefined;
     try {
-      const testCache = new SimpleCache(50); // 50ms TTL
+      testCache = new SimpleCache(50); // 50ms TTL
 
       testCache.set('short-lived', '<html>test</html>', '# Test');
 
@@ -66,45 +86,39 @@ async function runTests() {
       assert.ok(testCache.get('short-lived'));
 
       // Advance past the TTL
-      now += 51;
+      advance(51);
 
       // Should be expired
       assert.equal(testCache.get('short-lived'), null);
-
-      testCache.destroy();
     } finally {
-      Date.now = realNow;
+      testCache?.destroy();
     }
-  }, results);
+  }), results);
 
-  await testFunction('Cache uses CACHE_TTL_MS when constructed without explicit TTL', () => {
+  await testFunction('Cache uses CACHE_TTL_MS when constructed without explicit TTL', () => withControlledClock((advance) => {
     const previousTtl = process.env.CACHE_TTL_MS;
-    process.env.CACHE_TTL_MS = '1000';
-    // Controlled clock (see 'Cache TTL expiration') — deterministic, no real sleep.
-    const realNow = Date.now;
-    let now = realNow();
-    Date.now = () => now;
-    const testCache = new SimpleCache();
-
+    let testCache: SimpleCache | undefined;
     try {
+      process.env.CACHE_TTL_MS = '1000';
+      testCache = new SimpleCache();
+
       testCache.set('env-ttl', '<html>test</html>', '# Test');
 
       assert.ok(testCache.get('env-ttl'));
 
       // Advance past the env-configured 1000ms TTL
-      now += 1001;
+      advance(1001);
 
       assert.equal(testCache.get('env-ttl'), null);
     } finally {
-      Date.now = realNow;
-      testCache.destroy();
+      testCache?.destroy();
       if (previousTtl === undefined) {
         delete process.env.CACHE_TTL_MS;
       } else {
         process.env.CACHE_TTL_MS = previousTtl;
       }
     }
-  }, results);
+  }), results);
 
   await testFunction('Cache falls back to defaults for invalid CACHE_TTL_MS and CACHE_MAX_ENTRIES', () => {
     const previousTtl = process.env.CACHE_TTL_MS;
@@ -186,13 +200,10 @@ async function runTests() {
     testCache.destroy();
   }, results);
 
-  await testFunction('Cache purges expired entries before LFU eviction', () => {
-    // Controlled clock (see 'Cache TTL expiration') — deterministic, no real sleep.
-    const realNow = Date.now;
-    let now = realNow();
-    Date.now = () => now;
+  await testFunction('Cache purges expired entries before LFU eviction', () => withControlledClock((advance) => {
+    let testCache: SimpleCache | undefined;
     try {
-      const testCache = new SimpleCache(50, 2, 1000);
+      testCache = new SimpleCache(50, 2, 1000);
 
       testCache.set('expired-popular-url', '<html>expired</html>', '# Expired');
       for (let i = 0; i < 5; i++) {
@@ -200,7 +211,7 @@ async function runTests() {
       }
 
       // Advance past the 50ms TTL so the popular entry is now expired
-      now += 51;
+      advance(51);
 
       testCache.set('fresh-url', '<html>fresh</html>', '# Fresh');
       testCache.set('new-url', '<html>new</html>', '# New');
@@ -209,12 +220,10 @@ async function runTests() {
       assert.ok(testCache.get('fresh-url'), 'Expected fresh URL to remain cached');
       assert.ok(testCache.get('new-url'), 'Expected new URL to remain cached');
       assert.equal(testCache.getStats().size, 2);
-
-      testCache.destroy();
     } finally {
-      Date.now = realNow;
+      testCache?.destroy();
     }
-  }, results);
+  }), results);
 
   await testFunction('Cache normalizes invalid cleanup interval to default', () => {
     const testCache = new SimpleCache(1000, 500, Number.NaN);
@@ -266,55 +275,46 @@ async function runTests() {
     urlCache.clear();
   }, results);
 
-  await testFunction('Cache get() returns null after TTL expiry', () => {
-    // Controlled clock (see 'Cache TTL expiration') — deterministic, no real sleep.
-    const realNow = Date.now;
-    let now = realNow();
-    Date.now = () => now;
+  await testFunction('Cache get() returns null after TTL expiry', () => withControlledClock((advance) => {
+    let testCache: SimpleCache | undefined;
     try {
-      const testCache = new SimpleCache(50); // 50ms TTL
+      testCache = new SimpleCache(50); // 50ms TTL
 
       testCache.set('cleanup-test', '<html>test</html>', '# Test');
 
       // Advance past the TTL
-      now += 51;
+      advance(51);
 
       assert.equal(testCache.get('cleanup-test'), null);
-
-      testCache.destroy();
     } finally {
-      Date.now = realNow;
+      testCache?.destroy();
     }
-  }, results);
+  }), results);
 
-  await testFunction('Cache cleanup interval removes expired entries', async () => {
-    // The expiry decision is deterministic via a controlled clock; only the 1ms
+  await testFunction('Cache cleanup interval removes expired entries', () => withControlledClock(async (advance) => {
+    // The expiry decision is deterministic via the controlled clock; only the 1ms
     // interval *firing* needs real time (a scheduler dependency, not the flaky
     // wall-clock-vs-timer one). Assert via getStats() — which does NOT lazily
     // expire — so this verifies the background interval purged the entry rather
     // than get()'s own expiry check.
-    const realNow = Date.now;
-    let now = realNow();
-    Date.now = () => now;
+    let testCache: SimpleCache | undefined;
     try {
-      const testCache = new SimpleCache(50, 500, 1); // 50ms TTL, 1ms cleanup interval
+      testCache = new SimpleCache(50, 500, 1); // 50ms TTL, 1ms cleanup interval
 
       testCache.set('cleanup-target', '<html>test</html>', '# Test');
       assert.equal(testCache.getStats().size, 1);
 
       // Logically expire the entry, then let the 1ms interval fire and purge it.
-      now += 51;
+      advance(51);
       for (let i = 0; i < 100 && testCache.getStats().size > 0; i++) {
         await new Promise(resolve => setTimeout(resolve, 5));
       }
 
       assert.equal(testCache.getStats().size, 0, 'Expected cleanup interval to purge the expired entry');
-
-      testCache.destroy();
     } finally {
-      Date.now = realNow;
+      testCache?.destroy();
     }
-  }, results);
+  }), results);
 
   await testFunction('Cache cleanup interval does not keep process alive', () => {
     const testCache = new SimpleCache(1000, 500, 1000);

--- a/__tests__/unit/cache.test.ts
+++ b/__tests__/unit/cache.test.ts
@@ -49,26 +49,41 @@ async function runTests() {
     testCache.destroy();
   }, results);
 
-  await testFunction('Cache TTL expiration', async () => {
-    const testCache = new SimpleCache(50); // 50ms TTL
+  await testFunction('Cache TTL expiration', () => {
+    // Drive expiry with a controlled clock instead of sleeping real time:
+    // get() decides expiry via Date.now() (src/cache.ts), and setTimeout vs
+    // Date.now() are not guaranteed to advance in lockstep (notably on WSL2),
+    // which made the wall-clock version flaky. This is deterministic and instant.
+    const realNow = Date.now;
+    let now = realNow();
+    Date.now = () => now;
+    try {
+      const testCache = new SimpleCache(50); // 50ms TTL
 
-    testCache.set('short-lived', '<html>test</html>', '# Test');
+      testCache.set('short-lived', '<html>test</html>', '# Test');
 
-    // Should exist immediately
-    assert.ok(testCache.get('short-lived'));
+      // Should exist immediately
+      assert.ok(testCache.get('short-lived'));
 
-    // Wait for expiration
-    await new Promise(resolve => setTimeout(resolve, 100));
+      // Advance past the TTL
+      now += 51;
 
-    // Should be expired
-    assert.equal(testCache.get('short-lived'), null);
+      // Should be expired
+      assert.equal(testCache.get('short-lived'), null);
 
-    testCache.destroy();
+      testCache.destroy();
+    } finally {
+      Date.now = realNow;
+    }
   }, results);
 
-  await testFunction('Cache uses CACHE_TTL_MS when constructed without explicit TTL', async () => {
+  await testFunction('Cache uses CACHE_TTL_MS when constructed without explicit TTL', () => {
     const previousTtl = process.env.CACHE_TTL_MS;
     process.env.CACHE_TTL_MS = '1000';
+    // Controlled clock (see 'Cache TTL expiration') — deterministic, no real sleep.
+    const realNow = Date.now;
+    let now = realNow();
+    Date.now = () => now;
     const testCache = new SimpleCache();
 
     try {
@@ -76,10 +91,12 @@ async function runTests() {
 
       assert.ok(testCache.get('env-ttl'));
 
-      await new Promise(resolve => setTimeout(resolve, 1050));
+      // Advance past the env-configured 1000ms TTL
+      now += 1001;
 
       assert.equal(testCache.get('env-ttl'), null);
     } finally {
+      Date.now = realNow;
       testCache.destroy();
       if (previousTtl === undefined) {
         delete process.env.CACHE_TTL_MS;
@@ -169,25 +186,34 @@ async function runTests() {
     testCache.destroy();
   }, results);
 
-  await testFunction('Cache purges expired entries before LFU eviction', async () => {
-    const testCache = new SimpleCache(50, 2, 1000);
+  await testFunction('Cache purges expired entries before LFU eviction', () => {
+    // Controlled clock (see 'Cache TTL expiration') — deterministic, no real sleep.
+    const realNow = Date.now;
+    let now = realNow();
+    Date.now = () => now;
+    try {
+      const testCache = new SimpleCache(50, 2, 1000);
 
-    testCache.set('expired-popular-url', '<html>expired</html>', '# Expired');
-    for (let i = 0; i < 5; i++) {
-      assert.ok(testCache.get('expired-popular-url'));
+      testCache.set('expired-popular-url', '<html>expired</html>', '# Expired');
+      for (let i = 0; i < 5; i++) {
+        assert.ok(testCache.get('expired-popular-url'));
+      }
+
+      // Advance past the 50ms TTL so the popular entry is now expired
+      now += 51;
+
+      testCache.set('fresh-url', '<html>fresh</html>', '# Fresh');
+      testCache.set('new-url', '<html>new</html>', '# New');
+
+      assert.equal(testCache.get('expired-popular-url'), null, 'Expected expired popular URL to be purged');
+      assert.ok(testCache.get('fresh-url'), 'Expected fresh URL to remain cached');
+      assert.ok(testCache.get('new-url'), 'Expected new URL to remain cached');
+      assert.equal(testCache.getStats().size, 2);
+
+      testCache.destroy();
+    } finally {
+      Date.now = realNow;
     }
-
-    await new Promise(resolve => setTimeout(resolve, 80));
-
-    testCache.set('fresh-url', '<html>fresh</html>', '# Fresh');
-    testCache.set('new-url', '<html>new</html>', '# New');
-
-    assert.equal(testCache.get('expired-popular-url'), null, 'Expected expired popular URL to be purged');
-    assert.ok(testCache.get('fresh-url'), 'Expected fresh URL to remain cached');
-    assert.ok(testCache.get('new-url'), 'Expected new URL to remain cached');
-    assert.equal(testCache.getStats().size, 2);
-
-    testCache.destroy();
   }, results);
 
   await testFunction('Cache normalizes invalid cleanup interval to default', () => {
@@ -240,36 +266,54 @@ async function runTests() {
     urlCache.clear();
   }, results);
 
-  await testFunction('Cache get() returns null after TTL expiry', async () => {
-    const testCache = new SimpleCache(50); // 50ms TTL
+  await testFunction('Cache get() returns null after TTL expiry', () => {
+    // Controlled clock (see 'Cache TTL expiration') — deterministic, no real sleep.
+    const realNow = Date.now;
+    let now = realNow();
+    Date.now = () => now;
+    try {
+      const testCache = new SimpleCache(50); // 50ms TTL
 
-    testCache.set('cleanup-test', '<html>test</html>', '# Test');
+      testCache.set('cleanup-test', '<html>test</html>', '# Test');
 
-    // Wait for cleanup to run
-    await new Promise(resolve => setTimeout(resolve, 150));
+      // Advance past the TTL
+      now += 51;
 
-    // Entry should be cleaned up
-    assert.equal(testCache.get('cleanup-test'), null);
+      assert.equal(testCache.get('cleanup-test'), null);
 
-    testCache.destroy();
+      testCache.destroy();
+    } finally {
+      Date.now = realNow;
+    }
   }, results);
 
   await testFunction('Cache cleanup interval removes expired entries', async () => {
-    // Use 50ms TTL and 1ms cleanup interval so the interval fires quickly
-    const testCache = new SimpleCache(50, 500, 1);
+    // The expiry decision is deterministic via a controlled clock; only the 1ms
+    // interval *firing* needs real time (a scheduler dependency, not the flaky
+    // wall-clock-vs-timer one). Assert via getStats() — which does NOT lazily
+    // expire — so this verifies the background interval purged the entry rather
+    // than get()'s own expiry check.
+    const realNow = Date.now;
+    let now = realNow();
+    Date.now = () => now;
+    try {
+      const testCache = new SimpleCache(50, 500, 1); // 50ms TTL, 1ms cleanup interval
 
-    testCache.set('cleanup-target', '<html>test</html>', '# Test');
+      testCache.set('cleanup-target', '<html>test</html>', '# Test');
+      assert.equal(testCache.getStats().size, 1);
 
-    // Confirm entry exists immediately
-    assert.ok(testCache.get('cleanup-target'));
+      // Logically expire the entry, then let the 1ms interval fire and purge it.
+      now += 51;
+      for (let i = 0; i < 100 && testCache.getStats().size > 0; i++) {
+        await new Promise(resolve => setTimeout(resolve, 5));
+      }
 
-    // Wait for TTL to expire (50ms) + a few cleanup ticks (5ms buffer)
-    await new Promise(resolve => setTimeout(resolve, 80));
+      assert.equal(testCache.getStats().size, 0, 'Expected cleanup interval to purge the expired entry');
 
-    // Cleanup interval has fired and should have removed the expired entry
-    assert.equal(testCache.get('cleanup-target'), null);
-
-    testCache.destroy();
+      testCache.destroy();
+    } finally {
+      Date.now = realNow;
+    }
   }, results);
 
   await testFunction('Cache cleanup interval does not keep process alive', () => {


### PR DESCRIPTION
## TODO item

**BUG-011** — Flaky cache TTL tests: wall-clock-dependent expiry assertions with a razor-thin margin (🟡 Medium, from TODO-bugs.md)
Surfaced during PR #145 review.

## Context

`__tests__/unit/cache.test.ts` intermittently failed in the full suite (`npm run test:coverage`) — observed ~1 in 6 runs — while passing in isolation. The `Cache uses CACHE_TTL_MS…` test set a **1000ms** TTL, slept `setTimeout(…, 1050)`, then asserted the entry had expired; on failure it got a live entry back.

Root cause is **wall-clock dependence with a ~50ms (5%) margin**, not cross-test leakage. `SimpleCache.get()` decides expiry via `Date.now() - entry.timestamp > ttlMs` (`src/cache.ts:91`), but the tests drove that by sleeping on a `setTimeout` timer. `setTimeout` (timer clock) and `Date.now()` (wall clock) are not guaranteed to advance in lockstep — on **WSL2** (this dev/CI environment) the wall clock drifts and periodically resyncs, and any divergence past the 50ms slack flips the comparison. Ruled out leakage: `cache.test.ts` runs 3rd in `run-all.ts`, the suite has no `Date`/timer mocks, and the test self-isolates with `try/finally`.

## What changed

`__tests__/unit/cache.test.ts` only — no production code.

Five tests asserted TTL expiry by sleeping real time; all now drive expiry with a **controlled clock** (`const realNow = Date.now; Date.now = () => now; … now += ttl + 1; … finally { Date.now = realNow }`) instead of `await setTimeout`:

- `Cache TTL expiration`
- `Cache uses CACHE_TTL_MS when constructed without explicit TTL`
- `Cache purges expired entries before LFU eviction`
- `Cache get() returns null after TTL expiry`
- `Cache cleanup interval removes expired entries` — expiry made deterministic via the controlled clock; the 1ms interval still fires on a short real wait, and the assertion now uses `getStats().size` (which does **not** lazily expire) so it genuinely verifies the background interval purged the entry rather than `get()`'s own check.

This eliminates the flake class, is robust to any clock/scheduler jitter, and drops ~1.1s of real sleeping from the suite.

## How it was verified

- `npm run build` — pass
- `npm run test:coverage` — **20/20 consecutive full-suite runs green** (was ~1 in 6 failing); coverage 95.94% lines / 92.09% branches (≥ 90/85 gate, unchanged)
- `npm run test:e2e` — 2/2 local (live suites skip without `SEARXNG_LIVE_URL`)
- `npm run lint` — clean
- `cache.test.ts` in isolation — 16/16, 3× consecutive

## Documentation

None — test-only change with no user-visible behavior, parameter, or env var.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
