### PR TITLE
feat(search): apply per-instance Basic Auth from SEARXNG_URL userinfo (FEAT-049)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,7 +6,7 @@ All environment variables for `mcp-searxng`, organized by concern. All variables
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `SEARXNG_URL` | Yes | — | URL of your SearXNG instance, or a semicolon-separated list of interchangeable replica base URLs. Single URL behavior is unchanged. Format: `<protocol>://<hostname>[:<port>]` (e.g. `http://localhost:8080` or `https://one.example.com;https://two.example.com`) |
+| `SEARXNG_URL` | Yes | — | URL of your SearXNG instance, or a semicolon-separated list of interchangeable replica base URLs. Single URL behavior is unchanged. Format: `<protocol>://[username[:password]@]<hostname>[:<port>]` (e.g. `http://localhost:8080`, `https://user:pass@search.example.com`, or `https://user:pass@one.example.com;https://two.example.com`) |
 | `SEARXNG_FANOUT` | No | `false` | Set to `true` to query all healthy configured SearXNG instances in parallel and merge results. Default failover mode tries instances in order until one returns results. |
 
 When `SEARXNG_URL` contains multiple semicolon-separated URLs, they are treated as interchangeable replicas. Default mode fails over in order when an instance hard-fails or returns no results. A reachable `200 OK` response with an empty `results` array is considered healthy and does not trigger cooldown. Instances with 3 consecutive hard failures are skipped for 60 seconds.
@@ -15,10 +15,24 @@ With `SEARXNG_FANOUT=true`, all healthy instances are queried in parallel. Resul
 
 ## Authentication
 
+For SearXNG instances protected with HTTP Basic Auth, embed credentials in each `SEARXNG_URL` entry:
+
+```bash
+SEARXNG_URL=https://username:password@search.example.com
+```
+
+For multiple interchangeable replicas, each semicolon-separated URL can carry its own credentials. This supports mixed deployments such as one private auth-gated instance and one public instance without sending the private credentials to the public host:
+
+```bash
+SEARXNG_URL=https://alice:secret@private-search.example.com;https://public-search.example.com
+```
+
+Percent-encode special characters in usernames or passwords before placing them in the URL. For example, password `p@ss` should be written as `p%40ss`.
+
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `AUTH_USERNAME` | No | — | HTTP Basic Auth username for password-protected SearXNG instances |
-| `AUTH_PASSWORD` | No | — | HTTP Basic Auth password for password-protected SearXNG instances |
+| `AUTH_USERNAME` | No | — | Legacy global HTTP Basic Auth username fallback used only when a `SEARXNG_URL` entry has no userinfo |
+| `AUTH_PASSWORD` | No | — | Legacy global HTTP Basic Auth password fallback used only when a `SEARXNG_URL` entry has no userinfo |
 
 ## Timeouts
 
