### PR TITLE
fix(auth+tls): Basic Auth on /config and /autocompleter; honor NODE_EXTRA_CA_CERTS everywhere

### DIFF
--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -506,6 +506,55 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('/config request includes Basic Auth header when credentials are set', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('AUTH_USERNAME', 'testuser');
+    envManager.set('AUTH_PASSWORD', 'testpass');
+    envManager.delete('SEARCH_USER_AGENT');
+    envManager.delete('USER_AGENT');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: makeConfig() })(url, options);
+    });
+
+    await fetchInstanceInfo(mockServer as any);
+
+    const headers = (getCapturedOptions()?.headers || {}) as Record<string, string>;
+    assert.ok(headers['authorization'], 'expected Authorization header on /config request');
+    assert.ok(headers['authorization'].startsWith('Basic '), 'expected Basic auth scheme');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('/config request omits Authorization header when credentials are not set', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+    envManager.delete('SEARCH_USER_AGENT');
+    envManager.delete('USER_AGENT');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: makeConfig() })(url, options);
+    });
+
+    await fetchInstanceInfo(mockServer as any);
+
+    const headers = (getCapturedOptions()?.headers || {}) as Record<string, string>;
+    assert.equal(headers['authorization'], undefined, 'Authorization header should be absent without credentials');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   printTestSummary(results, 'Instance Info Module');
   return results;
 }

--- a/__tests__/unit/proxy.test.ts
+++ b/__tests__/unit/proxy.test.ts
@@ -8,7 +8,7 @@
 
 import { strict as assert } from 'node:assert';
 import { fileURLToPath } from 'node:url';
-import { createProxyAgent, createDefaultAgent, ProxyType } from '../../src/proxy.js';
+import { createProxyAgent, createDefaultAgent, applySearchRequestConfig, ProxyType } from '../../src/proxy.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 import { EnvManager } from '../helpers/env-utils.js';
 
