### PR TITLE
feat(search): apply per-instance Basic Auth from SEARXNG_URL userinfo (FEAT-049)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,7 +6,7 @@ All environment variables for `mcp-searxng`, organized by concern. All variables
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `SEARXNG_URL` | Yes | — | URL of your SearXNG instance, or a semicolon-separated list of interchangeable replica base URLs. Single URL behavior is unchanged. Format: `<protocol>://[username[:password]@]<hostname>[:<port>]` (e.g. `http://localhost:8080`, `https://user:pass@search.example.com`, or `https://user:pass@one.example.com;https://two.example.com`) |
+| `SEARXNG_URL` | Yes | — | URL of your SearXNG instance, or a semicolon-separated list of interchangeable replica base URLs. Single URL behavior is unchanged. Format: `<protocol>://[username[:password]@]<hostname>[:<port>][/path]` (e.g. `http://localhost:8080`, `https://user:pass@search.example.com`, `https://searx.example.com/searxng`, or `https://user:pass@one.example.com;https://two.example.com`) |
 | `SEARXNG_FANOUT` | No | `false` | Set to `true` to query all healthy configured SearXNG instances in parallel and merge results. Default failover mode tries instances in order until one returns results. |
 
 When `SEARXNG_URL` contains multiple semicolon-separated URLs, they are treated as interchangeable replicas. Default mode fails over in order when an instance hard-fails or returns no results. A reachable `200 OK` response with an empty `results` array is considered healthy and does not trigger cooldown. Instances with 3 consecutive hard failures are skipped for 60 seconds.

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -6,7 +6,7 @@ All environment variables for `mcp-searxng`, organized by concern. All variables
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `SEARXNG_URL` | Yes | — | URL of your SearXNG instance, or a semicolon-separated list of interchangeable replica base URLs. Single URL behavior is unchanged. Format: `<protocol>://<hostname>[:<port>]` (e.g. `http://localhost:8080` or `https://one.example.com;https://two.example.com`) |
+| `SEARXNG_URL` | Yes | — | URL of your SearXNG instance, or a semicolon-separated list of interchangeable replica base URLs. Single URL behavior is unchanged. Format: `<protocol>://[username[:password]@]<hostname>[:<port>]` (e.g. `http://localhost:8080`, `https://user:pass@search.example.com`, or `https://user:pass@one.example.com;https://two.example.com`) |
 | `SEARXNG_FANOUT` | No | `false` | Set to `true` to query all healthy configured SearXNG instances in parallel and merge results. Default failover mode tries instances in order until one returns results. |
 
 When `SEARXNG_URL` contains multiple semicolon-separated URLs, they are treated as interchangeable replicas. Default mode fails over in order when an instance hard-fails or returns no results. A reachable `200 OK` response with an empty `results` array is considered healthy and does not trigger cooldown. Instances with 3 consecutive hard failures are skipped for 60 seconds.
@@ -15,10 +15,24 @@ With `SEARXNG_FANOUT=true`, all healthy instances are queried in parallel. Resul
 
 ## Authentication
 
+For SearXNG instances protected with HTTP Basic Auth, embed credentials in each `SEARXNG_URL` entry:
+
+```bash
+SEARXNG_URL=https://username:password@search.example.com
+```
+
+For multiple interchangeable replicas, each semicolon-separated URL can carry its own credentials. This supports mixed deployments such as one private auth-gated instance and one public instance without sending the private credentials to the public host:
+
+```bash
+SEARXNG_URL=https://alice:secret@private-search.example.com;https://public-search.example.com
+```
+
+Percent-encode special characters in usernames or passwords before placing them in the URL. For example, password `p@ss` should be written as `p%40ss`.
+
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `AUTH_USERNAME` | No | — | HTTP Basic Auth username for password-protected SearXNG instances |
-| `AUTH_PASSWORD` | No | — | HTTP Basic Auth password for password-protected SearXNG instances |
+| `AUTH_USERNAME` | No | — | Legacy global HTTP Basic Auth username fallback used only when a `SEARXNG_URL` entry has no userinfo |
+| `AUTH_PASSWORD` | No | — | Legacy global HTTP Basic Auth password fallback used only when a `SEARXNG_URL` entry has no userinfo |
 
 ## Timeouts
 
