### PR TITLE
fix(tls+auth): honor NODE_EXTRA_CA_CERTS; apply Basic auth to /config and autocompleter

### DIFF
--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -441,6 +441,55 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('/config request includes Basic Auth header when credentials are set', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('AUTH_USERNAME', 'testuser');
+    envManager.set('AUTH_PASSWORD', 'testpass');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: makeConfig() })(url, options);
+    });
+
+    await fetchInstanceInfo(mockServer as any);
+
+    const options = getCapturedOptions();
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    assert.ok(headers['Authorization'], 'expected Authorization header on /config request');
+    assert.ok(headers['Authorization'].startsWith('Basic '), 'expected Basic auth scheme');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('/config request omits Authorization header when credentials are not set', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: makeConfig() })(url, options);
+    });
+
+    await fetchInstanceInfo(mockServer as any);
+
+    const options = getCapturedOptions();
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    assert.equal(headers['Authorization'], undefined, 'Authorization header should be absent without credentials');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   printTestSummary(results, 'Instance Info Module');
   return results;
 }

--- a/__tests__/unit/suggestions.test.ts
+++ b/__tests__/unit/suggestions.test.ts
@@ -170,6 +170,53 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('/autocompleter request includes Basic Auth header when credentials are set', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('AUTH_USERNAME', 'testuser');
+    envManager.set('AUTH_PASSWORD', 'testpass');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: ['type', ['typescript']] })(url, options);
+    });
+
+    await performSearchSuggestions(mockServer as any, 'type');
+
+    const options = getCapturedOptions();
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    assert.ok(headers['Authorization'], 'expected Authorization header on /autocompleter request');
+    assert.ok(headers['Authorization'].startsWith('Basic '), 'expected Basic auth scheme');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('/autocompleter request omits Authorization header when credentials are not set', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: ['type', ['typescript']] })(url, options);
+    });
+
+    await performSearchSuggestions(mockServer as any, 'type');
+
+    const options = getCapturedOptions();
+    const headers = (options?.headers ?? {}) as Record<string, string>;
+    assert.equal(headers['Authorization'], undefined, 'Authorization header should be absent without credentials');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   printTestSummary(results, 'Suggestions Module');
   return results;
 }

--- a/__tests__/unit/tls-config.test.ts
+++ b/__tests__/unit/tls-config.test.ts
@@ -29,9 +29,14 @@ async function runTests() {
     assert.ok(certs === null || typeof certs === 'string');
   }, results);
 