@@ -191,7 +205,7 @@ Complete MCP client configuration with every variable. Mix and match as needed �
       "command": "npx",
       "args": ["-y", "mcp-searxng"],
       "env": {
-        "SEARXNG_URL": "YOUR_SEARXNG_INSTANCE_URL",
+        "SEARXNG_URL": "https://your_username:your_password@searxng.example.com",
         "SEARXNG_FANOUT": "false",
         "SEARXNG_TIMEOUT_MS": "10000",
         "FETCH_TIMEOUT_MS": "10000",
@@ -205,8 +219,6 @@ Complete MCP client configuration with every variable. Mix and match as needed �
         "URL_READ_MAX_CONTENT_LENGTH_BYTES": "5242880",
         "CACHE_TTL_MS": "86400000",
         "CACHE_MAX_ENTRIES": "500",
-        "AUTH_USERNAME": "your_username",
-        "AUTH_PASSWORD": "your_password",
         "USER_AGENT": "MyBot/1.0",
         "SEARCH_USER_AGENT": "MySearchBot/1.0",
         "URL_READER_USER_AGENT": "Mozilla/5.0 (compatible; MyBot/1.0)",

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ curl http://localhost:3000/health
 
 ## Configuration
 
-Set `SEARXNG_URL` to your SearXNG instance URL. For failover, set it to semicolon-separated interchangeable replica URLs. Set `SEARXNG_FANOUT=true` to query all healthy replicas in parallel and merge results. All other variables are optional.
+Set `SEARXNG_URL` to your SearXNG instance URL. For Basic Auth, embed credentials per instance, for example `https://user:password@search.example.com`. For failover, set it to semicolon-separated interchangeable replica URLs; each entry can carry its own credentials. Set `SEARXNG_FANOUT=true` to query all healthy replicas in parallel and merge results. All other variables are optional.
 
 Full environment variable reference: [CONFIGURATION.md](CONFIGURATION.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ The primary security surface areas are:
 | `web_url_read` tool | SSRF — the server fetches user-supplied URLs on behalf of the AI |
 | HTTP transport | Unauthorized access, DNS rebinding, CORS misconfiguration |
 | Proxy credentials | Credential exposure in environment variables |
-| SearXNG credentials | `AUTH_PASSWORD` in environment |
+| SearXNG credentials | Credentials in `SEARXNG_URL` userinfo or legacy `AUTH_PASSWORD` fallback |
 | Query forwarding | Search queries are forwarded verbatim to SearXNG |
 
 ## Security Features
@@ -131,7 +131,9 @@ Enable `MCP_HTTP_TRUST_PROXY` only when the server is behind a trusted reverse p
 
 ### Secrets in Environment Variables
 
-`AUTH_PASSWORD`, `MCP_HTTP_AUTH_TOKEN`, and proxy credentials are read from environment variables. Avoid committing these to source control. Use secret management (Docker secrets, environment injection at runtime, or a secrets manager) in production.
+SearXNG Basic Auth is supported by embedding credentials in `SEARXNG_URL` userinfo, such as `https://user:password@search.example.com`. This is the recommended path because each semicolon-separated instance URL can carry its own credentials. URL userinfo is stripped from outgoing fetch URLs and redacted from logs and errors.
+
+`AUTH_PASSWORD` remains available as a legacy global fallback when a `SEARXNG_URL` entry has no userinfo. `MCP_HTTP_AUTH_TOKEN`, proxy credentials, and any credentials embedded in `SEARXNG_URL` are secrets. Avoid committing them to source control. Use secret management (Docker secrets, environment injection at runtime, or a secrets manager) in production.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -131,7 +131,7 @@ Enable `MCP_HTTP_TRUST_PROXY` only when the server is behind a trusted reverse p
 
 ### Secrets in Environment Variables
 
-SearXNG Basic Auth is supported by embedding credentials in `SEARXNG_URL` userinfo, such as `https://user:password@search.example.com`. This is the recommended path because each semicolon-separated instance URL can carry its own credentials. URL userinfo is stripped from outgoing fetch URLs and redacted from logs and errors.
+SearXNG Basic Auth is supported by embedding credentials in `SEARXNG_URL` userinfo, such as `https://user:pass@search.example.com`. This is the recommended path because each semicolon-separated instance URL can carry its own credentials. URL userinfo is stripped from outgoing fetch URLs and redacted from logs and errors.
 
 `AUTH_PASSWORD` remains available as a legacy global fallback when a `SEARXNG_URL` entry has no userinfo. `MCP_HTTP_AUTH_TOKEN`, proxy credentials, and any credentials embedded in `SEARXNG_URL` are secrets. Avoid committing them to source control. Use secret management (Docker secrets, environment injection at runtime, or a secrets manager) in production.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -131,7 +131,7 @@ Enable `MCP_HTTP_TRUST_PROXY` only when the server is behind a trusted reverse p
 
 ### Secrets in Environment Variables
 
-SearXNG Basic Auth is supported by embedding credentials in `SEARXNG_URL` userinfo, such as `https://user:pass@search.example.com`. This is the recommended path because each semicolon-separated instance URL can carry its own credentials. URL userinfo is stripped from outgoing fetch URLs and redacted from logs and errors.
+SearXNG Basic Auth is supported by embedding credentials in the `SEARXNG_URL` userinfo — see the [Authentication section of CONFIGURATION.md](CONFIGURATION.md#authentication) for the exact format. This is the recommended path because each semicolon-separated instance URL can carry its own credentials. URL userinfo is stripped from outgoing fetch URLs and redacted from logs and errors.
 
 `AUTH_PASSWORD` remains available as a legacy global fallback when a `SEARXNG_URL` entry has no userinfo. `MCP_HTTP_AUTH_TOKEN`, proxy credentials, and any credentials embedded in `SEARXNG_URL` are secrets. Avoid committing them to source control. Use secret management (Docker secrets, environment injection at runtime, or a secrets manager) in production.
 

--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -377,6 +377,34 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('/config fetch strips URL credentials and uses per-instance auth header', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://config-user:p%40ss@config-auth.example.com');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedUrl, getCapturedOptions } = createCapturingMockFetch();
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: makeConfig() })(url, options);
+    });
+
+    const payload = JSON.parse(await fetchInstanceInfo(mockServer as any, true));
+
+    const capturedUrl = getCapturedUrl();
+    const parsedUrl = new URL(capturedUrl);
+    const headers = getCapturedOptions()?.headers as Record<string, string>;
+    assert.equal(payload.available, true);
+    assert.equal(parsedUrl.username, '');
+    assert.equal(parsedUrl.password, '');
+    assert.equal(parsedUrl.hostname, 'config-auth.example.com');
+    assert.equal(parsedUrl.pathname, '/config');
+    assert.ok(!capturedUrl.includes('config-user:p%40ss@'), capturedUrl);
+    assert.equal(headers['authorization'], `Basic ${Buffer.from('config-user:p@ss').toString('base64')}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('credential-bearing instance URLs are redacted from unavailable payload', async () => {
     clearInstanceInfoCacheForTests();
     envManager.set('SEARXNG_URL', 'https://user:pass@down-one.example.com;https://user:pass@down-two.example.com');

--- a/__tests__/unit/resources.test.ts
+++ b/__tests__/unit/resources.test.ts
@@ -77,6 +77,13 @@ async function runTests() {
     assert.ok(help.includes('### 4. web_url_read'), 'missing URL reader tool section');
   }, results);
 
+  await testFunction('help resource recommends URL userinfo for SearXNG Basic Auth', () => {
+    const help = createHelpResource();
+
+    assert.ok(help.includes('https://user:password@search.example.com'), 'missing URL userinfo auth example');
+    assert.ok(help.includes('Legacy global Basic Auth fallback'), 'missing legacy AUTH_* fallback note');
+  }, results);
+
   await testFunction('createConfigResource - hasAuth true when both credentials set', () => {
     envManager.set('AUTH_USERNAME', 'testuser');
     envManager.set('AUTH_PASSWORD', 'testpass');

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -204,8 +204,76 @@ async function runTests() {
     const options = getCapturedOptions();
     assert.ok(options?.headers);
     const headers = options.headers as Record<string, string>;
-    assert.ok(headers['Authorization']);
-    assert.ok(headers['Authorization'].startsWith('Basic '));
+    assert.equal(headers['Authorization'], `Basic ${Buffer.from('testuser:testpass').toString('base64')}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('embedded URL auth overrides global auth for search requests', async () => {
+    envManager.set('SEARXNG_URL', 'https://embedded:p%40ss@test-searx.example.com');
+    envManager.set('AUTH_USERNAME', 'global-user');
+    envManager.set('AUTH_PASSWORD', 'global-pass');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: { results: [] } })(url, options);
+    });
+
+    await performWebSearch(mockServer as any, 'test query');
+
+    const headers = getCapturedOptions()?.headers as Record<string, string>;
+    assert.equal(headers['Authorization'], `Basic ${Buffer.from('embedded:p@ss').toString('base64')}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('search fetch URL strips embedded credentials before request', async () => {
+    envManager.set('SEARXNG_URL', 'https://user:pass@test-searx.example.com/subpath');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedUrl } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: { results: [] } })(url, options);
+    });
+
+    await performWebSearch(mockServer as any, 'test query');
+
+    const capturedUrl = getCapturedUrl();
+    const parsedUrl = new URL(capturedUrl);
+    assert.equal(parsedUrl.username, '');
+    assert.equal(parsedUrl.password, '');
+    assert.equal(parsedUrl.hostname, 'test-searx.example.com');
+    assert.equal(parsedUrl.pathname, '/subpath/search');
+    assert.ok(!capturedUrl.includes('user:pass@'), capturedUrl);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('search request omits Authorization when no credentials are configured', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: { results: [] } })(url, options);
+    });
+
+    await performWebSearch(mockServer as any, 'test query');
+
+    const headers = (getCapturedOptions()?.headers || {}) as Record<string, string>;
+    assert.equal(headers['Authorization'], undefined);
 
     fetchMocker.restore();
     envManager.restore();
@@ -1918,6 +1986,53 @@ async function runTests() {
     assert.deepEqual(requestedHosts, ['https://first.example.com', 'https://second.example.com']);
     assert.deepEqual(payload.servedBy, ['https://second.example.com']);
     assert.equal(payload.results[0].title, 'Second Result');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('multi-instance search uses embedded auth first and global fallback second', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://embedded:p%40ss@first.example.com;https://second.example.com');
+    envManager.set('AUTH_USERNAME', 'global-user');
+    envManager.set('AUTH_PASSWORD', 'global-pass');
+    envManager.delete('SEARXNG_FANOUT');
+
+    const mockServer = createMockServer();
+    const requests: Array<{ url: string; authorization?: string }> = [];
+
+    fetchMocker.mock(async (url, options) => {
+      const headers = (options?.headers || {}) as Record<string, string>;
+      requests.push({
+        url: url.toString(),
+        authorization: headers['Authorization'],
+      });
+
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.hostname === 'first.example.com') {
+        throw new Error('first instance unavailable');
+      }
+
+      return createMockFetch({
+        json: {
+          query: 'multi auth',
+          results: [
+            { title: 'Second Result', content: 'Second', url: 'https://example.com/second', score: 1 },
+          ],
+        },
+      })(url, options);
+    });
+
+    const result = await performWebSearch(mockServer as any, 'multi auth', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const payload = JSON.parse(result);
+
+    assert.equal(payload.results[0].title, 'Second Result');
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0].authorization, `Basic ${Buffer.from('embedded:p@ss').toString('base64')}`);
+    assert.equal(requests[1].authorization, `Basic ${Buffer.from('global-user:global-pass').toString('base64')}`);
+    assert.ok(!requests[0].url.includes('embedded:p%40ss@'), requests[0].url);
+    assert.equal(new URL(requests[0].url).username, '');
+    assert.equal(new URL(requests[1].url).username, '');
 
     fetchMocker.restore();
     envManager.restore();

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -505,6 +505,46 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('HTML fallback on 200 non-JSON body strips embedded credentials from the refetch URL', async () => {
+    envManager.set('SEARXNG_URL', 'https://user:p%40ss@test-searx.example.com');
+    envManager.set('SEARXNG_HTML_FALLBACK', 'true');
+
+    const mockServer = createMockServer();
+    const fetchedUrls: string[] = [];
+    fetchMocker.mock(async (url) => {
+      fetchedUrls.push(url.toString());
+      if (fetchedUrls.length === 1) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => { throw new Error('Unexpected token < in JSON'); },
+          text: async () => '<!doctype html><html><body>JSON disabled</body></html>',
+        } as any;
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => searxngHtmlFixture,
+      } as Response;
+    });
+
+    await performWebSearch(mockServer as any, 'non json creds', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+
+    assert.equal(fetchedUrls.length, 2);
+    // Neither the initial fetch nor the HTML-fallback refetch may carry userinfo —
+    // Node's fetch rejects credential-bearing URLs outright.
+    for (const fetched of fetchedUrls) {
+      assert.equal(new URL(fetched).username, '');
+      assert.ok(!fetched.includes('user:p%40ss@'), fetched);
+    }
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('403 without HTML fallback enabled returns original error and does not refetch', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
     envManager.delete('SEARXNG_HTML_FALLBACK');

--- a/__tests__/unit/searxng-instances.test.ts
+++ b/__tests__/unit/searxng-instances.test.ts
@@ -145,6 +145,14 @@ async function runTests() {
     assert.equal(header, `Basic ${Buffer.from('token:').toString('base64')}`);
   }, results);
 
+  await testFunction('getSearxngBasicAuthHeader tolerates malformed percent-encoding in userinfo', () => {
+    // A literal `%` the operator forgot to encode parses as a URL but makes
+    // decodeURIComponent throw — the header must fall back to the raw value, not crash.
+    const header = getSearxngBasicAuthHeader(new URL('https://user:100%@search.example.com'));
+
+    assert.equal(header, `Basic ${Buffer.from('user:100%').toString('base64')}`);
+  }, results);
+
   await testFunction('getSearxngBasicAuthHeader falls back to global auth only without URL userinfo', () => {
     envManager.set('AUTH_USERNAME', 'global-user');
     envManager.set('AUTH_PASSWORD', 'global-pass');

--- a/__tests__/unit/searxng-instances.test.ts
+++ b/__tests__/unit/searxng-instances.test.ts
@@ -13,11 +13,13 @@ import {
   getHealthySearxngInstances,
   getPrimarySearxngInstance,
   getSearxngInstances,
+  getSearxngBasicAuthHeader,
   isSearxngFanoutEnabled,
   parseSearxngUrls,
   redactSearxngInstanceUrl,
   recordSearxngInstanceFailure,
   recordSearxngInstanceSuccess,
+  stripSearxngInstanceUrlUserinfo,
   validateSearxngInstanceUrl,
 } from '../../src/searxng-instances.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
@@ -121,6 +123,48 @@ async function runTests() {
     for (const url of urls) {
       assert.equal(redactSearxngInstanceUrl(url), url);
     }
+  }, results);
+
+  await testFunction('stripSearxngInstanceUrlUserinfo removes credentials and preserves request target', () => {
+    const stripped = stripSearxngInstanceUrlUserinfo(new URL('https://user:pass@search.example.com/base/search?q=test#top'));
+
+    assert.equal(stripped.toString(), 'https://search.example.com/base/search?q=test#top');
+    assert.equal(stripped.username, '');
+    assert.equal(stripped.password, '');
+  }, results);
+
+  await testFunction('getSearxngBasicAuthHeader decodes percent-encoded URL credentials', () => {
+    const header = getSearxngBasicAuthHeader(new URL('https://user:p%40ss@search.example.com'));
+
+    assert.equal(header, `Basic ${Buffer.from('user:p@ss').toString('base64')}`);
+  }, results);
+
+  await testFunction('getSearxngBasicAuthHeader supports username-only URL credentials', () => {
+    const header = getSearxngBasicAuthHeader(new URL('https://token@search.example.com'));
+
+    assert.equal(header, `Basic ${Buffer.from('token:').toString('base64')}`);
+  }, results);
+
+  await testFunction('getSearxngBasicAuthHeader falls back to global auth only without URL userinfo', () => {
+    envManager.set('AUTH_USERNAME', 'global-user');
+    envManager.set('AUTH_PASSWORD', 'global-pass');
+
+    const header = getSearxngBasicAuthHeader(new URL('https://search.example.com'));
+
+    assert.equal(header, `Basic ${Buffer.from('global-user:global-pass').toString('base64')}`);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('getSearxngBasicAuthHeader returns undefined when no credentials exist', () => {
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+
+    const header = getSearxngBasicAuthHeader(new URL('https://search.example.com'));
+
+    assert.equal(header, undefined);
+
+    envManager.restore();
   }, results);
 
   await testFunction('isSearxngFanoutEnabled is true only for literal true', () => {

--- a/__tests__/unit/searxng-instances.test.ts
+++ b/__tests__/unit/searxng-instances.test.ts
@@ -153,6 +153,18 @@ async function runTests() {
     assert.equal(header, `Basic ${Buffer.from('user:100%').toString('base64')}`);
   }, results);
 
+  await testFunction('getSearxngBasicAuthHeader ignores password-only URL userinfo (no username)', () => {
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+
+    // Password-only userinfo is treated as absent — no stray secret is sent.
+    const header = getSearxngBasicAuthHeader(new URL('https://:pass@search.example.com'));
+
+    assert.equal(header, undefined);
+
+    envManager.restore();
+  }, results);
+
   await testFunction('getSearxngBasicAuthHeader falls back to global auth only without URL userinfo', () => {
     envManager.set('AUTH_USERNAME', 'global-user');
     envManager.set('AUTH_PASSWORD', 'global-pass');

--- a/__tests__/unit/suggestions.test.ts
+++ b/__tests__/unit/suggestions.test.ts
@@ -132,6 +132,58 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('autocompleter fetch strips URL credentials and uses primary URL auth header', async () => {
+    envManager.set('SEARXNG_URL', 'https://primary-user:p%40ss@primary.example.com/base;https://secondary.example.com');
+    envManager.set('AUTH_USERNAME', 'global-user');
+    envManager.set('AUTH_PASSWORD', 'global-pass');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedUrl, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: ['type', ['typescript']] })(url, options);
+    });
+
+    const suggestions = await performSearchSuggestions(mockServer as any, 'type');
+
+    const capturedUrl = getCapturedUrl();
+    const parsedUrl = new URL(capturedUrl);
+    const headers = getCapturedOptions()?.headers as Record<string, string>;
+    assert.deepEqual(suggestions, ['typescript']);
+    assert.equal(parsedUrl.username, '');
+    assert.equal(parsedUrl.password, '');
+    assert.equal(parsedUrl.hostname, 'primary.example.com');
+    assert.equal(parsedUrl.pathname, '/base/autocompleter');
+    assert.ok(!capturedUrl.includes('primary-user:p%40ss@'), capturedUrl);
+    assert.equal(headers['authorization'], `Basic ${Buffer.from('primary-user:p@ss').toString('base64')}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('autocompleter uses global auth fallback when primary URL has no userinfo', async () => {
+    envManager.set('SEARXNG_URL', 'https://primary.example.com');
+    envManager.set('AUTH_USERNAME', 'global-user');
+    envManager.set('AUTH_PASSWORD', 'global-pass');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: ['type', ['typescript']] })(url, options);
+    });
+
+    await performSearchSuggestions(mockServer as any, 'type');
+
+    const headers = getCapturedOptions()?.headers as Record<string, string>;
+    assert.equal(headers['authorization'], `Basic ${Buffer.from('global-user:global-pass').toString('base64')}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('language=all omits lang parameter', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
     const mockServer = createMockServer();

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -9,7 +9,6 @@ export interface ErrorContext {
   url?: string;
   searxngUrl?: string;
   proxyAgent?: boolean;
-  username?: string;
   timeout?: number;
   query?: string;
 }

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logMessage } from "./logging.js";
 import { applySearchRequestConfig } from "./proxy.js";
-import { getSearxngInstances, redactSearxngInstanceUrl } from "./searxng-instances.js";
+import { getSearxngInstances, redactSearxngInstanceUrl, stripSearxngInstanceUrlUserinfo } from "./searxng-instances.js";
 
 type SearXNGConfig = Record<string, any>;
 type ConfigResult =
@@ -263,12 +263,13 @@ async function requestInstanceConfig(mcpServer: McpServer, base: string): Promis
   try {
     const parsedBase = new URL(base.endsWith("/") ? base : `${base}/`);
     const url = new URL("config", parsedBase);
+    const requestUrl = stripSearxngInstanceUrlUserinfo(url);
     const requestOptions: RequestInit = {
       signal: AbortSignal.timeout(5000),
     };
     applySearchRequestConfig(requestOptions, url.toString());
 
-    const response = await fetch(url.toString(), requestOptions);
+    const response = await fetch(requestUrl.toString(), requestOptions);
     if (!response.ok) {
       const message = `SearXNG /config is unavailable: HTTP ${response.status} ${response.statusText}`;
       return {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,6 +3,7 @@ import { Agent, ProxyAgent } from "undici";
 import { getHttpSecurityConfig } from "./http-security.js";
 import { getConnectOptions } from "./tls-config.js";
 import { createUrlSecurityPolicyDnsError, isPrivateAddress } from "./url-security.js";
+import { getSearxngBasicAuthHeader } from "./searxng-instances.js";
 
 type LookupCallback = (
   err: NodeJS.ErrnoException | null,
@@ -297,12 +298,10 @@ export function getSearchUserAgent(): string | undefined {
  * Apply the shared SearXNG-instance request configuration — the SEARCH-group
  * proxy dispatcher and resolved SEARCH-group User-Agent header — to an outgoing request.
  *
- * Used by the instance-side fetches that don't build their own auth headers:
- * the `/config` fetch (`instance-info.ts`) and the autocompleter fetch
- * (`suggestions.ts`), so both route through the same proxy and present a
- * consistent User-Agent identity without duplicating the wiring. `searxng_web_search`
- * builds its own options in `search.ts` because Basic Auth handling is interleaved
- * there, but uses the same `getSearchUserAgent()` resolver.
+ * Used by the `/config` fetch (`instance-info.ts`) and the autocompleter fetch
+ * (`suggestions.ts`), so both route through the same auth, proxy, and User-Agent
+ * wiring without duplicating it. `searxng_web_search` builds its own options in
+ * `search.ts`, but uses the same auth and User-Agent resolvers.
  *
  * The User-Agent is merged through a `Headers` instance, so any already-set
  * `headers` — whether a plain object, a `Headers` instance, or a tuple array —
@@ -319,13 +318,19 @@ export function applySearchRequestConfig(
     (requestOptions as any).dispatcher = dispatcher;
   }
 
+  const authHeader = getSearxngBasicAuthHeader(new URL(targetUrl));
   const userAgent = getSearchUserAgent();
-  if (userAgent) {
+  if (authHeader || userAgent) {
     // Normalize via Headers so any HeadersInit shape (plain object, Headers
     // instance, or tuple array) merges without dropping already-set entries,
     // then hand back a plain object.
     const headers = new Headers(requestOptions.headers);
-    headers.set("User-Agent", userAgent);
+    if (authHeader) {
+      headers.set("Authorization", authHeader);
+    }
+    if (userAgent) {
+      headers.set("User-Agent", userAgent);
+    }
     requestOptions.headers = Object.fromEntries(headers);
   }
 }

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -296,17 +296,19 @@ export function getSearchUserAgent(): string | undefined {
 
 /**
  * Apply the shared SearXNG-instance request configuration — the SEARCH-group
- * proxy dispatcher and resolved SEARCH-group User-Agent header — to an outgoing request.
+ * proxy dispatcher, Basic Auth header, and resolved SEARCH-group User-Agent
+ * header — to an outgoing request.
  *
  * Used by the `/config` fetch (`instance-info.ts`) and the autocompleter fetch
  * (`suggestions.ts`), so both route through the same auth, proxy, and User-Agent
  * wiring without duplicating it. `searxng_web_search` builds its own options in
  * `search.ts`, but uses the same auth and User-Agent resolvers.
  *
- * The User-Agent is merged through a `Headers` instance, so any already-set
- * `headers` — whether a plain object, a `Headers` instance, or a tuple array —
- * is preserved; the result is written back as a plain object. (In practice both
- * callers pass a freshly-built `RequestInit` with no prior headers.)
+ * The Authorization and User-Agent headers are merged through a `Headers`
+ * instance, so any already-set `headers` — whether a plain object, a `Headers`
+ * instance, or a tuple array — is preserved; the result is written back as a
+ * plain object. (In practice both callers pass a freshly-built `RequestInit`
+ * with no prior headers.)
  */
 export function applySearchRequestConfig(
   requestOptions: RequestInit,

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -93,10 +93,10 @@ Reads and converts web page content to Markdown format.
 ## Configuration
 
 ### Required Environment Variables
-- \`SEARXNG_URL\`: URL of your SearXNG instance (e.g., http://localhost:8080)
+- \`SEARXNG_URL\`: URL of your SearXNG instance (e.g., http://localhost:8080). For Basic Auth, embed credentials in the URL (e.g., https://user:password@search.example.com). Multi-instance lists can use different credentials per semicolon-separated URL.
 
 ### Optional Environment Variables
-- \`AUTH_USERNAME\` & \`AUTH_PASSWORD\`: Basic authentication for SearXNG
+- \`AUTH_USERNAME\` & \`AUTH_PASSWORD\`: Legacy global Basic Auth fallback when \`SEARXNG_URL\` has no userinfo
 - \`HTTP_PROXY\` / \`HTTPS_PROXY\`: Proxy server configuration
 - \`NO_PROXY\` / \`no_proxy\`: Comma-separated list of hosts to bypass proxy
 - \`MCP_HTTP_PORT\`: Enable HTTP transport on specified port

--- a/src/search.ts
+++ b/src/search.ts
@@ -7,10 +7,12 @@ import { logMessage } from "./logging.js";
 import {
   getHealthySearxngInstances,
   getSearxngInstances,
+  getSearxngBasicAuthHeader,
   isSearxngFanoutEnabled,
   recordSearxngInstanceFailure,
   recordSearxngInstanceSuccess,
   redactSearxngInstanceUrl,
+  stripSearxngInstanceUrlUserinfo,
 } from "./searxng-instances.js";
 import {
   MCPSearXNGError,
@@ -161,7 +163,6 @@ async function fetchWithSearchTimeout(
       url: redactedUrl,
       searxngUrl: redactSearxngInstanceUrl(searxngUrl),
       proxyAgent: !!(requestOptions as any).dispatcher,
-      username: process.env.AUTH_USERNAME,
     };
     throw createNetworkError(safeError, context);
   } finally {
@@ -438,14 +439,11 @@ function buildSearchRequestOptions(url: URL): RequestInit {
     (requestOptions as any).dispatcher = dispatcher;
   }
 
-  const username = process.env.AUTH_USERNAME;
-  const password = process.env.AUTH_PASSWORD;
-
-  if (username && password) {
-    const base64Auth = Buffer.from(`${username}:${password}`).toString('base64');
+  const authHeader = getSearxngBasicAuthHeader(url);
+  if (authHeader) {
     requestOptions.headers = {
       ...requestOptions.headers,
-      'Authorization': `Basic ${base64Auth}`
+      'Authorization': authHeader
     };
   }
 
@@ -467,13 +465,14 @@ async function fetchSearchFromInstance(
 ): Promise<InstanceSearchResult> {
   const url = buildSearchUrl(instanceUrl, request);
   const requestOptions = buildSearchRequestOptions(url);
-  const response = await fetchWithSearchTimeout(mcpServer, url, requestOptions, request.timeoutMs, request.query, instanceUrl);
+  const requestUrl = stripSearxngInstanceUrlUserinfo(url);
+  const response = await fetchWithSearchTimeout(mcpServer, requestUrl, requestOptions, request.timeoutMs, request.query, instanceUrl);
 
   let data: SearXNGWeb;
 
   if (!response.ok) {
     if (isHtmlFallbackEnabled() && shouldFallbackForStatus(response.status)) {
-      data = await fetchHtmlFallbackSearch(mcpServer, url, requestOptions, request.timeoutMs, request.query, instanceUrl);
+      data = await fetchHtmlFallbackSearch(mcpServer, requestUrl, requestOptions, request.timeoutMs, request.query, instanceUrl);
     } else {
       let responseBody: string;
       try {

--- a/src/search.ts
+++ b/src/search.ts
@@ -502,7 +502,7 @@ async function fetchSearchFromInstance(
       data = JSON.parse(responseText) as SearXNGWeb;
     } catch {
       if (isHtmlFallbackEnabled()) {
-        data = await fetchHtmlFallbackSearch(mcpServer, url, requestOptions, request.timeoutMs, request.query, instanceUrl);
+        data = await fetchHtmlFallbackSearch(mcpServer, requestUrl, requestOptions, request.timeoutMs, request.query, instanceUrl);
       } else {
         throw createJSONError(responseText);
       }

--- a/src/searxng-instances.ts
+++ b/src/searxng-instances.ts
@@ -76,10 +76,22 @@ export function stripSearxngInstanceUrlUserinfo(url: URL): URL {
   return stripped;
 }
 
+// `URL` stores userinfo percent-encoded, so decode before base64. A literal `%`
+// the operator forgot to encode (e.g. `100%` instead of `100%25`) parses fine as
+// a URL but makes decodeURIComponent throw URIError — fall back to the raw value
+// instead of crashing request setup rather than guess at re-encoding.
+function decodeUserinfoComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
 export function getSearxngBasicAuthHeader(url: URL): string | undefined {
   if (url.username !== "" || url.password !== "") {
-    const username = decodeURIComponent(url.username);
-    const password = decodeURIComponent(url.password);
+    const username = decodeUserinfoComponent(url.username);
+    const password = decodeUserinfoComponent(url.password);
     return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
   }
 

--- a/src/searxng-instances.ts
+++ b/src/searxng-instances.ts
@@ -69,6 +69,31 @@ export function redactSearxngInstanceUrl(raw: string): string {
   }
 }
 
+export function stripSearxngInstanceUrlUserinfo(url: URL): URL {
+  const stripped = new URL(url.toString());
+  stripped.username = "";
+  stripped.password = "";
+  return stripped;
+}
+
+export function getSearxngBasicAuthHeader(url: URL): string | undefined {
+  if (url.username !== "" || url.password !== "") {
+    const username = decodeURIComponent(url.username);
+    const password = decodeURIComponent(url.password);
+    return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+  }
+
+  const username = process.env.AUTH_USERNAME;
+  const password = process.env.AUTH_PASSWORD;
+
+  if (username && password) {
+    const base64Auth = Buffer.from(`${username}:${password}`).toString('base64');
+    return `Basic ${base64Auth}`;
+  }
+
+  return undefined;
+}
+
 export function isSearxngFanoutEnabled(): boolean {
   return process.env.SEARXNG_FANOUT === "true";
 }

--- a/src/searxng-instances.ts
+++ b/src/searxng-instances.ts
@@ -89,7 +89,11 @@ function decodeUserinfoComponent(value: string): string {
 }
 
 export function getSearxngBasicAuthHeader(url: URL): string | undefined {
-  if (url.username !== "" || url.password !== "") {
+  // URL auth requires a username (username-only token or username+password).
+  // Password-only userinfo (`https://:pass@host`) is treated as absent so a
+  // mistyped URL falls back to global AUTH_* / no header instead of sending a
+  // stray secret; the password is still stripped from the outgoing URL.
+  if (url.username !== "") {
     const username = decodeUserinfoComponent(url.username);
     const password = decodeUserinfoComponent(url.password);
     return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logMessage } from "./logging.js";
 import { applySearchRequestConfig } from "./proxy.js";
-import { getPrimarySearxngInstance } from "./searxng-instances.js";
+import { getPrimarySearxngInstance, stripSearxngInstanceUrlUserinfo } from "./searxng-instances.js";
 
 export async function performSearchSuggestions(
   mcpServer: McpServer,
@@ -15,10 +15,12 @@ export async function performSearchSuggestions(
 
   const parsedBase = new URL(base.endsWith("/") ? base : `${base}/`);
   const url = new URL("autocompleter", parsedBase);
+  const requestUrl = stripSearxngInstanceUrlUserinfo(url);
   url.searchParams.set("q", query);
   if (language !== "all") {
     url.searchParams.set("lang", language);
   }
+  requestUrl.search = url.search;
 
   try {
     const requestOptions: RequestInit = {
@@ -26,7 +28,7 @@ export async function performSearchSuggestions(
     };
     applySearchRequestConfig(requestOptions, url.toString());
 
-    const response = await fetch(url.toString(), requestOptions);
+    const response = await fetch(requestUrl.toString(), requestOptions);
     if (!response.ok) {
       return [];
     }

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -15,12 +15,11 @@ export async function performSearchSuggestions(
 
   const parsedBase = new URL(base.endsWith("/") ? base : `${base}/`);
   const url = new URL("autocompleter", parsedBase);
-  const requestUrl = stripSearxngInstanceUrlUserinfo(url);
   url.searchParams.set("q", query);
   if (language !== "all") {
     url.searchParams.set("lang", language);
   }
-  requestUrl.search = url.search;
+  const requestUrl = stripSearxngInstanceUrlUserinfo(url);
 
   try {
     const requestOptions: RequestInit = {


### PR DESCRIPTION
## TODO item

**FEAT-049** — Apply per-instance Basic Auth from `SEARXNG_URL` userinfo (multi-instance credentials) (🟡 Medium, from TODO-features.md)
Refs: BUG-007, FEAT-047, FEAT-048

## Context

`buildSearchRequestOptions(url)` received the per-instance URL but ignored it for auth — it read the global `AUTH_USERNAME`/`AUTH_PASSWORD` and applied one identical Basic Auth header to **every** instance. With `SEARXNG_URL` holding multiple semicolon-separated replicas, there was no way to give different replicas different credentials, and a heterogeneous setup (one private auth-gated instance + one public/no-auth instance) sent the operator's credentials to the host that never asked for them — a credential leak to the wrong origin.

Two facts uncovered during investigation shaped the change:
- **Node's `fetch` (undici) rejects credential-bearing URLs** (`Request cannot be constructed from a URL that includes credentials`). So embedding userinfo in `SEARXNG_URL` didn't just risk a leak — it broke the request outright. Stripping userinfo before `fetch` is mandatory.
- The `/config` (instance info) and `/autocompleter` (suggestions) fetches build SearXNG-derived URLs the same way and previously sent **no** `Authorization` at all. Since this change makes URL userinfo the documented primary auth method, all three SearXNG-bound paths must honor it, or the feature ships half-broken.

## What changed

- **`src/searxng-instances.ts`** — new shared `getSearxngBasicAuthHeader(url)` (URL userinfo first, percent-decoded, username-only supported; global `AUTH_*` fallback; else none) and non-mutating `stripSearxngInstanceUrlUserinfo(url)`. Single source of truth for auth + stripping.
- **`src/search.ts`** — search requests build auth from the entry's userinfo via the shared helper, then fetch a credential-free URL (search + HTML-fallback paths). Removed the stale, never-read `ErrorContext.username` field.
- **`src/proxy.ts`** — `applySearchRequestConfig()` now also applies the shared Basic Auth header (merged through `Headers` alongside User-Agent), so `/config` and `/autocompleter` authenticate consistently.
- **`src/instance-info.ts`, `src/suggestions.ts`** — strip userinfo before fetch while using per-instance/global auth.
- **`src/resources.ts`** — in-tool help recommends URL userinfo and demotes `AUTH_*` to legacy fallback; `hasAuth` stays env-only.
- **Docs** — `CONFIGURATION.md` leads Authentication with URL userinfo (incl. mixed private/public multi-instance example + percent-encoding note; Full Example switched to a userinfo `SEARXNG_URL`, `AUTH_*` demoted to legacy); `SECURITY.md` documents userinfo as the supported path with redaction; `README.md` notes per-instance embedded credentials.

Backward compatibility: single-URL + global `AUTH_*` behavior is byte-identical (the legacy auth test was tightened to assert the exact header). `AUTH_USERNAME`/`AUTH_PASSWORD` and the env-mismatch validation are retained.

## How it was verified

- `npm run build` — pass
- `npm test` (coverage-gated) — 470/470 pass; 96.08% lines overall (`searxng-instances.ts` and `resources.ts` at 100%), gate ≥80%
- `npm run test:e2e` (local) — 2/2 pass
- `SEARXNG_LIVE_URL=https://searxng.ihor.top npm run test:e2e` (live) — 11/11 pass
- `npm run lint` — clean

(verified independently by the tech lead, not just by the implementer)

Notable new tests: embedded userinfo overrides global auth; multi-instance failover uses embedded auth for instance 1 and global fallback for instance 2, both with credential-free URLs; outgoing fetch URLs stripped of userinfo; percent-encoded `p%40ss` decodes before base64; `/config` and `/autocompleter` carry the per-instance header on a stripped URL.

## Documentation

`CONFIGURATION.md`, `SECURITY.md`, and `README.md` now present URL userinfo as the primary Basic Auth path (with a mixed private/public multi-instance example and percent-encoding guidance), and demote `AUTH_USERNAME`/`AUTH_PASSWORD` to a documented legacy global fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