@@ -191,7 +205,7 @@ Complete MCP client configuration with every variable. Mix and match as needed �
       "command": "npx",
       "args": ["-y", "mcp-searxng"],
       "env": {
-        "SEARXNG_URL": "YOUR_SEARXNG_INSTANCE_URL",
+        "SEARXNG_URL": "https://your_username:your_password@searxng.example.com",
         "SEARXNG_FANOUT": "false",
         "SEARXNG_TIMEOUT_MS": "10000",
         "FETCH_TIMEOUT_MS": "10000",
@@ -205,8 +219,6 @@ Complete MCP client configuration with every variable. Mix and match as needed �
         "URL_READ_MAX_CONTENT_LENGTH_BYTES": "5242880",
         "CACHE_TTL_MS": "86400000",
         "CACHE_MAX_ENTRIES": "500",
-        "AUTH_USERNAME": "your_username",
-        "AUTH_PASSWORD": "your_password",
         "USER_AGENT": "MyBot/1.0",
         "SEARCH_USER_AGENT": "MySearchBot/1.0",
         "URL_READER_USER_AGENT": "Mozilla/5.0 (compatible; MyBot/1.0)",

--- a/README.md
+++ b/README.md
@@ -258,7 +258,7 @@ curl http://localhost:3000/health
 
 ## Configuration
 
-Set `SEARXNG_URL` to your SearXNG instance URL. For failover, set it to semicolon-separated interchangeable replica URLs. Set `SEARXNG_FANOUT=true` to query all healthy replicas in parallel and merge results. All other variables are optional.
+Set `SEARXNG_URL` to your SearXNG instance URL. For Basic Auth, embed credentials per instance, for example `https://user:password@search.example.com`. For failover, set it to semicolon-separated interchangeable replica URLs; each entry can carry its own credentials. Set `SEARXNG_FANOUT=true` to query all healthy replicas in parallel and merge results. All other variables are optional.
 
 Full environment variable reference: [CONFIGURATION.md](CONFIGURATION.md)
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -131,7 +131,7 @@ Enable `MCP_HTTP_TRUST_PROXY` only when the server is behind a trusted reverse p
 
 ### Secrets in Environment Variables
 
-SearXNG Basic Auth is supported by embedding credentials in the `SEARXNG_URL` userinfo — see the [Authentication section of CONFIGURATION.md](CONFIGURATION.md#authentication) for the exact format. This is the recommended path because each semicolon-separated instance URL can carry its own credentials. URL userinfo is stripped from outgoing fetch URLs and redacted from logs and errors, and it is redacted from the `config://server-config` resource as well (the host is shown, credentials are not). The `/health` endpoint never exposes `SEARXNG_URL`.
+SearXNG Basic Auth is supported by embedding credentials in the `SEARXNG_URL` userinfo — see the [Authentication section of CONFIGURATION.md](CONFIGURATION.md#authentication) for the exact format. This is the recommended path because each semicolon-separated instance URL can carry its own credentials. URL userinfo is stripped from outgoing fetch URLs and redacted from logs and errors, and it is redacted from the `config://server-config` resource as well (the host is shown, credentials are not). The `/health` endpoint does not expose `SEARXNG_URL`.
 
 Because credentials may be embedded in it, treat the whole `SEARXNG_URL` as a secret: `AUTH_PASSWORD` remains available as a legacy global fallback when a `SEARXNG_URL` entry has no userinfo, and `MCP_HTTP_AUTH_TOKEN`, proxy credentials, and any credentials embedded in `SEARXNG_URL` are secrets. Avoid committing them to source control. Use secret management (Docker secrets, environment injection at runtime, or a secrets manager) in production.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -131,9 +131,9 @@ Enable `MCP_HTTP_TRUST_PROXY` only when the server is behind a trusted reverse p
 
 ### Secrets in Environment Variables
 
-SearXNG Basic Auth is supported by embedding credentials in the `SEARXNG_URL` userinfo — see the [Authentication section of CONFIGURATION.md](CONFIGURATION.md#authentication) for the exact format. This is the recommended path because each semicolon-separated instance URL can carry its own credentials. URL userinfo is stripped from outgoing fetch URLs and redacted from logs and errors.
+SearXNG Basic Auth is supported by embedding credentials in the `SEARXNG_URL` userinfo — see the [Authentication section of CONFIGURATION.md](CONFIGURATION.md#authentication) for the exact format. This is the recommended path because each semicolon-separated instance URL can carry its own credentials. URL userinfo is stripped from outgoing fetch URLs and redacted from logs and errors, and it is redacted from the `config://server-config` resource as well (the host is shown, credentials are not). The `/health` endpoint never exposes `SEARXNG_URL`.
 
-`AUTH_PASSWORD` remains available as a legacy global fallback when a `SEARXNG_URL` entry has no userinfo. `MCP_HTTP_AUTH_TOKEN`, proxy credentials, and any credentials embedded in `SEARXNG_URL` are secrets. Avoid committing them to source control. Use secret management (Docker secrets, environment injection at runtime, or a secrets manager) in production.
+Because credentials may be embedded in it, treat the whole `SEARXNG_URL` as a secret: `AUTH_PASSWORD` remains available as a legacy global fallback when a `SEARXNG_URL` entry has no userinfo, and `MCP_HTTP_AUTH_TOKEN`, proxy credentials, and any credentials embedded in `SEARXNG_URL` are secrets. Avoid committing them to source control. Use secret management (Docker secrets, environment injection at runtime, or a secrets manager) in production.
 
 ## Scope
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -35,7 +35,7 @@ The primary security surface areas are:
 | `web_url_read` tool | SSRF — the server fetches user-supplied URLs on behalf of the AI |
 | HTTP transport | Unauthorized access, DNS rebinding, CORS misconfiguration |
 | Proxy credentials | Credential exposure in environment variables |
-| SearXNG credentials | `AUTH_PASSWORD` in environment |
+| SearXNG credentials | Credentials in `SEARXNG_URL` userinfo or legacy `AUTH_PASSWORD` fallback |
 | Query forwarding | Search queries are forwarded verbatim to SearXNG |
 
 ## Security Features
@@ -131,7 +131,9 @@ Enable `MCP_HTTP_TRUST_PROXY` only when the server is behind a trusted reverse p
 
 ### Secrets in Environment Variables
 
-`AUTH_PASSWORD`, `MCP_HTTP_AUTH_TOKEN`, and proxy credentials are read from environment variables. Avoid committing these to source control. Use secret management (Docker secrets, environment injection at runtime, or a secrets manager) in production.
+SearXNG Basic Auth is supported by embedding credentials in the `SEARXNG_URL` userinfo — see the [Authentication section of CONFIGURATION.md](CONFIGURATION.md#authentication) for the exact format. This is the recommended path because each semicolon-separated instance URL can carry its own credentials. URL userinfo is stripped from outgoing fetch URLs and redacted from logs and errors.
+
+`AUTH_PASSWORD` remains available as a legacy global fallback when a `SEARXNG_URL` entry has no userinfo. `MCP_HTTP_AUTH_TOKEN`, proxy credentials, and any credentials embedded in `SEARXNG_URL` are secrets. Avoid committing them to source control. Use secret management (Docker secrets, environment injection at runtime, or a secrets manager) in production.
 
 ## Scope
 

--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -377,6 +377,34 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('/config fetch strips URL credentials and uses per-instance auth header', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://config-user:p%40ss@config-auth.example.com');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedUrl, getCapturedOptions } = createCapturingMockFetch();
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: makeConfig() })(url, options);
+    });
+
+    const payload = JSON.parse(await fetchInstanceInfo(mockServer as any, true));
+
+    const capturedUrl = getCapturedUrl();
+    const parsedUrl = new URL(capturedUrl);
+    const headers = getCapturedOptions()?.headers as Record<string, string>;
+    assert.equal(payload.available, true);
+    assert.equal(parsedUrl.username, '');
+    assert.equal(parsedUrl.password, '');
+    assert.equal(parsedUrl.hostname, 'config-auth.example.com');
+    assert.equal(parsedUrl.pathname, '/config');
+    assert.ok(!capturedUrl.includes('config-user:p%40ss@'), capturedUrl);
+    assert.equal(headers['authorization'], `Basic ${Buffer.from('config-user:p@ss').toString('base64')}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('credential-bearing instance URLs are redacted from unavailable payload', async () => {
     clearInstanceInfoCacheForTests();
     envManager.set('SEARXNG_URL', 'https://user:pass@down-one.example.com;https://user:pass@down-two.example.com');

--- a/__tests__/unit/resources.test.ts
+++ b/__tests__/unit/resources.test.ts
@@ -123,10 +123,15 @@ async function runTests() {
 
     const config = JSON.parse(createConfigResource());
     assert.ok(config.environment.searxngUrl, 'expected searxngUrl to be exposed in non-hardened mode');
-    assert.ok(!config.environment.searxngUrl.includes('user:'), config.environment.searxngUrl);
+    // Parse each entry and assert on the exact host so a leaked credential can't
+    // hide in a substring, and no userinfo survives redaction.
+    const entries = config.environment.searxngUrl.split('; ').map((entry: string) => new URL(entry));
+    assert.equal(entries.length, 2);
+    assert.equal(entries[0].hostname, 'search.example.com');
+    assert.equal(entries[0].username, '');
+    assert.equal(entries[0].password, '');
+    assert.equal(entries[1].hostname, 'public.example.com');
     assert.ok(!config.environment.searxngUrl.includes('p%40ss'), config.environment.searxngUrl);
-    assert.ok(config.environment.searxngUrl.includes('search.example.com'), config.environment.searxngUrl);
-    assert.ok(config.environment.searxngUrl.includes('public.example.com'), config.environment.searxngUrl);
 
     envManager.restore();
   }, results);

--- a/__tests__/unit/resources.test.ts
+++ b/__tests__/unit/resources.test.ts
@@ -81,6 +81,7 @@ async function runTests() {
     const help = createHelpResource();
 
     assert.ok(help.includes('https://user:password@search.example.com'), 'missing URL userinfo auth example');
+    assert.ok(help.includes('percent-encode'), 'missing percent-encoding note');
     assert.ok(help.includes('Legacy global Basic Auth fallback'), 'missing legacy AUTH_* fallback note');
   }, results);
 

--- a/__tests__/unit/resources.test.ts
+++ b/__tests__/unit/resources.test.ts
@@ -77,6 +77,13 @@ async function runTests() {
     assert.ok(help.includes('### 4. web_url_read'), 'missing URL reader tool section');
   }, results);
 
+  await testFunction('help resource recommends URL userinfo for SearXNG Basic Auth', () => {
+    const help = createHelpResource();
+
+    assert.ok(help.includes('https://user:password@search.example.com'), 'missing URL userinfo auth example');
+    assert.ok(help.includes('Legacy global Basic Auth fallback'), 'missing legacy AUTH_* fallback note');
+  }, results);
+
   await testFunction('createConfigResource - hasAuth true when both credentials set', () => {
     envManager.set('AUTH_USERNAME', 'testuser');
     envManager.set('AUTH_PASSWORD', 'testpass');

--- a/__tests__/unit/resources.test.ts
+++ b/__tests__/unit/resources.test.ts
@@ -98,9 +98,35 @@ async function runTests() {
   await testFunction('createConfigResource - hasAuth false when credentials absent', () => {
     envManager.delete('AUTH_USERNAME');
     envManager.delete('AUTH_PASSWORD');
+    envManager.set('SEARXNG_URL', 'https://search.example.com');
 
     const config = JSON.parse(createConfigResource());
     assert.equal(config.environment.hasAuth, false);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('createConfigResource - hasAuth true when SEARXNG_URL carries userinfo without global AUTH_*', () => {
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+    envManager.set('SEARXNG_URL', 'https://token@search.example.com');
+
+    const config = JSON.parse(createConfigResource());
+    assert.equal(config.environment.hasAuth, true);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('createConfigResource - redacts embedded userinfo from searxngUrl (non-hardened)', () => {
+    envManager.delete('MCP_HTTP_HARDEN');
+    envManager.set('SEARXNG_URL', 'https://user:p%40ss@search.example.com;https://public.example.com');
+
+    const config = JSON.parse(createConfigResource());
+    assert.ok(config.environment.searxngUrl, 'expected searxngUrl to be exposed in non-hardened mode');
+    assert.ok(!config.environment.searxngUrl.includes('user:'), config.environment.searxngUrl);
+    assert.ok(!config.environment.searxngUrl.includes('p%40ss'), config.environment.searxngUrl);
+    assert.ok(config.environment.searxngUrl.includes('search.example.com'), config.environment.searxngUrl);
+    assert.ok(config.environment.searxngUrl.includes('public.example.com'), config.environment.searxngUrl);
 
     envManager.restore();
   }, results);

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -204,8 +204,76 @@ async function runTests() {
     const options = getCapturedOptions();
     assert.ok(options?.headers);
     const headers = options.headers as Record<string, string>;
-    assert.ok(headers['authorization']);
-    assert.ok(headers['authorization'].startsWith('Basic '));
+    assert.equal(headers['authorization'], `Basic ${Buffer.from('testuser:testpass').toString('base64')}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('embedded URL auth overrides global auth for search requests', async () => {
+    envManager.set('SEARXNG_URL', 'https://embedded:p%40ss@test-searx.example.com');
+    envManager.set('AUTH_USERNAME', 'global-user');
+    envManager.set('AUTH_PASSWORD', 'global-pass');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: { results: [] } })(url, options);
+    });
+
+    await performWebSearch(mockServer as any, 'test query');
+
+    const headers = getCapturedOptions()?.headers as Record<string, string>;
+    assert.equal(headers['authorization'], `Basic ${Buffer.from('embedded:p@ss').toString('base64')}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('search fetch URL strips embedded credentials before request', async () => {
+    envManager.set('SEARXNG_URL', 'https://user:pass@test-searx.example.com/subpath');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedUrl } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: { results: [] } })(url, options);
+    });
+
+    await performWebSearch(mockServer as any, 'test query');
+
+    const capturedUrl = getCapturedUrl();
+    const parsedUrl = new URL(capturedUrl);
+    assert.equal(parsedUrl.username, '');
+    assert.equal(parsedUrl.password, '');
+    assert.equal(parsedUrl.hostname, 'test-searx.example.com');
+    assert.equal(parsedUrl.pathname, '/subpath/search');
+    assert.ok(!capturedUrl.includes('user:pass@'), capturedUrl);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('search request omits Authorization when no credentials are configured', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: { results: [] } })(url, options);
+    });
+
+    await performWebSearch(mockServer as any, 'test query');
+
+    const headers = (getCapturedOptions()?.headers || {}) as Record<string, string>;
+    assert.equal(headers['authorization'], undefined);
 
     fetchMocker.restore();
     envManager.restore();
@@ -432,6 +500,46 @@ async function runTests() {
     assert.equal(payload.sourceFormat, 'html');
     assert.equal(payload.results[1].title, 'Beta Result');
     assert.equal(payload.results[1].url, 'https://example.com/beta');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('HTML fallback on 200 non-JSON body strips embedded credentials from the refetch URL', async () => {
+    envManager.set('SEARXNG_URL', 'https://user:p%40ss@test-searx.example.com');
+    envManager.set('SEARXNG_HTML_FALLBACK', 'true');
+
+    const mockServer = createMockServer();
+    const fetchedUrls: string[] = [];
+    fetchMocker.mock(async (url) => {
+      fetchedUrls.push(url.toString());
+      if (fetchedUrls.length === 1) {
+        return {
+          ok: true,
+          status: 200,
+          statusText: 'OK',
+          json: async () => { throw new Error('Unexpected token < in JSON'); },
+          text: async () => '<!doctype html><html><body>JSON disabled</body></html>',
+        } as any;
+      }
+
+      return {
+        ok: true,
+        status: 200,
+        statusText: 'OK',
+        text: async () => searxngHtmlFixture,
+      } as Response;
+    });
+
+    await performWebSearch(mockServer as any, 'non json creds', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+
+    assert.equal(fetchedUrls.length, 2);
+    // Neither the initial fetch nor the HTML-fallback refetch may carry userinfo —
+    // Node's fetch rejects credential-bearing URLs outright.
+    for (const fetched of fetchedUrls) {
+      assert.equal(new URL(fetched).username, '');
+      assert.ok(!fetched.includes('user:p%40ss@'), fetched);
+    }
 
     fetchMocker.restore();
     envManager.restore();
@@ -1918,6 +2026,53 @@ async function runTests() {
     assert.deepEqual(requestedHosts, ['https://first.example.com', 'https://second.example.com']);
     assert.deepEqual(payload.servedBy, ['https://second.example.com']);
     assert.equal(payload.results[0].title, 'Second Result');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('multi-instance search uses embedded auth first and global fallback second', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://embedded:p%40ss@first.example.com;https://second.example.com');
+    envManager.set('AUTH_USERNAME', 'global-user');
+    envManager.set('AUTH_PASSWORD', 'global-pass');
+    envManager.delete('SEARXNG_FANOUT');
+
+    const mockServer = createMockServer();
+    const requests: Array<{ url: string; authorization?: string }> = [];
+
+    fetchMocker.mock(async (url, options) => {
+      const headers = (options?.headers || {}) as Record<string, string>;
+      requests.push({
+        url: url.toString(),
+        authorization: headers['authorization'],
+      });
+
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.hostname === 'first.example.com') {
+        throw new Error('first instance unavailable');
+      }
+
+      return createMockFetch({
+        json: {
+          query: 'multi auth',
+          results: [
+            { title: 'Second Result', content: 'Second', url: 'https://example.com/second', score: 1 },
+          ],
+        },
+      })(url, options);
+    });
+
+    const result = await performWebSearch(mockServer as any, 'multi auth', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const payload = JSON.parse(result);
+
+    assert.equal(payload.results[0].title, 'Second Result');
+    assert.equal(requests.length, 2);
+    assert.equal(requests[0].authorization, `Basic ${Buffer.from('embedded:p@ss').toString('base64')}`);
+    assert.equal(requests[1].authorization, `Basic ${Buffer.from('global-user:global-pass').toString('base64')}`);
+    assert.ok(!requests[0].url.includes('embedded:p%40ss@'), requests[0].url);
+    assert.equal(new URL(requests[0].url).username, '');
+    assert.equal(new URL(requests[1].url).username, '');
 
     fetchMocker.restore();
     envManager.restore();

--- a/__tests__/unit/searxng-instances.test.ts
+++ b/__tests__/unit/searxng-instances.test.ts
@@ -13,11 +13,13 @@ import {
   getHealthySearxngInstances,
   getPrimarySearxngInstance,
   getSearxngInstances,
+  getSearxngBasicAuthHeader,
   isSearxngFanoutEnabled,
   parseSearxngUrls,
   redactSearxngInstanceUrl,
   recordSearxngInstanceFailure,
   recordSearxngInstanceSuccess,
+  stripSearxngInstanceUrlUserinfo,
   validateSearxngInstanceUrl,
 } from '../../src/searxng-instances.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
@@ -121,6 +123,68 @@ async function runTests() {
     for (const url of urls) {
       assert.equal(redactSearxngInstanceUrl(url), url);
     }
+  }, results);
+
+  await testFunction('stripSearxngInstanceUrlUserinfo removes credentials and preserves request target', () => {
+    const stripped = stripSearxngInstanceUrlUserinfo(new URL('https://user:pass@search.example.com/base/search?q=test#top'));
+
+    assert.equal(stripped.toString(), 'https://search.example.com/base/search?q=test#top');
+    assert.equal(stripped.username, '');
+    assert.equal(stripped.password, '');
+  }, results);
+
+  await testFunction('getSearxngBasicAuthHeader decodes percent-encoded URL credentials', () => {
+    const header = getSearxngBasicAuthHeader(new URL('https://user:p%40ss@search.example.com'));
+
+    assert.equal(header, `Basic ${Buffer.from('user:p@ss').toString('base64')}`);
+  }, results);
+
+  await testFunction('getSearxngBasicAuthHeader supports username-only URL credentials', () => {
+    const header = getSearxngBasicAuthHeader(new URL('https://token@search.example.com'));
+
+    assert.equal(header, `Basic ${Buffer.from('token:').toString('base64')}`);
+  }, results);
+
+  await testFunction('getSearxngBasicAuthHeader tolerates malformed percent-encoding in userinfo', () => {
+    // A literal `%` the operator forgot to encode parses as a URL but makes
+    // decodeURIComponent throw — the header must fall back to the raw value, not crash.
+    const header = getSearxngBasicAuthHeader(new URL('https://user:100%@search.example.com'));
+
+    assert.equal(header, `Basic ${Buffer.from('user:100%').toString('base64')}`);
+  }, results);
+
+  await testFunction('getSearxngBasicAuthHeader ignores password-only URL userinfo (no username)', () => {
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+
+    // Password-only userinfo is treated as absent — no stray secret is sent.
+    const header = getSearxngBasicAuthHeader(new URL('https://:pass@search.example.com'));
+
+    assert.equal(header, undefined);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('getSearxngBasicAuthHeader falls back to global auth only without URL userinfo', () => {
+    envManager.set('AUTH_USERNAME', 'global-user');
+    envManager.set('AUTH_PASSWORD', 'global-pass');
+
+    const header = getSearxngBasicAuthHeader(new URL('https://search.example.com'));
+
+    assert.equal(header, `Basic ${Buffer.from('global-user:global-pass').toString('base64')}`);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('getSearxngBasicAuthHeader returns undefined when no credentials exist', () => {
+    envManager.delete('AUTH_USERNAME');
+    envManager.delete('AUTH_PASSWORD');
+
+    const header = getSearxngBasicAuthHeader(new URL('https://search.example.com'));
+
+    assert.equal(header, undefined);
+
+    envManager.restore();
   }, results);
 
   await testFunction('isSearxngFanoutEnabled is true only for literal true', () => {

--- a/__tests__/unit/suggestions.test.ts
+++ b/__tests__/unit/suggestions.test.ts
@@ -132,6 +132,58 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('autocompleter fetch strips URL credentials and uses primary URL auth header', async () => {
+    envManager.set('SEARXNG_URL', 'https://primary-user:p%40ss@primary.example.com/base;https://secondary.example.com');
+    envManager.set('AUTH_USERNAME', 'global-user');
+    envManager.set('AUTH_PASSWORD', 'global-pass');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedUrl, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: ['type', ['typescript']] })(url, options);
+    });
+
+    const suggestions = await performSearchSuggestions(mockServer as any, 'type');
+
+    const capturedUrl = getCapturedUrl();
+    const parsedUrl = new URL(capturedUrl);
+    const headers = getCapturedOptions()?.headers as Record<string, string>;
+    assert.deepEqual(suggestions, ['typescript']);
+    assert.equal(parsedUrl.username, '');
+    assert.equal(parsedUrl.password, '');
+    assert.equal(parsedUrl.hostname, 'primary.example.com');
+    assert.equal(parsedUrl.pathname, '/base/autocompleter');
+    assert.ok(!capturedUrl.includes('primary-user:p%40ss@'), capturedUrl);
+    assert.equal(headers['authorization'], `Basic ${Buffer.from('primary-user:p@ss').toString('base64')}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('autocompleter uses global auth fallback when primary URL has no userinfo', async () => {
+    envManager.set('SEARXNG_URL', 'https://primary.example.com');
+    envManager.set('AUTH_USERNAME', 'global-user');
+    envManager.set('AUTH_PASSWORD', 'global-pass');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedOptions } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      return createMockFetch({ json: ['type', ['typescript']] })(url, options);
+    });
+
+    await performSearchSuggestions(mockServer as any, 'type');
+
+    const headers = getCapturedOptions()?.headers as Record<string, string>;
+    assert.equal(headers['authorization'], `Basic ${Buffer.from('global-user:global-pass').toString('base64')}`);
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('language=all omits lang parameter', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
     const mockServer = createMockServer();

--- a/src/error-handler.ts
+++ b/src/error-handler.ts
@@ -9,7 +9,6 @@ export interface ErrorContext {
   url?: string;
   searxngUrl?: string;
   proxyAgent?: boolean;
-  username?: string;
   timeout?: number;
   query?: string;
 }

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logMessage } from "./logging.js";
 import { applySearchRequestConfig } from "./proxy.js";
-import { getSearxngInstances, redactSearxngInstanceUrl } from "./searxng-instances.js";
+import { getSearxngInstances, redactSearxngInstanceUrl, stripSearxngInstanceUrlUserinfo } from "./searxng-instances.js";
 
 type SearXNGConfig = Record<string, any>;
 type ConfigResult =
@@ -263,12 +263,13 @@ async function requestInstanceConfig(mcpServer: McpServer, base: string): Promis
   try {
     const parsedBase = new URL(base.endsWith("/") ? base : `${base}/`);
     const url = new URL("config", parsedBase);
+    const requestUrl = stripSearxngInstanceUrlUserinfo(url);
     const requestOptions: RequestInit = {
       signal: AbortSignal.timeout(5000),
     };
     applySearchRequestConfig(requestOptions, url.toString());
 
-    const response = await fetch(url.toString(), requestOptions);
+    const response = await fetch(requestUrl.toString(), requestOptions);
     if (!response.ok) {
       const message = `SearXNG /config is unavailable: HTTP ${response.status} ${response.statusText}`;
       return {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -3,6 +3,7 @@ import { Agent, ProxyAgent } from "undici";
 import { getHttpSecurityConfig } from "./http-security.js";
 import { getConnectOptions } from "./tls-config.js";
 import { createUrlSecurityPolicyDnsError, isPrivateAddress } from "./url-security.js";
+import { getSearxngBasicAuthHeader } from "./searxng-instances.js";
 
 type LookupCallback = (
   err: NodeJS.ErrnoException | null,
@@ -303,6 +304,8 @@ export function getSearchUserAgent(): string | undefined {
  * SearXNG instances return 401 on `/config` and `/autocompleter` unless the
  * `Authorization` header is present, so the Basic Auth block must live here
  * alongside the proxy/User-Agent wiring rather than only in `search.ts`.
+ * Credentials come from the instance URL userinfo first (per-instance), then
+ * fall back to the global `AUTH_*` env vars — see `getSearxngBasicAuthHeader`.
  * `web_url_read` deliberately does NOT use this — it fetches arbitrary URLs.
  *
  * The User-Agent and Authorization are merged through a `Headers` instance,
@@ -320,15 +323,13 @@ export function applySearchRequestConfig(
     (requestOptions as any).dispatcher = dispatcher;
   }
 
-  // Always normalize headers via Headers so all three mutations below merge
+  // Always normalize headers via Headers so all mutations below merge
   // cleanly regardless of the incoming HeadersInit shape.
   const headers = new Headers(requestOptions.headers);
 
-  const username = process.env.AUTH_USERNAME;
-  const password = process.env.AUTH_PASSWORD;
-  if (username && password) {
-    const base64Auth = Buffer.from(`${username}:${password}`).toString("base64");
-    headers.set("Authorization", `Basic ${base64Auth}`);
+  const authHeader = getSearxngBasicAuthHeader(new URL(targetUrl));
+  if (authHeader) {
+    headers.set("Authorization", authHeader);
   }
 
   const userAgent = getSearchUserAgent();

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -93,10 +93,10 @@ Reads and converts web page content to Markdown format.
 ## Configuration
 
 ### Required Environment Variables
-- \`SEARXNG_URL\`: URL of your SearXNG instance (e.g., http://localhost:8080)
+- \`SEARXNG_URL\`: URL of your SearXNG instance (e.g., http://localhost:8080). For Basic Auth, embed credentials in the URL (e.g., https://user:password@search.example.com). Multi-instance lists can use different credentials per semicolon-separated URL.
 
 ### Optional Environment Variables
-- \`AUTH_USERNAME\` & \`AUTH_PASSWORD\`: Basic authentication for SearXNG
+- \`AUTH_USERNAME\` & \`AUTH_PASSWORD\`: Legacy global Basic Auth fallback when \`SEARXNG_URL\` has no userinfo
 - \`HTTP_PROXY\` / \`HTTPS_PROXY\`: Proxy server configuration
 - \`NO_PROXY\` / \`no_proxy\`: Comma-separated list of hosts to bypass proxy
 - \`MCP_HTTP_PORT\`: Enable HTTP transport on specified port

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -93,7 +93,7 @@ Reads and converts web page content to Markdown format.
 ## Configuration
 
 ### Required Environment Variables
-- \`SEARXNG_URL\`: URL of your SearXNG instance (e.g., http://localhost:8080). For Basic Auth, embed credentials in the URL (e.g., https://user:password@search.example.com). Multi-instance lists can use different credentials per semicolon-separated URL.
+- \`SEARXNG_URL\`: URL of your SearXNG instance (e.g., http://localhost:8080). For Basic Auth, embed credentials in the URL (e.g., https://user:password@search.example.com); percent-encode special characters in the username or password (e.g. \`@\` as \`%40\`). Multi-instance lists can use different credentials per semicolon-separated URL.
 
 ### Optional Environment Variables
 - \`AUTH_USERNAME\` & \`AUTH_PASSWORD\`: Legacy global Basic Auth fallback when \`SEARXNG_URL\` has no userinfo

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,6 +1,40 @@
 import { getCurrentLogLevel } from "./logging.js";
 import { packageVersion } from "./version.js";
 import { getHttpSecurityConfig } from "./http-security.js";
+import { parseSearxngUrls, redactSearxngInstanceUrl } from "./searxng-instances.js";
+
+// SEARXNG_URL may embed Basic Auth credentials in its userinfo (the recommended
+// auth path) and may be a semicolon-separated multi-instance list. Redact the
+// userinfo from each entry before exposing it in the config resource so the host
+// stays visible for debugging but embedded secrets are never returned to clients.
+function redactedConfiguredSearxngUrl(): string {
+  const raw = process.env.SEARXNG_URL;
+  if (!raw) {
+    return "(not configured)";
+  }
+  const redacted = raw
+    .split(";")
+    .map((entry) => entry.trim())
+    .filter((entry) => entry !== "")
+    .map(redactSearxngInstanceUrl)
+    .join("; ");
+  return redacted || raw;
+}
+
+// Auth is configured when the global AUTH_* fallback is set or any instance URL
+// carries userinfo (the recommended per-instance path).
+function hasConfiguredAuth(): boolean {
+  if (process.env.AUTH_USERNAME && process.env.AUTH_PASSWORD) {
+    return true;
+  }
+  return parseSearxngUrls().some((instance) => {
+    try {
+      return new URL(instance).username !== "";
+    } catch {
+      return false;
+    }
+  });
+}
 
 export function createConfigResource() {
   const security = getHttpSecurityConfig();
@@ -14,9 +48,9 @@ export function createConfigResource() {
     },
     environment: {
       ...(showFullConfig
-        ? { searxngUrl: process.env.SEARXNG_URL || "(not configured)" }
+        ? { searxngUrl: redactedConfiguredSearxngUrl() }
         : { searxngUrlConfigured: !!process.env.SEARXNG_URL }),
-      hasAuth: !!(process.env.AUTH_USERNAME && process.env.AUTH_PASSWORD),
+      hasAuth: hasConfiguredAuth(),
       hasProxy: !!(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy),
       hasNoProxy: !!(process.env.NO_PROXY || process.env.no_proxy),
       nodeVersion: process.version,

--- a/src/search.ts
+++ b/src/search.ts
@@ -11,6 +11,7 @@ import {
   recordSearxngInstanceFailure,
   recordSearxngInstanceSuccess,
   redactSearxngInstanceUrl,
+  stripSearxngInstanceUrlUserinfo,
 } from "./searxng-instances.js";
 import {
   MCPSearXNGError,
@@ -161,7 +162,6 @@ async function fetchWithSearchTimeout(
       url: redactedUrl,
       searxngUrl: redactSearxngInstanceUrl(searxngUrl),
       proxyAgent: !!(requestOptions as any).dispatcher,
-      username: process.env.AUTH_USERNAME,
     };
     throw createNetworkError(safeError, context);
   } finally {
@@ -444,13 +444,14 @@ async function fetchSearchFromInstance(
 ): Promise<InstanceSearchResult> {
   const url = buildSearchUrl(instanceUrl, request);
   const requestOptions = buildSearchRequestOptions(url);
-  const response = await fetchWithSearchTimeout(mcpServer, url, requestOptions, request.timeoutMs, request.query, instanceUrl);
+  const requestUrl = stripSearxngInstanceUrlUserinfo(url);
+  const response = await fetchWithSearchTimeout(mcpServer, requestUrl, requestOptions, request.timeoutMs, request.query, instanceUrl);
 
   let data: SearXNGWeb;
 
   if (!response.ok) {
     if (isHtmlFallbackEnabled() && shouldFallbackForStatus(response.status)) {
-      data = await fetchHtmlFallbackSearch(mcpServer, url, requestOptions, request.timeoutMs, request.query, instanceUrl);
+      data = await fetchHtmlFallbackSearch(mcpServer, requestUrl, requestOptions, request.timeoutMs, request.query, instanceUrl);
     } else {
       let responseBody: string;
       try {
@@ -480,7 +481,7 @@ async function fetchSearchFromInstance(
       data = JSON.parse(responseText) as SearXNGWeb;
     } catch {
       if (isHtmlFallbackEnabled()) {
-        data = await fetchHtmlFallbackSearch(mcpServer, url, requestOptions, request.timeoutMs, request.query, instanceUrl);
+        data = await fetchHtmlFallbackSearch(mcpServer, requestUrl, requestOptions, request.timeoutMs, request.query, instanceUrl);
       } else {
         throw createJSONError(responseText);
       }

--- a/src/searxng-instances.ts
+++ b/src/searxng-instances.ts
@@ -69,6 +69,47 @@ export function redactSearxngInstanceUrl(raw: string): string {
   }
 }
 
+export function stripSearxngInstanceUrlUserinfo(url: URL): URL {
+  const stripped = new URL(url.toString());
+  stripped.username = "";
+  stripped.password = "";
+  return stripped;
+}
+
+// `URL` stores userinfo percent-encoded, so decode before base64. A literal `%`
+// the operator forgot to encode (e.g. `100%` instead of `100%25`) parses fine as
+// a URL but makes decodeURIComponent throw URIError — fall back to the raw value
+// instead of crashing request setup rather than guess at re-encoding.
+function decodeUserinfoComponent(value: string): string {
+  try {
+    return decodeURIComponent(value);
+  } catch {
+    return value;
+  }
+}
+
+export function getSearxngBasicAuthHeader(url: URL): string | undefined {
+  // URL auth requires a username (username-only token or username+password).
+  // Password-only userinfo (`https://:pass@host`) is treated as absent so a
+  // mistyped URL falls back to global AUTH_* / no header instead of sending a
+  // stray secret; the password is still stripped from the outgoing URL.
+  if (url.username !== "") {
+    const username = decodeUserinfoComponent(url.username);
+    const password = decodeUserinfoComponent(url.password);
+    return `Basic ${Buffer.from(`${username}:${password}`).toString("base64")}`;
+  }
+
+  const username = process.env.AUTH_USERNAME;
+  const password = process.env.AUTH_PASSWORD;
+
+  if (username && password) {
+    const base64Auth = Buffer.from(`${username}:${password}`).toString('base64');
+    return `Basic ${base64Auth}`;
+  }
+
+  return undefined;
+}
+
 export function isSearxngFanoutEnabled(): boolean {
   return process.env.SEARXNG_FANOUT === "true";
 }

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -1,7 +1,7 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logMessage } from "./logging.js";
 import { applySearchRequestConfig } from "./proxy.js";
-import { getPrimarySearxngInstance } from "./searxng-instances.js";
+import { getPrimarySearxngInstance, stripSearxngInstanceUrlUserinfo } from "./searxng-instances.js";
 
 export async function performSearchSuggestions(
   mcpServer: McpServer,
@@ -19,6 +19,7 @@ export async function performSearchSuggestions(
   if (language !== "all") {
     url.searchParams.set("lang", language);
   }
+  const requestUrl = stripSearxngInstanceUrlUserinfo(url);
 
   try {
     const requestOptions: RequestInit = {
@@ -26,7 +27,7 @@ export async function performSearchSuggestions(
     };
     applySearchRequestConfig(requestOptions, url.toString());
 
-    const response = await fetch(url.toString(), requestOptions);
+    const response = await fetch(requestUrl.toString(), requestOptions);
     if (!response.ok) {
       return [];
     }


### PR DESCRIPTION
## TODO item

**FEAT-049** — Apply per-instance Basic Auth from `SEARXNG_URL` userinfo (multi-instance credentials) (🟡 Medium, from TODO-features.md)
Refs: BUG-007, FEAT-047, FEAT-048

> Fresh PR for a clean review slate (previous iterations: #151, #159 — both closed). The branch is up to date with `main` (includes #152) and all code review + CI feedback from those iterations is already resolved in the commits here.

## Context

`buildSearchRequestOptions(url)` applied one global `AUTH_USERNAME`/`AUTH_PASSWORD` Basic header to **every** instance, so a heterogeneous multi-instance `SEARXNG_URL` (private auth-gated + public no-auth replica) leaked the operator's credentials to the host that never asked for them. Two facts shaped the implementation:

- **Node's `fetch` (undici) rejects credential-bearing URLs** — embedding userinfo in `SEARXNG_URL` didn't just risk a leak, it broke the request. Userinfo must be stripped before `fetch`.
- All three SearXNG-instance paths (`/search`, `/config`, `/autocompleter`) must honor the credentials, or the documented userinfo auth ships half-broken.

## What changed

- **`src/searxng-instances.ts`** — `getSearxngBasicAuthHeader(url)` derives Basic Auth from the URL userinfo first (guarded percent-decode; requires a non-empty username; supports username-only tokens), falling back to global `AUTH_*`, else no header. Non-mutating `stripSearxngInstanceUrlUserinfo(url)`.
- **`src/proxy.ts`** — `applySearchRequestConfig()` applies that shared per-instance auth header (plus proxy dispatcher and User-Agent) for every SearXNG-instance fetch; search delegates its request config here too (built on #152's structure).
- **`src/search.ts`, `src/instance-info.ts`, `src/suggestions.ts`** — strip userinfo before every `fetch` (main + HTML-fallback paths). Removed the stale, unused `ErrorContext.username`.
- **`src/resources.ts`** — the `config://server-config` resource redacts `SEARXNG_URL` userinfo (host shown, credentials removed); `hasAuth` reflects URL-userinfo auth in addition to the global `AUTH_*` fallback; in-tool help recommends userinfo with percent-encoding guidance.
- **Docs** — `CONFIGURATION.md` leads Authentication with URL userinfo (mixed private/public multi-instance example, percent-encoding, optional `[/path]`, Full Example uses a userinfo `SEARXNG_URL`); `AUTH_*` demoted to legacy fallback; `SECURITY.md` documents userinfo redaction (logs, errors, and the config resource) and that `SEARXNG_URL` is a secret; `README.md` notes per-instance credentials.

## Relationship to #152

#152 (already on `main`) moved **global** Basic Auth into `applySearchRequestConfig` and made `buildSearchRequestOptions` delegate to it. This branch adopts that structure and swaps the global-only auth for `getSearxngBasicAuthHeader` (per-instance userinfo first, global fallback), keeping the userinfo stripping — one auth code path serving all three SearXNG endpoints, with per-instance credentials on top of #152's global-auth-everywhere.

## How it was verified

- `npm run build` — pass
- `npm test` (coverage-gated) — **486/486** pass; 96.09% lines (`searxng-instances.ts` 100%), gate ≥80%
- `npm run test:e2e` (local) — 2/2 pass
- `SEARXNG_LIVE_URL=https://searxng.ihor.top npm run test:e2e` (live) — 11/11 pass
- `npm run lint` — clean

(verified independently by the tech lead, not just by the implementer)

## Review feedback already resolved (from #151 / #159)

- Guarded `decodeURIComponent` so malformed userinfo (`https://user:100%@host`) falls back to the raw value instead of throwing.
- Fixed a second HTML-fallback path that still used the credentialed URL.
- Require a non-empty username for URL auth (password-only `https://:pass@host` no longer sends a stray secret).
- Removed the dead `ErrorContext.username` field.
- **Config resource** no longer returns raw `SEARXNG_URL` userinfo to clients (per-instance redaction); `hasAuth` is userinfo-aware.
- Percent-encoding note added to the in-tool help; `[/path]` documented in the URL format.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