-  await testFunction('getSystemCACerts returns null on Windows, string-or-null elsewhere', () => {
+  await testFunction('getSystemCACerts returns null on Windows unless NODE_EXTRA_CA_CERTS is set', () => {
     if (process.platform === 'win32') {
-      assert.equal(getSystemCACerts(), null);
+      const certs = getSystemCACerts();
+      if (process.env.NODE_EXTRA_CA_CERTS) {
+        assert.ok(typeof certs === 'string' && certs.length > 0, 'extra CA should be returned on Windows when NODE_EXTRA_CA_CERTS is set');
+      } else {
+        assert.equal(certs, null);
+      }
     } else {
       const certs = getSystemCACerts();
       assert.ok(certs === null || (typeof certs === 'string' && certs.length > 0));
@@ -66,16 +71,30 @@ async function runTests() {
 
   // --- Injected dependencies: deterministic branch coverage ---
 
-  await testFunction('getSystemCACerts returns null on win32 without touching the filesystem', () => {
+  await testFunction('getSystemCACerts returns null on win32 when no extra CA is configured', () => {
     let touched = false;
     const certs = getSystemCACerts({
       platformName: 'win32',
       fileExists: () => { touched = true; return true; },
       readFile: () => { touched = true; return PEM; },
       caPaths: ['/should/not/be/read'],
+      extraCaPath: null,
     });
     assert.equal(certs, null);
-    assert.equal(touched, false, 'win32 short-circuits before any fs access');
+    assert.equal(touched, false, 'win32 skips system bundle discovery and only reads the extra CA path');
+  }, results);
+
+  await testFunction('getSystemCACerts honors NODE_EXTRA_CA_CERTS on win32 (skips system bundle loop)', () => {
+    const reads: string[] = [];
+    const certs = getSystemCACerts({
+      platformName: 'win32',
+      fileExists: () => { throw new Error('system bundle path should not be probed on win32'); },
+      readFile: (p) => { reads.push(p); return PEM; },
+      caPaths: ['/should/not/be/read'],
+      extraCaPath: '/opt/extra.pem',
+    });
+    assert.equal(certs, PEM, 'win32 returns the extra CA bundle');
+    assert.deepEqual(reads, ['/opt/extra.pem'], 'only the extra CA path is read on win32');
   }, results);
 
   await testFunction('getSystemCACerts returns the first readable bundle', () => {

--- a/__tests__/unit/tls-config.test.ts
+++ b/__tests__/unit/tls-config.test.ts
@@ -85,6 +85,7 @@ async function runTests() {
       fileExists: () => true,
       readFile: (p) => { reads.push(p); return PEM; },
       caPaths: ['/etc/ssl/first.crt', '/etc/ssl/second.crt'],
+      extraCaPath: null,
     });
     assert.equal(certs, PEM);
     assert.deepEqual(reads, ['/etc/ssl/first.crt'], 'stops at the first readable bundle');
@@ -101,6 +102,7 @@ async function runTests() {
         return PEM;
       },
       caPaths: ['/etc/ssl/locked.crt', '/etc/ssl/readable.crt'],
+      extraCaPath: null,
     });
     assert.equal(certs, PEM, 'falls through the unreadable path to the readable one');
   }, results);
@@ -131,6 +133,7 @@ async function runTests() {
       fileExists: () => true,
       readFile: () => PEM,
       caPaths: ['/etc/ssl/found.crt'],
+      extraCaPath: null,
     });
     assert.deepEqual(opts, { ca: PEM });
   }, results);
@@ -140,8 +143,36 @@ async function runTests() {
       platformName: 'linux',
       fileExists: () => false,
       caPaths: ['/nope.crt'],
+      extraCaPath: null,
     });
     assert.deepEqual(opts, {});
+  }, results);
+
+  await testFunction('getSystemCACerts merges extra CA bundle into system bundle', () => {
+    const certs = getSystemCACerts({
+      platformName: 'linux',
+      fileExists: () => true,
+      readFile: () => PEM,
+      caPaths: ['/etc/ssl/found.crt'],
+      extraCaPath: '/opt/extra.pem',
+    });
+    assert.equal(certs, PEM + '\n' + PEM, 'system bundle and extra bundle are joined with a newline');
+  }, results);
+
+  await testFunction('getSystemCACerts silently ignores an unreadable extra CA path', () => {
+    const certs = getSystemCACerts({
+      platformName: 'linux',
+      fileExists: () => true,
+      readFile: (p) => {
+        if (p === '/opt/locked-extra.pem') {
+          throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+        }
+        return PEM;
+      },
+      caPaths: ['/etc/ssl/found.crt'],
+      extraCaPath: '/opt/locked-extra.pem',
+    });
+    assert.equal(certs, PEM, 'unreadable extra path is silently dropped');
   }, results);
 
   printTestSummary(results, 'TLS Config Module');

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,24 @@
+/**
+ * Build HTTP headers carrying SearXNG Basic auth credentials from the
+ * environment (`AUTH_USERNAME` / `AUTH_PASSWORD`).
+ *
+ * Returns an object with a single `Authorization: Basic ...` header when both
+ * env vars are set, or an empty object otherwise — callers can spread it into
+ * their existing `headers` object without conditionals.
+ *
+ * Shared by `/search`, `/config` (capability discovery) and `/autocompleter`
+ * (suggestions) so auth-gated SearXNG instances don't 401 on the non-search
+ * endpoints. `web_url_read` deliberately does NOT use this — it fetches
+ * arbitrary URLs.
+ */
+export function buildSearxngAuthHeaders(): Record<string, string> {
+  const username = process.env.AUTH_USERNAME;
+  const password = process.env.AUTH_PASSWORD;
+
+  if (username && password) {
+    const base64Auth = Buffer.from(`${username}:${password}`).toString("base64");
+    return { Authorization: `Basic ${base64Auth}` };
+  }
+
+  return {};
+}

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -266,6 +266,15 @@ async function requestInstanceConfig(mcpServer: McpServer, base: string): Promis
     const requestOptions: RequestInit = {
       signal: AbortSignal.timeout(5000),
     };