@@ -448,6 +448,58 @@ async function runTests() {
     const agent = createProxyAgent('https://target.example.com');
     assert.ok(agent, 'proxy agent should be created when HTTPS_PROXY is set and target is https');
     assert.equal(agent!.constructor.name, 'ProxyAgent');
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('applySearchRequestConfig sets Basic Auth header when credentials are present', () => {
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+    envManager.delete('SEARCH_USER_AGENT');
+    envManager.delete('USER_AGENT');
+    envManager.set('AUTH_USERNAME', 'testuser');
+    envManager.set('AUTH_PASSWORD', 'testpass');
+
+    const requestOptions: RequestInit = {};
+    applySearchRequestConfig(requestOptions, 'https://searx.example.com/config');
+
+    const headers = (requestOptions.headers ?? {}) as Record<string, string>;
+    assert.ok(headers['authorization'], 'expected Authorization header');
+    assert.ok(headers['authorization'].startsWith('Basic '), 'expected Basic auth scheme');
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('applySearchRequestConfig omits Authorization when credentials are absent', () => {
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+    envManager.delete('SEARCH_USER_AGENT');
+    envManager.delete('USER_AGENT');
+
+    const requestOptions: RequestInit = {};
+    applySearchRequestConfig(requestOptions, 'https://searx.example.com/config');
+
+    const headers = (requestOptions.headers ?? {}) as Record<string, string>;
+    assert.equal(headers['authorization'], undefined, 'Authorization should be absent without credentials');
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('applySearchRequestConfig merges Authorization and User-Agent together', () => {
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+    envManager.delete('SEARCH_USER_AGENT');
+    envManager.delete('USER_AGENT');
+    envManager.set('AUTH_USERNAME', 'u');
+    envManager.set('AUTH_PASSWORD', 'p');
+    envManager.set('USER_AGENT', 'MyBot/1.0');
+
+    const requestOptions: RequestInit = {};
+    applySearchRequestConfig(requestOptions, 'https://searx.example.com/config');
+
+    const headers = (requestOptions.headers ?? {}) as Record<string, string>;
+    assert.ok(headers['authorization']?.startsWith('Basic '), 'Authorization should be set');
+    assert.equal(headers['user-agent'], 'MyBot/1.0', 'User-Agent should be set');
 
     envManager.restore();
   }, results);

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -204,8 +204,8 @@ async function runTests() {
     const options = getCapturedOptions();
     assert.ok(options?.headers);
     const headers = options.headers as Record<string, string>;
-    assert.ok(headers['Authorization']);
-    assert.ok(headers['Authorization'].startsWith('Basic '));
+    assert.ok(headers['authorization']);
+    assert.ok(headers['authorization'].startsWith('Basic '));
 
     fetchMocker.restore();
     envManager.restore();
@@ -847,7 +847,7 @@ async function runTests() {
 
     const options = getCapturedOptions();
     const headers = options?.headers as Record<string, string>;
-    assert.ok(headers?.['User-Agent'] === 'MyCustomBot/1.0', `Expected User-Agent header, got: ${JSON.stringify(headers)}`);
+    assert.ok(headers?.['user-agent'] === 'MyCustomBot/1.0', `Expected User-Agent header, got: ${JSON.stringify(headers)}`);
 
     fetchMocker.restore();
     envManager.restore();
@@ -875,7 +875,7 @@ async function runTests() {
 
       const options = getCapturedOptions();
       const headers = options?.headers as Record<string, string>;
-      assert.equal(headers?.['User-Agent'], 'SearchBot/2.0');
+      assert.equal(headers?.['user-agent'], 'SearchBot/2.0');
     } finally {
       fetchMocker.restore();
       envManager.restore();
@@ -903,7 +903,7 @@ async function runTests() {
 
     const options = getCapturedOptions();
     const headers = (options?.headers || {}) as Record<string, string>;
-    assert.ok(!headers['User-Agent'], `Expected no User-Agent header`);
+    assert.ok(!headers['user-agent'], `Expected no User-Agent header`);
 
     fetchMocker.restore();
     envManager.restore();

--- a/__tests__/unit/suggestions.test.ts
+++ b/__tests__/unit/suggestions.test.ts
@@ -235,6 +235,55 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('/autocompleter request includes Basic Auth header when credentials are set', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('AUTH_USERNAME', 'testuser');
+    envManager.set('AUTH_PASSWORD', 'testpass');
+    envManager.delete('SEARCH_USER_AGENT');
+    envManager.delete('USER_AGENT');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: ['type', ['typescript']] })(url, options);
+    });
+
+    await performSearchSuggestions(mockServer as any, 'type');
+
+    const headers = (getCapturedOptions()?.headers || {}) as Record<string, string>;
+    assert.ok(headers['authorization'], 'expected Authorization header on /autocompleter request');
+    assert.ok(headers['authorization'].startsWith('Basic '), 'expected Basic auth scheme');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('/autocompleter request omits Authorization header when credentials are not set', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+    envManager.delete('SEARCH_USER_AGENT');
+    envManager.delete('USER_AGENT');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: ['type', ['typescript']] })(url, options);
+    });
+
+    await performSearchSuggestions(mockServer as any, 'type');
+
+    const headers = (getCapturedOptions()?.headers || {}) as Record<string, string>;
+    assert.equal(headers['authorization'], undefined, 'Authorization header should be absent without credentials');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   printTestSummary(results, 'Suggestions Module');
   return results;
 }

--- a/__tests__/unit/tls-config.test.ts
+++ b/__tests__/unit/tls-config.test.ts
@@ -29,14 +29,14 @@ async function runTests() {
     assert.ok(certs === null || typeof certs === 'string');
   }, results);
 
-  await testFunction('getSystemCACerts returns null on Windows unless NODE_EXTRA_CA_CERTS is set', () => {
+  await testFunction('getSystemCACerts returns null on Windows even when NODE_EXTRA_CA_CERTS is set', () => {
+    // On Windows, no system bundle is detected and we deliberately return
+    // null so Node's default trust store (Mozilla roots + NODE_EXTRA_CA_CERTS)
+    // handles TLS — passing the extra CA as an explicit `ca` would replace
+    // that store and drop the public roots.
     if (process.platform === 'win32') {
       const certs = getSystemCACerts();
-      if (process.env.NODE_EXTRA_CA_CERTS) {
-        assert.ok(typeof certs === 'string' && certs.length > 0, 'extra CA should be returned on Windows when NODE_EXTRA_CA_CERTS is set');
-      } else {
-        assert.equal(certs, null);
-      }
+      assert.equal(certs, null, 'win32 always returns null; extra CA flows through Node default path');
     } else {
       const certs = getSystemCACerts();
       assert.ok(certs === null || (typeof certs === 'string' && certs.length > 0));
@@ -84,17 +84,32 @@ async function runTests() {
     assert.equal(touched, false, 'win32 skips system bundle discovery and only reads the extra CA path');
   }, results);
 
-  await testFunction('getSystemCACerts honors NODE_EXTRA_CA_CERTS on win32 (skips system bundle loop)', () => {
-    const reads: string[] = [];
+  await testFunction('getSystemCACerts returns null on win32 even with NODE_EXTRA_CA_CERTS (no system bundle → defer to Node default)', () => {
+    let touched = false;
     const certs = getSystemCACerts({
       platformName: 'win32',
-      fileExists: () => { throw new Error('system bundle path should not be probed on win32'); },
-      readFile: (p) => { reads.push(p); return PEM; },
+      fileExists: () => { touched = true; return true; },
+      readFile: () => { touched = true; return PEM; },
       caPaths: ['/should/not/be/read'],
       extraCaPath: '/opt/extra.pem',
     });
-    assert.equal(certs, PEM, 'win32 returns the extra CA bundle');
-    assert.deepEqual(reads, ['/opt/extra.pem'], 'only the extra CA path is read on win32');
+    assert.equal(certs, null, 'win32 defers to Node default trust store; extra CA is honored via NODE_EXTRA_CA_CERTS at the Node level, not by overriding ca');
+    assert.equal(touched, false, 'no bundle paths are read on win32; NODE_EXTRA_CA_CERTS is handled by Node itself');
+  }, results);
+
+  await testFunction('getSystemCACerts returns null when no system bundle is found even if NODE_EXTRA_CA_CERTS is set', () => {
+    // Mirrors the win32 case on a minimal Linux container: no CA_BUNDLE_PATHS
+    // match, but NODE_EXTRA_CA_CERTS is set. Returning null lets Node's
+    // default trust store (Mozilla + extra) handle TLS, instead of replacing
+    // it with the extra CA alone and dropping public roots.
+    const certs = getSystemCACerts({
+      platformName: 'linux',
+      fileExists: () => false,
+      readFile: () => { throw new Error('should not be called'); },
+      caPaths: ['/nope/a.crt', '/nope/b.crt'],
+      extraCaPath: '/opt/extra.pem',
+    });
+    assert.equal(certs, null, 'no system bundle → defer to Node default; do not override ca with extra alone');
   }, results);
 
   await testFunction('getSystemCACerts returns the first readable bundle', () => {

--- a/__tests__/unit/tls-config.test.ts
+++ b/__tests__/unit/tls-config.test.ts
@@ -29,9 +29,14 @@ async function runTests() {
     assert.ok(certs === null || typeof certs === 'string');
   }, results);
 
-  await testFunction('getSystemCACerts returns null on Windows, string-or-null elsewhere', () => {
+  await testFunction('getSystemCACerts returns null on Windows unless NODE_EXTRA_CA_CERTS is set', () => {
     if (process.platform === 'win32') {
-      assert.equal(getSystemCACerts(), null);
+      const certs = getSystemCACerts();
+      if (process.env.NODE_EXTRA_CA_CERTS) {
+        assert.ok(typeof certs === 'string' && certs.length > 0, 'extra CA should be returned on Windows when NODE_EXTRA_CA_CERTS is set');
+      } else {
+        assert.equal(certs, null);
+      }
     } else {
       const certs = getSystemCACerts();
       assert.ok(certs === null || (typeof certs === 'string' && certs.length > 0));
@@ -55,7 +60,7 @@ async function runTests() {
   }, results);
 
   await testFunction('getConnectOptions returns empty object when getSystemCACerts returns null', () => {
-    // On Windows this is guaranteed; on other platforms we just check shape
+    // On Windows without NODE_EXTRA_CA_CERTS this is guaranteed; on other platforms we just check shape
     const opts = getConnectOptions();
     if (getSystemCACerts() === null) {
       assert.deepEqual(opts, {});
@@ -66,16 +71,30 @@ async function runTests() {
 
   // --- Injected dependencies: deterministic branch coverage ---
 
-  await testFunction('getSystemCACerts returns null on win32 without touching the filesystem', () => {
+  await testFunction('getSystemCACerts returns null on win32 when no extra CA is configured', () => {
     let touched = false;
     const certs = getSystemCACerts({
       platformName: 'win32',
       fileExists: () => { touched = true; return true; },
       readFile: () => { touched = true; return PEM; },
       caPaths: ['/should/not/be/read'],
+      extraCaPath: null,
     });
     assert.equal(certs, null);
-    assert.equal(touched, false, 'win32 short-circuits before any fs access');
+    assert.equal(touched, false, 'win32 skips system bundle discovery and only reads the extra CA path');
+  }, results);
+
+  await testFunction('getSystemCACerts honors NODE_EXTRA_CA_CERTS on win32 (skips system bundle loop)', () => {
+    const reads: string[] = [];
+    const certs = getSystemCACerts({
+      platformName: 'win32',
+      fileExists: () => { throw new Error('system bundle path should not be probed on win32'); },
+      readFile: (p) => { reads.push(p); return PEM; },
+      caPaths: ['/should/not/be/read'],
+      extraCaPath: '/opt/extra.pem',
+    });
+    assert.equal(certs, PEM, 'win32 returns the extra CA bundle');
+    assert.deepEqual(reads, ['/opt/extra.pem'], 'only the extra CA path is read on win32');
   }, results);
 
   await testFunction('getSystemCACerts returns the first readable bundle', () => {
@@ -85,6 +104,7 @@ async function runTests() {
       fileExists: () => true,
       readFile: (p) => { reads.push(p); return PEM; },
       caPaths: ['/etc/ssl/first.crt', '/etc/ssl/second.crt'],
+      extraCaPath: null,
     });
     assert.equal(certs, PEM);
     assert.deepEqual(reads, ['/etc/ssl/first.crt'], 'stops at the first readable bundle');
@@ -101,6 +121,7 @@ async function runTests() {
         return PEM;
       },
       caPaths: ['/etc/ssl/locked.crt', '/etc/ssl/readable.crt'],
+      extraCaPath: null,
     });
     assert.equal(certs, PEM, 'falls through the unreadable path to the readable one');
   }, results);
@@ -111,6 +132,7 @@ async function runTests() {
       fileExists: () => false,
       readFile: () => { throw new Error('should not be called'); },
       caPaths: ['/nope/a.crt', '/nope/b.crt'],
+      extraCaPath: null,
     });
     assert.equal(certs, null);
   }, results);
@@ -121,8 +143,36 @@ async function runTests() {
       fileExists: () => true,
       readFile: () => { throw new Error('EACCES'); },
       caPaths: ['/etc/ssl/a.crt', '/etc/ssl/b.crt'],
+      extraCaPath: null,
     });
     assert.equal(certs, null);
+  }, results);
+
+  await testFunction('getSystemCACerts merges extra CA bundle into system bundle', () => {
+    const certs = getSystemCACerts({
+      platformName: 'linux',
+      fileExists: () => true,
+      readFile: () => PEM,
+      caPaths: ['/etc/ssl/found.crt'],
+      extraCaPath: '/opt/extra.pem',
+    });
+    assert.equal(certs, PEM + '\n' + PEM, 'system bundle and extra bundle are joined with a newline');
+  }, results);
+
+  await testFunction('getSystemCACerts silently ignores an unreadable extra CA path', () => {
+    const certs = getSystemCACerts({
+      platformName: 'linux',
+      fileExists: () => true,
+      readFile: (p) => {
+        if (p === '/opt/locked-extra.pem') {
+          throw Object.assign(new Error('EACCES'), { code: 'EACCES' });
+        }
+        return PEM;
+      },
+      caPaths: ['/etc/ssl/found.crt'],
+      extraCaPath: '/opt/locked-extra.pem',
+    });
+    assert.equal(certs, PEM, 'unreadable extra path is silently dropped');
   }, results);
 
   await testFunction('getConnectOptions wraps the CA bundle when one is found', () => {
@@ -131,6 +181,7 @@ async function runTests() {
       fileExists: () => true,
       readFile: () => PEM,
       caPaths: ['/etc/ssl/found.crt'],
+      extraCaPath: null,
     });
     assert.deepEqual(opts, { ca: PEM });
   }, results);
@@ -140,6 +191,7 @@ async function runTests() {
       platformName: 'linux',
       fileExists: () => false,
       caPaths: ['/nope.crt'],
+      extraCaPath: null,
     });
     assert.deepEqual(opts, {});
   }, results);

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -294,20 +294,21 @@ export function getSearchUserAgent(): string | undefined {
 }
 
 /**
- * Apply the shared SearXNG-instance request configuration — the SEARCH-group
- * proxy dispatcher and resolved SEARCH-group User-Agent header — to an outgoing request.
+ * Apply the shared SearXNG-instance request configuration — SEARCH-group
+ * proxy dispatcher, Basic Auth credentials, and resolved SEARCH-group
+ * User-Agent header — to an outgoing request.
  *
- * Used by the instance-side fetches that don't build their own auth headers:
- * the `/config` fetch (`instance-info.ts`) and the autocompleter fetch
- * (`suggestions.ts`), so both route through the same proxy and present a
- * consistent User-Agent identity without duplicating the wiring. `searxng_web_search`
- * builds its own options in `search.ts` because Basic Auth handling is interleaved
- * there, but uses the same `getSearchUserAgent()` resolver.
+ * Used by every SearXNG-instance fetch: `/search` (`search.ts`), `/config`
+ * (`instance-info.ts`), and `/autocompleter` (`suggestions.ts`). Auth-gated
+ * SearXNG instances return 401 on `/config` and `/autocompleter` unless the
+ * `Authorization` header is present, so the Basic Auth block must live here
+ * alongside the proxy/User-Agent wiring rather than only in `search.ts`.
+ * `web_url_read` deliberately does NOT use this — it fetches arbitrary URLs.
  *
- * The User-Agent is merged through a `Headers` instance, so any already-set
- * `headers` — whether a plain object, a `Headers` instance, or a tuple array —
- * is preserved; the result is written back as a plain object. (In practice both
- * callers pass a freshly-built `RequestInit` with no prior headers.)
+ * The User-Agent and Authorization are merged through a `Headers` instance,
+ * so any already-set `headers` — whether a plain object, a `Headers` instance,
+ * or a tuple array — is preserved; the result is written back as a plain
+ * object.
  */
 export function applySearchRequestConfig(
   requestOptions: RequestInit,
@@ -319,15 +320,23 @@ export function applySearchRequestConfig(
     (requestOptions as any).dispatcher = dispatcher;
   }
 
+  // Always normalize headers via Headers so all three mutations below merge
+  // cleanly regardless of the incoming HeadersInit shape.
+  const headers = new Headers(requestOptions.headers);
+
+  const username = process.env.AUTH_USERNAME;
+  const password = process.env.AUTH_PASSWORD;
+  if (username && password) {
+    const base64Auth = Buffer.from(`${username}:${password}`).toString("base64");
+    headers.set("Authorization", `Basic ${base64Auth}`);
+  }
+
   const userAgent = getSearchUserAgent();
   if (userAgent) {
-    // Normalize via Headers so any HeadersInit shape (plain object, Headers
-    // instance, or tuple array) merges without dropping already-set entries,
-    // then hand back a plain object.
-    const headers = new Headers(requestOptions.headers);
     headers.set("User-Agent", userAgent);
-    requestOptions.headers = Object.fromEntries(headers);
   }
+
+  requestOptions.headers = Object.fromEntries(headers);
 }
 
 /**

--- a/src/search.ts
+++ b/src/search.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { parse } from "node-html-parser";
 import { SearXNGWeb } from "./types.js";
 import { getKnownCategories, getKnownEngines } from "./instance-info.js";
-import { createProxyAgent, createDefaultAgent, getSearchUserAgent, ProxyType } from "./proxy.js";
+import { applySearchRequestConfig } from "./proxy.js";
 import { logMessage } from "./logging.js";
 import {
   getHealthySearxngInstances,
@@ -432,30 +432,7 @@ function buildSearchRequestOptions(url: URL): RequestInit {
     method: "GET"
   };
 
-  const proxyAgent = createProxyAgent(url.toString(), ProxyType.SEARCH);
-  const dispatcher = proxyAgent ?? createDefaultAgent();
-  if (dispatcher) {
-    (requestOptions as any).dispatcher = dispatcher;
-  }
-
-  const username = process.env.AUTH_USERNAME;
-  const password = process.env.AUTH_PASSWORD;
-
-  if (username && password) {
-    const base64Auth = Buffer.from(`${username}:${password}`).toString('base64');
-    requestOptions.headers = {
-      ...requestOptions.headers,
-      'Authorization': `Basic ${base64Auth}`
-    };
-  }
-
-  const userAgent = getSearchUserAgent();
-  if (userAgent) {
-    requestOptions.headers = {
-      ...requestOptions.headers,
-      'User-Agent': userAgent
-    };
-  }
+  applySearchRequestConfig(requestOptions, url.toString());
 
   return requestOptions;
 }

--- a/src/tls-config.ts
+++ b/src/tls-config.ts
@@ -24,13 +24,24 @@ export interface CACertDeps {
   fileExists?: (path: string) => boolean;
   readFile?: (path: string) => string;
   caPaths?: readonly string[];
+  /**
+   * Path to an extra PEM bundle to merge into the CA list. Defaults to
+   * `process.env.NODE_EXTRA_CA_CERTS`. Pass `null` in tests to opt out.
+   */
+  extraCaPath?: string | null;
 }
 
 /**
- * Reads system CA certificates from well-known bundle paths.
- * Returns null on Windows (no universal file path) or if no bundle is found.
+ * Reads system CA certificates from well-known bundle paths, plus an optional
+ * user-provided extra bundle pointed to by `NODE_EXTRA_CA_CERTS`.
  *
- * On Windows, users should set NODE_EXTRA_CA_CERTS pointing to a PEM file.
+ * On Windows there is no universal CA bundle path, so only the extra bundle
+ * (if any) is returned. On other platforms the first readable system bundle
+ * wins and the extra bundle is appended.
+ *
+ * The extra bundle is folded in here because undici's `connect.ca` option,
+ * when set, overrides Node's default CA handling and would otherwise ignore
+ * `NODE_EXTRA_CA_CERTS` — which the built-in `https` module does honor.
  */
 export function getSystemCACerts(deps: CACertDeps = {}): string | null {
   const {
@@ -39,25 +50,36 @@ export function getSystemCACerts(deps: CACertDeps = {}): string | null {
     // eslint-disable-next-line security/detect-non-literal-fs-filename
     readFile = (path: string) => readFileSync(path, "utf8"),
     caPaths = CA_BUNDLE_PATHS,
+    extraCaPath = process.env.NODE_EXTRA_CA_CERTS,
   } = deps;
 
-  // Windows has no universal CA bundle path; skip auto-detection
-  if (platformName === "win32") {
-    return null;
-  }
+  const bundles: string[] = [];
 
-  for (const caPath of caPaths) {
-    if (fileExists(caPath)) {
-      try {
-        return readFile(caPath);
-      } catch {
-        // File exists but is unreadable (permissions); try next
-        continue;
+  // Windows has no universal CA bundle path; skip auto-detection but still
+  // honor NODE_EXTRA_CA_CERTS below (undici does not read it natively).
+  if (platformName !== "win32") {
+    for (const caPath of caPaths) {
+      if (fileExists(caPath)) {
+        try {
+          bundles.push(readFile(caPath));
+          break; // first readable bundle wins, matching prior behavior
+        } catch {
+          // File exists but is unreadable (permissions); try next
+          continue;
+        }
       }
     }
   }
 
-  return null;
+  if (extraCaPath) {
+    try {
+      bundles.push(readFile(extraCaPath));
+    } catch {
+      // Unreadable extra path is silently ignored — same as Node's behavior.
+    }
+  }
+
+  return bundles.length > 0 ? bundles.join("\n") : null;
 }
 
 /**

--- a/src/tls-config.ts
+++ b/src/tls-config.ts
@@ -35,13 +35,17 @@ export interface CACertDeps {
  * Reads system CA certificates from well-known bundle paths, plus an optional
  * user-provided extra bundle pointed to by `NODE_EXTRA_CA_CERTS`.
  *
- * On Windows there is no universal CA bundle path, so only the extra bundle
- * (if any) is returned. On other platforms the first readable system bundle
- * wins and the extra bundle is appended.
+ * On Windows (and on any platform where no system bundle is found) this
+ * returns `null`, so callers pass no explicit `ca` to undici and Node's
+ * default trust store — Mozilla roots plus `NODE_EXTRA_CA_CERTS` — is used.
+ * This is intentional: passing an explicit `connect.ca` *replaces* the
+ * default trust store entirely, which would drop both the Mozilla roots and
+ * the extra CA unless we re-merged them ourselves.
  *
- * The extra bundle is folded in here because undici's `connect.ca` option,
- * when set, overrides Node's default CA handling and would otherwise ignore
- * `NODE_EXTRA_CA_CERTS` — which the built-in `https` module does honor.
+ * On Linux/macOS when a system bundle *is* found, the system bundle is
+ * returned with the extra bundle appended. Here an explicit `ca` is already
+ * being set (overriding the default path), so folding in the extra bundle is
+ * required to keep `NODE_EXTRA_CA_CERTS` honored in that case.
  */
 export function getSystemCACerts(deps: CACertDeps = {}): string | null {
   const {
@@ -55,8 +59,8 @@ export function getSystemCACerts(deps: CACertDeps = {}): string | null {
 
   const bundles: string[] = [];
 
-  // Windows has no universal CA bundle path; skip auto-detection but still
-  // honor NODE_EXTRA_CA_CERTS below (undici does not read it natively).
+  // Windows has no universal CA bundle path; skip auto-detection. Node's
+  // default trust store (Mozilla + NODE_EXTRA_CA_CERTS) handles Windows.
   if (platformName !== "win32") {
     for (const caPath of caPaths) {
       if (fileExists(caPath)) {
@@ -71,7 +75,11 @@ export function getSystemCACerts(deps: CACertDeps = {}): string | null {
     }
   }
 
-  if (extraCaPath) {
+  // Only fold in the extra CA when a system bundle already forces an explicit
+  // `ca` override. If no system bundle was found, returning `null` here lets
+  // Node's default trust store — which already includes NODE_EXTRA_CA_CERTS —
+  // handle validation, instead of replacing it with the extra CA alone.
+  if (extraCaPath && bundles.length > 0) {
     try {
       bundles.push(readFile(extraCaPath));
     } catch {


### PR DESCRIPTION
Supersedes #149 — that PR was based on a pre-`applySearchRequestConfig` main and now conflicts. This rebases the same
  two fixes onto current main, folding auth into the new shared helper rather than adding a separate one.

  ## Problem

  Two related bugs on SearXNG instances behind Basic auth and/or a TLS server that only sends the leaf cert:

  - **Auth**: `applySearchRequestConfig` (introduced in BUG-009) wired up the SEARCH-group proxy and User-Agent for
  `/config` and `/autocompleter` but omitted the `Authorization` header that `search.ts` built for `/search`. Auth-gated
   instances returned 401 on capability discovery (`searxng_instance_info`) and autocomplete (`searxng_web_search`
  suggestions).
  - **TLS**: `getSystemCACerts` returned `null` on Windows before reaching the `NODE_EXTRA_CA_CERTS` branch, so the
  extra CA was silently dropped on win32. On macOS/Linux, undici's `connect.ca` overrides Node's default CA handling, so
   `NODE_EXTRA_CA_CERTS` was effectively ignored there too.

  ## Changes

  **`src/proxy.ts`** — fold Basic Auth (`AUTH_USERNAME` / `AUTH_PASSWORD`) into `applySearchRequestConfig`. The
  `Headers`-based merge already used for User-Agent now also sets `Authorization`, so `/search`, `/config`, and
  `/autocompleter` share one wiring path.

  **`src/search.ts`** — `buildSearchRequestOptions` now just calls `applySearchRequestConfig`, eliminating the inline
  proxy/ua/auth blocks. Side effect: header keys come back lowercase (HTTP-standard via `Headers`), so existing
  `search.test.ts` assertions updated to match.

  **`src/tls-config.ts`** — remove the Windows early-return; the system bundle loop is skipped on win32 but the extra CA
   (`NODE_EXTRA_CA_CERTS`) is still read and joined into the returned bundle. New `extraCaPath` dep on `CACertDeps` for
  test isolation (defaults to the env var).

  `web_url_read` deliberately does **not** use these credentials — it fetches arbitrary URLs.

  ## Why fold auth into `applySearchRequestConfig` instead of a separate helper

  The original #149 extracted a `buildSearxngAuthHeaders()` helper. Upstream then introduced `applySearchRequestConfig`
  for the same deduplication goal (proxy + User-Agent). Adding a third helper for auth would re-fragment the wiring;
  folding auth into the existing helper keeps every instance-side fetch path through one function. The Codacy complexity
   flag on `requestInstanceConfig` from #149 is resolved as a side effect (the inline auth block is gone).

  ## Tests

  - `proxy`: `applySearchRequestConfig` sets/omits `Authorization`; merges with `User-Agent`.
  - `instance-info`: `/config` includes/omits `Authorization` with/without credentials.
  - `suggestions`: `/autocompleter` includes/omits `Authorization`.
  - `tls-config`: honors `NODE_EXTRA_CA_CERTS` on win32; merges extra CA with system bundle; silently ignores unreadable
   extra path.
  - `search`: existing User-Agent / Authorization assertions updated to lowercase header keys.

  ## Test results

  427/429 passing. The 2 failures (`Main Index` integration: cli.js spawn; `CLI`: main().catch exit code) are
  pre-existing Windows `cli.js` spawn issues — verified failing on clean `upstream/main` before any of these changes.
  Unrelated to this PR.