### PR TITLE
feat(proxy): add SEARCH_USER_AGENT override for SearXNG-instance requests (FEAT-050)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -70,8 +70,11 @@ Self-hosting SearXNG with JSON output enabled remains the recommended setup. The
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `USER_AGENT` | No | — | Global User-Agent header for all outgoing requests (e.g. `MyBot/1.0`) |
-| `URL_READER_USER_AGENT` | No | — | User-Agent for `web_url_read` only — overrides `USER_AGENT` for URL reads |
+| `USER_AGENT` | No | — | Global default User-Agent header for outgoing requests (e.g. `MyBot/1.0`) |
+| `SEARCH_USER_AGENT` | No | `USER_AGENT` | User-Agent for SearXNG instance requests: `searxng_web_search`, `/config` capability discovery, and search suggestions |
+| `URL_READER_USER_AGENT` | No | `USER_AGENT` | User-Agent for `web_url_read` only |
+
+`SEARCH_USER_AGENT` and `URL_READER_USER_AGENT` are per-group overrides. When unset, both fall back to `USER_AGENT`. If neither the group override nor `USER_AGENT` is set, no User-Agent header is added by `mcp-searxng`.
 
 ## Proxy
 
@@ -205,6 +208,7 @@ Complete MCP client configuration with every variable. Mix and match as needed �
         "AUTH_USERNAME": "your_username",
         "AUTH_PASSWORD": "your_password",
         "USER_AGENT": "MyBot/1.0",
+        "SEARCH_USER_AGENT": "MySearchBot/1.0",
         "URL_READER_USER_AGENT": "Mozilla/5.0 (compatible; MyBot/1.0)",
         "SEARCH_HTTP_PROXY": "http://search-proxy.company.com:8080",
         "SEARCH_HTTPS_PROXY": "http://search-proxy.company.com:8080",

--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -474,13 +474,15 @@ async function runTests() {
       return createMockFetch({ json: makeConfig() })(url, options);
     });
 