+    const username = process.env.AUTH_USERNAME;
+    const password = process.env.AUTH_PASSWORD;
+    if (username && password) {
+      const base64Auth = Buffer.from(`${username}:${password}`).toString("base64");
+      requestOptions.headers = {
+        ...(requestOptions.headers as Record<string, string> | undefined),
+        Authorization: `Basic ${base64Auth}`,
+      };
+    }
     const proxyAgent = createProxyAgent(url.toString(), ProxyType.SEARCH);
     const dispatcher = proxyAgent ?? createDefaultAgent();
     if (dispatcher) {

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { buildSearxngAuthHeaders } from "./auth.js";
 import { logMessage } from "./logging.js";
 import { createDefaultAgent, createProxyAgent, ProxyType } from "./proxy.js";
 import { getSearxngInstances, redactSearxngInstanceUrl } from "./searxng-instances.js";
@@ -265,16 +266,8 @@ async function requestInstanceConfig(mcpServer: McpServer, base: string): Promis
     const url = new URL("config", parsedBase);
     const requestOptions: RequestInit = {
       signal: AbortSignal.timeout(5000),
+      headers: buildSearxngAuthHeaders(),
     };
-    const username = process.env.AUTH_USERNAME;
-    const password = process.env.AUTH_PASSWORD;
-    if (username && password) {
-      const base64Auth = Buffer.from(`${username}:${password}`).toString("base64");
-      requestOptions.headers = {
-        ...(requestOptions.headers as Record<string, string> | undefined),
-        Authorization: `Basic ${base64Auth}`,
-      };
-    }
     const proxyAgent = createProxyAgent(url.toString(), ProxyType.SEARCH);
     const dispatcher = proxyAgent ?? createDefaultAgent();
     if (dispatcher) {

--- a/src/search.ts
+++ b/src/search.ts
@@ -1,6 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { parse } from "node-html-parser";
 import { SearXNGWeb } from "./types.js";
+import { buildSearxngAuthHeaders } from "./auth.js";
 import { getKnownCategories, getKnownEngines } from "./instance-info.js";
 import { createProxyAgent, createDefaultAgent, ProxyType } from "./proxy.js";
 import { logMessage } from "./logging.js";
@@ -438,16 +439,10 @@ function buildSearchRequestOptions(url: URL): RequestInit {
     (requestOptions as any).dispatcher = dispatcher;
   }
 
-  const username = process.env.AUTH_USERNAME;
-  const password = process.env.AUTH_PASSWORD;
-
-  if (username && password) {
-    const base64Auth = Buffer.from(`${username}:${password}`).toString('base64');
-    requestOptions.headers = {
-      ...requestOptions.headers,
-      'Authorization': `Basic ${base64Auth}`
-    };
-  }
+  requestOptions.headers = {
+    ...requestOptions.headers,
+    ...buildSearxngAuthHeaders(),
+  };
 
   const userAgent = process.env.USER_AGENT;
   if (userAgent) {

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -1,4 +1,5 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { buildSearxngAuthHeaders } from "./auth.js";
 import { logMessage } from "./logging.js";
 import { createDefaultAgent, createProxyAgent, ProxyType } from "./proxy.js";
 import { getPrimarySearxngInstance } from "./searxng-instances.js";
@@ -23,16 +24,8 @@ export async function performSearchSuggestions(
   try {
     const requestOptions: RequestInit = {
       signal: AbortSignal.timeout(5000),
+      headers: buildSearxngAuthHeaders(),
     };
-    const username = process.env.AUTH_USERNAME;
-    const password = process.env.AUTH_PASSWORD;
-    if (username && password) {
-      const base64Auth = Buffer.from(`${username}:${password}`).toString("base64");
-      requestOptions.headers = {
-        ...(requestOptions.headers as Record<string, string> | undefined),
-        Authorization: `Basic ${base64Auth}`,
-      };
-    }
     const proxyAgent = createProxyAgent(url.toString(), ProxyType.SEARCH);
     const dispatcher = proxyAgent ?? createDefaultAgent();
     if (dispatcher) {

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -24,6 +24,15 @@ export async function performSearchSuggestions(
     const requestOptions: RequestInit = {
       signal: AbortSignal.timeout(5000),
     };
+    const username = process.env.AUTH_USERNAME;
+    const password = process.env.AUTH_PASSWORD;
+    if (username && password) {
+      const base64Auth = Buffer.from(`${username}:${password}`).toString("base64");
+      requestOptions.headers = {
+        ...(requestOptions.headers as Record<string, string> | undefined),
+        Authorization: `Basic ${base64Auth}`,
+      };
+    }
     const proxyAgent = createProxyAgent(url.toString(), ProxyType.SEARCH);
     const dispatcher = proxyAgent ?? createDefaultAgent();
     if (dispatcher) {

--- a/src/tls-config.ts
+++ b/src/tls-config.ts
@@ -35,7 +35,9 @@ export interface CACertDeps {
  * Reads system CA certificates from well-known bundle paths, plus an optional
  * user-provided extra bundle pointed to by `NODE_EXTRA_CA_CERTS`.
  *
- * Returns null on Windows (no universal file path) or if no bundle is found.
+ * On Windows there is no universal CA bundle path, so only the extra bundle
+ * (if any) is returned. On other platforms the first readable system bundle
+ * wins and the extra bundle is appended.
  *
  * The extra bundle is folded in here because undici's `connect.ca` option,
  * when set, overrides Node's default CA handling and would otherwise ignore
@@ -51,21 +53,20 @@ export function getSystemCACerts(deps: CACertDeps = {}): string | null {
     extraCaPath = process.env.NODE_EXTRA_CA_CERTS,
   } = deps;
 
-  // Windows has no universal CA bundle path; skip auto-detection
-  if (platformName === "win32") {
-    return null;
-  }
-
   const bundles: string[] = [];
 
-  for (const caPath of caPaths) {
-    if (fileExists(caPath)) {
-      try {
-        bundles.push(readFile(caPath));
-        break; // first readable bundle wins, matching prior behavior
-      } catch {
-        // File exists but is unreadable (permissions); try next
-        continue;
+  // Windows has no universal CA bundle path; skip auto-detection but still
+  // honor NODE_EXTRA_CA_CERTS below (undici does not read it natively).
+  if (platformName !== "win32") {
+    for (const caPath of caPaths) {
+      if (fileExists(caPath)) {
+        try {
+          bundles.push(readFile(caPath));
+          break; // first readable bundle wins, matching prior behavior
+        } catch {
+          // File exists but is unreadable (permissions); try next
+          continue;
+        }
       }
     }
   }

--- a/src/tls-config.ts
+++ b/src/tls-config.ts
@@ -24,13 +24,22 @@ export interface CACertDeps {
   fileExists?: (path: string) => boolean;
   readFile?: (path: string) => string;
   caPaths?: readonly string[];
+  /**
+   * Path to an extra PEM bundle to merge into the CA list. Defaults to
+   * `process.env.NODE_EXTRA_CA_CERTS`. Pass `null` in tests to opt out.
+   */
+  extraCaPath?: string | null;
 }
 
 /**
- * Reads system CA certificates from well-known bundle paths.
+ * Reads system CA certificates from well-known bundle paths, plus an optional
+ * user-provided extra bundle pointed to by `NODE_EXTRA_CA_CERTS`.
+ *
  * Returns null on Windows (no universal file path) or if no bundle is found.
  *
- * On Windows, users should set NODE_EXTRA_CA_CERTS pointing to a PEM file.
+ * The extra bundle is folded in here because undici's `connect.ca` option,
+ * when set, overrides Node's default CA handling and would otherwise ignore
+ * `NODE_EXTRA_CA_CERTS` — which the built-in `https` module does honor.
  */
 export function getSystemCACerts(deps: CACertDeps = {}): string | null {
   const {
@@ -39,6 +48,7 @@ export function getSystemCACerts(deps: CACertDeps = {}): string | null {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     readFile = (path: string) => readFileSync(path, "utf8"),
     caPaths = CA_BUNDLE_PATHS,
+    extraCaPath = process.env.NODE_EXTRA_CA_CERTS,
   } = deps;
 
   // Windows has no universal CA bundle path; skip auto-detection
@@ -46,10 +56,13 @@ export function getSystemCACerts(deps: CACertDeps = {}): string | null {
     return null;
   }
 
+  const bundles: string[] = [];
+
   for (const caPath of caPaths) {
     if (fileExists(caPath)) {
       try {
-        return readFile(caPath);
+        bundles.push(readFile(caPath));
+        break; // first readable bundle wins, matching prior behavior
       } catch {
         // File exists but is unreadable (permissions); try next
         continue;
@@ -57,7 +70,16 @@ export function getSystemCACerts(deps: CACertDeps = {}): string | null {
     }
   }
 
-  return null;
+  if (extraCaPath) {
+    try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename
+      bundles.push(readFile(extraCaPath));
+    } catch {
+      // Unreadable extra path is silently ignored — same as Node's behavior.
+    }
+  }
+
+  return bundles.length > 0 ? bundles.join("\n") : null;
 }
 
 /**


### PR DESCRIPTION
Two related fixes for SearXNG instances that sit behind (a) a TLS server that only sends the leaf cert and
   (b) HTTP basic auth.

   - **TLS**: `NODE_EXTRA_CA_CERTS` was silently ignored on macOS/Linux because undici's `connect.ca`
   overrides Node's default CA handling. Worked on Windows only because `getSystemCACerts` short-circuits to
   null there.
   - **Auth**: `/config` (capability discovery) and `/autocompleter` (suggestions) built their fetch options
   without the `Authorization` header that `buildSearchRequestOptions` already adds for `/search`. Auth-gated
   instances returned 401, breaking both features.

   ## Changes

   **`src/tls-config.ts`** — fold `NODE_EXTRA_CA_CERTS` into the bundle returned by `getSystemCACerts` so
   undici's `connect.ca` includes user-provided intermediates on every platform. New `extraCaPath` dep on
   `CACertDeps` for test isolation (defaults to the env var).

   **`src/instance-info.ts`** — inline the same 5-line Basic-auth construction from `search.ts` in
   `requestInstanceConfig`.

   **`src/suggestions.ts`** — same, in `performSearchSuggestions`.

   `web_url_read` deliberately does **not** use these credentials — it fetches arbitrary URLs.

   ## Why not extract a shared helper

   Kept changes minimal and local to each call site to match the existing pattern (e.g.
   `buildSearchRequestOptions` in `search.ts`). Happy to extract a `buildSearxngAuthHeaders()` helper if you'd
    prefer — just say the word.

   ## Testing

   - Full suite: **424/424 passing** (added 2 new `tls-config` tests for the merge + unreadable-path branches;
    added `extraCaPath: null` to 4 existing tests for env isolation).
  https://github.com/ihor-sokoliuk/mcp-searxng/compare/main...wchy1128:mcp-searxng:feat/node-extra-ca-certs-and-a
  uth-everywhere