-    await fetchInstanceInfo(mockServer as any);
+    try {
+      await fetchInstanceInfo(mockServer as any);
 
-    const headers = getCapturedOptions()?.headers as Record<string, string>;
-    assert.equal(headers?.['user-agent'], 'SearchBot/2.0');
-
-    fetchMocker.restore();
-    envManager.restore();
+      const headers = getCapturedOptions()?.headers as Record<string, string>;
+      assert.equal(headers?.['user-agent'], 'SearchBot/2.0');
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+    }
   }, results);
 
   await testFunction('config request omits User-Agent header when USER_AGENT is unset', async () => {

--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -444,6 +444,7 @@ async function runTests() {
   await testFunction('config request includes User-Agent header when USER_AGENT is set', async () => {
     clearInstanceInfoCacheForTests();
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('SEARCH_USER_AGENT');
     envManager.set('USER_AGENT', 'MyBot/1.0');
     const mockServer = createMockServer();
     const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
@@ -461,9 +462,31 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('config request uses SEARCH_USER_AGENT over USER_AGENT', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARCH_USER_AGENT', 'SearchBot/2.0');
+    envManager.set('USER_AGENT', 'GlobalBot/1.0');
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: makeConfig() })(url, options);
+    });
+
+    await fetchInstanceInfo(mockServer as any);
+
+    const headers = getCapturedOptions()?.headers as Record<string, string>;
+    assert.equal(headers?.['user-agent'], 'SearchBot/2.0');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('config request omits User-Agent header when USER_AGENT is unset', async () => {
     clearInstanceInfoCacheForTests();
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('SEARCH_USER_AGENT');
     envManager.delete('USER_AGENT');
     const mockServer = createMockServer();
     const { mockFetch, getCapturedOptions } = createCapturingMockFetch();

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -867,17 +867,19 @@ async function runTests() {
     });
 
     try {
-      await performWebSearch(mockServer as any, 'test query');
-    } catch {
-      // expected
+      try {
+        await performWebSearch(mockServer as any, 'test query');
+      } catch {
+        // expected
+      }
+
+      const options = getCapturedOptions();
+      const headers = options?.headers as Record<string, string>;
+      assert.equal(headers?.['User-Agent'], 'SearchBot/2.0');
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
     }
-
-    const options = getCapturedOptions();
-    const headers = options?.headers as Record<string, string>;
-    assert.equal(headers?.['User-Agent'], 'SearchBot/2.0');
-
-    fetchMocker.restore();
-    envManager.restore();
   }, results);
 
   await testFunction('User-Agent header absent when USER_AGENT env var not set', async () => {

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -828,6 +828,7 @@ async function runTests() {
 
   await testFunction('User-Agent header added when USER_AGENT env var is set', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('SEARCH_USER_AGENT');
     envManager.set('USER_AGENT', 'MyCustomBot/1.0');
 
     const mockServer = createMockServer();
@@ -852,8 +853,36 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('SEARCH_USER_AGENT overrides USER_AGENT for search requests', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARCH_USER_AGENT', 'SearchBot/2.0');
+    envManager.set('USER_AGENT', 'GlobalBot/1.0');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      throw new Error('MOCK_STOP');
+    });
+
+    try {
+      await performWebSearch(mockServer as any, 'test query');
+    } catch {
+      // expected
+    }
+
+    const options = getCapturedOptions();
+    const headers = options?.headers as Record<string, string>;
+    assert.equal(headers?.['User-Agent'], 'SearchBot/2.0');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('User-Agent header absent when USER_AGENT env var not set', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('SEARCH_USER_AGENT');
     envManager.delete('USER_AGENT');
 
     const mockServer = createMockServer();

--- a/__tests__/unit/suggestions.test.ts
+++ b/__tests__/unit/suggestions.test.ts
@@ -172,6 +172,7 @@ async function runTests() {
 
   await testFunction('autocompleter request includes User-Agent header when USER_AGENT is set', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('SEARCH_USER_AGENT');
     envManager.set('USER_AGENT', 'MyBot/1.0');
     const mockServer = createMockServer();
     const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
@@ -190,8 +191,30 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('autocompleter request uses SEARCH_USER_AGENT over USER_AGENT', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARCH_USER_AGENT', 'SearchBot/2.0');
+    envManager.set('USER_AGENT', 'GlobalBot/1.0');
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: ['type', ['typescript']] })(url, options);
+    });
+
+    await performSearchSuggestions(mockServer as any, 'type');
+
+    const headers = getCapturedOptions()?.headers as Record<string, string>;
+    assert.equal(headers?.['user-agent'], 'SearchBot/2.0');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('autocompleter request omits User-Agent header when USER_AGENT is unset', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('SEARCH_USER_AGENT');
     envManager.delete('USER_AGENT');
     const mockServer = createMockServer();
     const { mockFetch, getCapturedOptions } = createCapturingMockFetch();

--- a/__tests__/unit/suggestions.test.ts
+++ b/__tests__/unit/suggestions.test.ts
@@ -203,13 +203,15 @@ async function runTests() {
       return createMockFetch({ json: ['type', ['typescript']] })(url, options);
     });
 
-    await performSearchSuggestions(mockServer as any, 'type');
+    try {
+      await performSearchSuggestions(mockServer as any, 'type');
 
-    const headers = getCapturedOptions()?.headers as Record<string, string>;
-    assert.equal(headers?.['user-agent'], 'SearchBot/2.0');
-
-    fetchMocker.restore();
-    envManager.restore();
+      const headers = getCapturedOptions()?.headers as Record<string, string>;
+      assert.equal(headers?.['user-agent'], 'SearchBot/2.0');
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+    }
   }, results);
 
   await testFunction('autocompleter request omits User-Agent header when USER_AGENT is unset', async () => {

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -284,6 +284,52 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('SEARCH_USER_AGENT does not override USER_AGENT for URL reads', async () => {
+    envManager.set('SEARCH_USER_AGENT', 'SearchBot/2.0');
+    envManager.set('USER_AGENT', 'GlobalBot/1.0');
+    envManager.delete('URL_READER_USER_AGENT');
+    const mockServer = createMockServer();
+    const seenUserAgents: string[] = [];
+    const { url, close } = await startHttpServer((req, res) => {
+      seenUserAgents.push(req.headers['user-agent'] ?? '');
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end('<html><body><h1>Readable</h1></body></html>');
+    });
+
+    try {
+      await fetchAndConvertToMarkdown(mockServer as any, url);
+
+      assert.ok(seenUserAgents.length > 0, 'Expected the URL reader to make a request');
+      assert.ok(seenUserAgents.every((userAgent) => userAgent === 'GlobalBot/1.0'));
+    } finally {
+      await close();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('URL_READER_USER_AGENT still overrides USER_AGENT when SEARCH_USER_AGENT is set', async () => {
+    envManager.set('SEARCH_USER_AGENT', 'SearchBot/2.0');
+    envManager.set('USER_AGENT', 'GlobalBot/1.0');
+    envManager.set('URL_READER_USER_AGENT', 'ReaderBot/3.0');
+    const mockServer = createMockServer();
+    const seenUserAgents: string[] = [];
+    const { url, close } = await startHttpServer((req, res) => {
+      seenUserAgents.push(req.headers['user-agent'] ?? '');
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end('<html><body><h1>Readable</h1></body></html>');
+    });
+
+    try {
+      await fetchAndConvertToMarkdown(mockServer as any, url);
+
+      assert.ok(seenUserAgents.length > 0, 'Expected the URL reader to make a request');
+      assert.ok(seenUserAgents.every((userAgent) => userAgent === 'ReaderBot/3.0'));
+    } finally {
+      await close();
+      envManager.restore();
+    }
+  }, results);
+
   // ── HEAD content-length preflight ─────────────────────────────────────────
 
   await testFunction('HEAD preflight returns Content-Length when present', async () => {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -287,15 +287,22 @@ export function createDefaultAgent(): Agent | undefined {
 }
 
 /**
+ * Resolve the User-Agent for SearXNG-instance requests.
+ */
+export function getSearchUserAgent(): string | undefined {
+  return process.env.SEARCH_USER_AGENT || process.env.USER_AGENT;
+}
+
+/**
  * Apply the shared SearXNG-instance request configuration — the SEARCH-group
- * proxy dispatcher and the global `USER_AGENT` header — to an outgoing request.
+ * proxy dispatcher and resolved SEARCH-group User-Agent header — to an outgoing request.
  *
- * Used by the two instance-side fetches that don't build their own auth headers:
+ * Used by the instance-side fetches that don't build their own auth headers:
  * the `/config` fetch (`instance-info.ts`) and the autocompleter fetch
  * (`suggestions.ts`), so both route through the same proxy and present a
  * consistent User-Agent identity without duplicating the wiring. `searxng_web_search`
- * still builds its own options in `search.ts` (Basic-Auth handling is interleaved
- * there); folding it in here is tracked under FEAT-050.
+ * builds its own options in `search.ts` because Basic Auth handling is interleaved
+ * there, but uses the same `getSearchUserAgent()` resolver.
  *
  * The User-Agent is merged through a `Headers` instance, so any already-set
  * `headers` — whether a plain object, a `Headers` instance, or a tuple array —
@@ -312,7 +319,7 @@ export function applySearchRequestConfig(
     (requestOptions as any).dispatcher = dispatcher;
   }
 
-  const userAgent = process.env.USER_AGENT;
+  const userAgent = getSearchUserAgent();
   if (userAgent) {
     // Normalize via Headers so any HeadersInit shape (plain object, Headers
     // instance, or tuple array) merges without dropping already-set entries,

--- a/src/search.ts
+++ b/src/search.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { parse } from "node-html-parser";
 import { SearXNGWeb } from "./types.js";
 import { getKnownCategories, getKnownEngines } from "./instance-info.js";
-import { createProxyAgent, createDefaultAgent, ProxyType } from "./proxy.js";
+import { createProxyAgent, createDefaultAgent, getSearchUserAgent, ProxyType } from "./proxy.js";
 import { logMessage } from "./logging.js";
 import {
   getHealthySearxngInstances,
@@ -449,7 +449,7 @@ function buildSearchRequestOptions(url: URL): RequestInit {
     };
   }
 
-  const userAgent = process.env.USER_AGENT;
+  const userAgent = getSearchUserAgent();
   if (userAgent) {
     requestOptions.headers = {
       ...requestOptions.headers,


### PR DESCRIPTION
## TODO item

**FEAT-050** — Add `SEARCH_USER_AGENT` for SearXNG instance requests (search, `/config`, suggestions) (🟡 Medium, from TODO-features.md)
Refs: BUG-009 (already shipped — this adds the override layer on top), FEAT-028

## Context

User-Agent config was asymmetric with proxy config. Proxy has a global (`HTTP_PROXY`) plus two group overrides (`SEARCH_*` for instance traffic, `URL_READER_*` for reads), but UA only had a global (`USER_AGENT`) plus a reader override (`URL_READER_USER_AGENT`) — so "the SearXNG-instance User-Agent" was *implicitly* `USER_AGENT`, which isn't obvious. This adds an explicit `SEARCH_USER_AGENT` for the instance-side group so UA mirrors the proxy mental model exactly: **global default + per-group override**.

## What changed

- **`src/proxy.ts`** — new `getSearchUserAgent()` resolving `SEARCH_USER_AGENT || USER_AGENT`. `applySearchRequestConfig()` (the shared SEARCH-group request config that BUG-009 introduced, already used by `/config` and suggestions) now resolves the header through it; JSDoc updated to describe the SEARCH-group UA and drop the stale "folding it in here is tracked under FEAT-050" note.
- **`src/search.ts`** — `buildSearchRequestOptions()` now uses `getSearchUserAgent()` instead of `process.env.USER_AGENT`, preserving the interleaved Basic-Auth header handling.
- **`web_url_read` unchanged** — still `URL_READER_USER_AGENT || USER_AGENT` (`src/url-reader.ts`).
- **Tests** (unit): `SEARCH_USER_AGENT` override coverage added for search, `/config`, and suggestions; the existing "UA set" / "UA unset" tests hardened to delete `SEARCH_USER_AGENT` so they assert the fallback explicitly; two new url-reader tests prove `SEARCH_USER_AGENT` does **not** affect URL reads and that `URL_READER_USER_AGENT` still wins there.
- **`CONFIGURATION.md`** — new `SEARCH_USER_AGENT` row (default `USER_AGENT`), a paragraph documenting the three-way model, corrected the `URL_READER_USER_AGENT` default to `USER_AGENT`, and added `SEARCH_USER_AGENT` to the Full Example.

Note: the TODO's Implementation section predated BUG-009 and assumed `/config`/suggestions "set no UA" and that the change belonged in `instance-info.ts`/`suggestions.ts`. Since BUG-009 centralized SEARCH-group config into `proxy.ts`, the resolver lives there and those two files needed no edits — they inherit the behavior through their existing calls.

## How it was verified

- `npm run build` — pass
- `npm run test:coverage` — all suites pass; 96.05% lines / 92.22% branches (gate ≥80% lines)
- `npm run test:e2e` (local) — 2/2
- `SEARXNG_LIVE_URL=https://searxng.ihor.top npm run test:e2e` (live) — 11/11
- `npm run lint` — clean

(verified independently by the tech lead, not just by the implementer)

## Documentation

`CONFIGURATION.md` User-Agent section now documents `SEARCH_USER_AGENT` and the full three-way model (`USER_AGENT` = global default, `SEARCH_USER_AGENT` = SearXNG instance requests, `URL_READER_USER_AGENT` = URL reads), with the variable added to the Full Example. No `README.md` change (it delegates the full env reference to `CONFIGURATION.md`); no `SECURITY.md` change (a User-Agent override is not a security surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
