### PR TITLE
feat(search): add in-memory search result cache (FEAT-008)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -62,6 +62,10 @@ Operator-level defaults applied when the caller omits the corresponding per-call
 |---|---|---|---|
 | `SEARXNG_MAX_RESULTS` | No | — | Operator-level maximum number of search results to return per call (1-20). Invalid values are ignored. Recommended: `10` for smaller context windows. |
 | `SEARXNG_MAX_RESULT_CHARS` | No | — | Maximum characters to include in each search result snippet. Longer snippets are truncated and marked with `…`. Invalid values are ignored. Recommended: `500` for smaller context windows. |
+| `SEARCH_CACHE_TTL_MS` | No | `86400000` | Search result cache TTL in milliseconds. Invalid or non-positive values fall back to the default (24 hours). |
+| `SEARCH_CACHE_MAX_ENTRIES` | No | `200` | Maximum number of cached search queries. When the cache exceeds this size, the least frequently used entry is evicted, with oldest entry used as the tie-breaker. Invalid or non-positive values fall back to the default. |
+
+Search results are cached in memory per process only; cache contents are not persisted across restarts. Cached text responses are marked with `_Cached result_`. Cached JSON responses remain parseable and include a top-level `"cached": true` field.
 
 ## Search Compatibility
 
@@ -214,6 +218,8 @@ Complete MCP client configuration with every variable. Mix and match as needed �
         "SEARXNG_DEFAULT_SAFESEARCH": "0",
         "SEARXNG_MAX_RESULTS": "10",
         "SEARXNG_MAX_RESULT_CHARS": "500",
+        "SEARCH_CACHE_TTL_MS": "86400000",
+        "SEARCH_CACHE_MAX_ENTRIES": "200",
         "SEARXNG_HTML_FALLBACK": "false",
         "URL_READ_MAX_CHARS": "2000",
         "URL_READ_MAX_CONTENT_LENGTH_BYTES": "5242880",

--- a/__tests__/helpers/mock-fetch.ts
+++ b/__tests__/helpers/mock-fetch.ts
@@ -4,6 +4,8 @@
  * Utilities for mocking fetch API in tests
  */
 
+import { searchCache } from '../../src/search-cache.js';
+
 export type FetchMockOptions = {
   status?: number;
   statusText?: string;
@@ -126,5 +128,6 @@ export class FetchMocker {
 
   restore(): void {
     global.fetch = this.originalFetch;
+    searchCache.clear();
   }
 }

--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -12,6 +12,7 @@ import { TestResult } from './helpers/test-utils.js';
 import { runTests as runLoggingTests } from './unit/logging.test.js';
 import { runTests as runTypesTests } from './unit/types.test.js';
 import { runTests as runCacheTests } from './unit/cache.test.js';
+import { runTests as runSearchCacheTests } from './unit/search-cache.test.js';
 import { runTests as runProxyTests } from './unit/proxy.test.js';
 import { runTests as runErrorHandlerTests } from './unit/error-handler.test.js';
 import { runTests as runSearxngInstancesTests } from './unit/searxng-instances.test.js';
@@ -42,6 +43,7 @@ const testSuites: TestSuite[] = [
   { name: 'Logging', category: 'unit', run: runLoggingTests },
   { name: 'Types', category: 'unit', run: runTypesTests },
   { name: 'Cache', category: 'unit', run: runCacheTests },
+  { name: 'Search Cache', category: 'unit', run: runSearchCacheTests },
   { name: 'Proxy', category: 'unit', run: runProxyTests },
   { name: 'Error Handler', category: 'unit', run: runErrorHandlerTests },
   { name: 'SearXNG Instances', category: 'unit', run: runSearxngInstancesTests },

--- a/__tests__/unit/search-cache.test.ts
+++ b/__tests__/unit/search-cache.test.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env tsx
+
+/**
+ * Unit Tests: search-cache.ts
+ *
+ * Tests for SearXNG search result caching functionality
+ */
+
+import { strict as assert } from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import { SearchCache, searchCache } from '../../src/search-cache.js';
+import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
+
+const results = createTestResults();
+
+async function withControlledClock(
+  fn: (advance: (ms: number) => void) => void | Promise<void>,
+): Promise<void> {
+  const realNow = Date.now;
+  let now = realNow();
+  Date.now = () => now;
+  try {
+    await fn((ms) => { now += ms; });
+  } finally {
+    Date.now = realNow;
+  }
+}
+
+async function runTests() {
+  console.log('🧪 Testing: search-cache.ts\n');
+
+  await testFunction('SearchCache set/get returns the stored result', () => {
+    const testCache = new SearchCache(1000, 10);
+
+    testCache.set('searxng_web_search', { query: 'test' }, 'stored result');
+
+    assert.equal(testCache.get('searxng_web_search', { query: 'test' }), 'stored result');
+  }, results);
+
+  await testFunction('SearchCache get increments hitCount', () => {
+    const testCache = new SearchCache(1000, 10);
+
+    testCache.set('searxng_web_search', { query: 'popular' }, 'popular result');
+    assert.equal(testCache.get('searxng_web_search', { query: 'popular' }), 'popular result');
+    assert.equal(testCache.get('searxng_web_search', { query: 'popular' }), 'popular result');
+
+    const stats = testCache.getStats();
+    assert.equal(stats.entries[0].hitCount, 2);
+  }, results);
+
+  await testFunction('SearchCache expires entries after TTL', () => withControlledClock((advance) => {
+    const testCache = new SearchCache(50, 10);
+
+    testCache.set('searxng_web_search', { query: 'short lived' }, 'expired result');
+    assert.equal(testCache.get('searxng_web_search', { query: 'short lived' }), 'expired result');
+
+    advance(51);
+
+    assert.equal(testCache.get('searxng_web_search', { query: 'short lived' }), null);
+    assert.equal(testCache.getStats().size, 0);
+  }), results);
+
+  await testFunction('SearchCache evicts the lowest-hitCount entry when maxEntries is reached', () => {
+    const testCache = new SearchCache(1000, 2);
+
+    testCache.set('searxng_web_search', { query: 'popular' }, 'popular result');
+    testCache.set('searxng_web_search', { query: 'cold' }, 'cold result');
+    assert.equal(testCache.get('searxng_web_search', { query: 'popular' }), 'popular result');
+
+    testCache.set('searxng_web_search', { query: 'new' }, 'new result');
+
+    assert.equal(testCache.get('searxng_web_search', { query: 'popular' }), 'popular result');
+    assert.equal(testCache.get('searxng_web_search', { query: 'cold' }), null);
+    assert.equal(testCache.get('searxng_web_search', { query: 'new' }), 'new result');
+    assert.equal(testCache.getStats().size, 2);
+  }, results);
+
+  await testFunction('SearchCache evicts oldest entry when hitCounts are tied', () => withControlledClock((advance) => {
+    const testCache = new SearchCache(1000, 2);
+
+    testCache.set('searxng_web_search', { query: 'oldest' }, 'oldest result');
+    advance(10);
+    testCache.set('searxng_web_search', { query: 'newer' }, 'newer result');
+    advance(10);
+    testCache.set('searxng_web_search', { query: 'newest' }, 'newest result');
+
+    assert.equal(testCache.get('searxng_web_search', { query: 'oldest' }), null);
+    assert.equal(testCache.get('searxng_web_search', { query: 'newer' }), 'newer result');
+    assert.equal(testCache.get('searxng_web_search', { query: 'newest' }), 'newest result');
+  }), results);
+
+  await testFunction('SearchCache purges expired entries before LFU-evicting a live one', () => withControlledClock((advance) => {
+    const testCache = new SearchCache(100, 2);
+
+    // Expired entry with a high hitCount — LFU alone would keep it and evict a fresh one.
+    testCache.set('searxng_web_search', { query: 'expired popular' }, 'stale result');
+    testCache.get('searxng_web_search', { query: 'expired popular' });
+    testCache.get('searxng_web_search', { query: 'expired popular' });
+
+    advance(101);
+
+    testCache.set('searxng_web_search', { query: 'fresh one' }, 'fresh one result');
+    testCache.set('searxng_web_search', { query: 'fresh two' }, 'fresh two result');
+
+    assert.equal(testCache.get('searxng_web_search', { query: 'expired popular' }), null);
+    assert.equal(testCache.get('searxng_web_search', { query: 'fresh one' }), 'fresh one result');
+    assert.equal(testCache.get('searxng_web_search', { query: 'fresh two' }), 'fresh two result');
+    assert.equal(testCache.getStats().size, 2);
+  }), results);
+
+  await testFunction('SearchCache normalizes arg order so equivalent args hit the same entry', () => {
+    const testCache = new SearchCache(1000, 10);
+
+    testCache.set('searxng_web_search', {
+      query: 'ordered',
+      filters: { engines: 'google,ddg', categories: 'general' },
+      options: [{ name: 'first', enabled: true }],
+    }, 'ordered result');
+
+    assert.equal(testCache.get('searxng_web_search', {
+      options: [{ enabled: true, name: 'first' }],
+      filters: { categories: 'general', engines: 'google,ddg' },
+      query: 'ordered',
+    }), 'ordered result');
+  }, results);
+
+  await testFunction('SearchCache falls back to defaults for invalid env values', () => {
+    const previousTtl = process.env.SEARCH_CACHE_TTL_MS;
+    const previousMaxEntries = process.env.SEARCH_CACHE_MAX_ENTRIES;
+    process.env.SEARCH_CACHE_TTL_MS = 'not-a-number';
+    process.env.SEARCH_CACHE_MAX_ENTRIES = '0';
+
+    const testCache = new SearchCache();
+
+    try {
+      assert.equal((testCache as any).ttlMs, 86400000);
+      assert.equal((testCache as any).maxEntries, 200);
+    } finally {
+      if (previousTtl === undefined) {
+        delete process.env.SEARCH_CACHE_TTL_MS;
+      } else {
+        process.env.SEARCH_CACHE_TTL_MS = previousTtl;
+      }
+      if (previousMaxEntries === undefined) {
+        delete process.env.SEARCH_CACHE_MAX_ENTRIES;
+      } else {
+        process.env.SEARCH_CACHE_MAX_ENTRIES = previousMaxEntries;
+      }
+    }
+  }, results);
+
+  await testFunction('Global search cache instance', () => {
+    searchCache.clear();
+
+    searchCache.set('searxng_web_search', { query: 'global' }, 'global result');
+    assert.equal(searchCache.get('searxng_web_search', { query: 'global' }), 'global result');
+
+    searchCache.clear();
+  }, results);
+
+  printTestSummary(results, 'Search Cache Module');
+  return results;
+}
+
+// Run if executed directly
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runTests().then(results => {
+    process.exit(results.failed > 0 ? 1 : 0);
+  }).catch(console.error);
+}
+
+export { runTests };

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -9,7 +9,8 @@
 import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { performWebSearch } from '../../src/search.js';
+import { performWebSearch, formatCachedSearchResult } from '../../src/search.js';
+import { searchCache } from '../../src/search-cache.js';
 import { clearInstanceInfoCacheForTests } from '../../src/instance-info.js';
 import {
   clearSearxngInstanceStateForTests,
@@ -24,6 +25,19 @@ const results = createTestResults();
 const fetchMocker = new FetchMocker();
 const envManager = new EnvManager();
 const searxngHtmlFixture = readFileSync('__tests__/fixtures/searxng-results.html', 'utf8');
+
+async function withControlledClock(
+  fn: (advance: (ms: number) => void) => void | Promise<void>,
+): Promise<void> {
+  const realNow = Date.now;
+  let now = realNow();
+  Date.now = () => now;
+  try {
+    await fn((ms) => { now += ms; });
+  } finally {
+    Date.now = realNow;
+  }
+}
 
 function makeMockSearchResults(count: number) {
   return Array.from({ length: count }, (_, index) => ({
@@ -706,6 +720,203 @@ async function runTests() {
 
     fetchMocker.restore();
     envManager.restore();
+  }, results);
+
+  await testFunction('formatCachedSearchResult annotates text and JSON, and never throws on bad JSON', () => {
+    // Text: appends the marker.
+    assert.equal(formatCachedSearchResult('plain body', 'text'), 'plain body\n\n_Cached result_');
+
+    // Valid JSON: stays parseable and gains cached: true.
+    const annotated = JSON.parse(formatCachedSearchResult('{"results":[]}', 'json'));
+    assert.deepEqual(annotated.results, []);
+    assert.equal(annotated.cached, true);
+
+    // Malformed JSON under a JSON key must not throw — serve it unannotated so a
+    // cache hit can never turn a previously successful call into a failure.
+    assert.equal(formatCachedSearchResult('not json{', 'json'), 'not json{');
+  }, results);
+
+  await testFunction('Second identical search returns cached result without calling fetch', async () => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://cache.example.com');
+
+    const mockServer = createMockServer();
+    let fetchCount = 0;
+    fetchMocker.mock(async (url, options) => {
+      fetchCount++;
+      return createMockFetch({
+        json: {
+          results: [
+            { title: 'Cached Result', content: 'Cached content', url: 'https://example.com/cached', score: 1 },
+          ],
+        },
+      })(url, options);
+    });
+
+    const firstResult = await performWebSearch(mockServer as any, 'cache query');
+    const secondResult = await performWebSearch(mockServer as any, 'cache query');
+
+    assert.equal(fetchCount, 1);
+    assert.ok(firstResult.includes('Cached Result'));
+    assert.ok(secondResult.includes('Cached Result'));
+    assert.ok(secondResult.endsWith('\n\n_Cached result_'), secondResult);
+
+    fetchMocker.restore();
+    envManager.restore();
+    searchCache.clear();
+  }, results);
+
+  await testFunction('Cached text search includes _Cached result_ suffix', async () => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://cache-marker.example.com');
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(createMockFetch({
+      json: {
+        results: [
+          { title: 'Marker Result', content: 'Marker content', url: 'https://example.com/marker', score: 0.9 },
+        ],
+      },
+    }));
+
+    const firstResult = await performWebSearch(mockServer as any, 'marker query');
+    const secondResult = await performWebSearch(mockServer as any, 'marker query');
+    const thirdResult = await performWebSearch(mockServer as any, 'marker query');
+
+    const markerCount = (text: string) => text.split('_Cached result_').length - 1;
+    assert.ok(!firstResult.includes('_Cached result_'), firstResult);
+    assert.equal(markerCount(secondResult), 1);
+    assert.equal(markerCount(thirdResult), 1);
+
+    fetchMocker.restore();
+    envManager.restore();
+    searchCache.clear();
+  }, results);
+
+  await testFunction('Cached JSON search remains parseable and includes cached field', async () => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://cache-json.example.com');
+
+    const mockServer = createMockServer();
+    let fetchCount = 0;
+    fetchMocker.mock(async (url, options) => {
+      fetchCount++;
+      return createMockFetch({
+        json: {
+          query: 'json cache',
+          results: [
+            { title: 'JSON Result', content: 'JSON content', url: 'https://example.com/json', score: 0.8 },
+          ],
+        },
+      })(url, options);
+    });
+
+    const firstPayload = JSON.parse(await performWebSearch(mockServer as any, 'json cache', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json'));
+    const secondResult = await performWebSearch(mockServer as any, 'json cache', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+    const secondPayload = JSON.parse(secondResult);
+
+    assert.equal(fetchCount, 1);
+    assert.equal(firstPayload.cached, undefined);
+    assert.equal(secondPayload.cached, true);
+    assert.ok(!secondResult.includes('_Cached result_'), secondResult);
+
+    fetchMocker.restore();
+    envManager.restore();
+    searchCache.clear();
+  }, results);
+
+  await testFunction('Expired cached search hits fetch again', async () => withControlledClock((advance) => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://cache-expiry.example.com');
+
+    const mockServer = createMockServer();
+    let fetchCount = 0;
+    fetchMocker.mock(async (url, options) => {
+      fetchCount++;
+      return createMockFetch({
+        json: {
+          results: [
+            {
+              title: `Fresh Result ${fetchCount}`,
+              content: 'Fresh content',
+              url: `https://example.com/fresh-${fetchCount}`,
+              score: 1,
+            },
+          ],
+        },
+      })(url, options);
+    });
+
+    return (async () => {
+      searchCache.set('searxng_web_search', {
+        query: 'unused warmup',
+      }, 'unused');
+
+      await performWebSearch(mockServer as any, 'expiry query');
+      advance(86400001);
+      const result = await performWebSearch(mockServer as any, 'expiry query');
+
+      assert.equal(fetchCount, 2);
+      assert.ok(result.includes('Fresh Result 2'), result);
+      assert.ok(!result.includes('_Cached result_'), result);
+
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+    })();
+  }), results);
+
+  await testFunction('Different effective args do not share cached results', async () => {
+    searchCache.clear();
+    clearInstanceInfoCacheForTests();
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://cache-a.example.com;https://cache-b.example.com');
+    envManager.set('SEARXNG_FANOUT', 'false');
+    envManager.set('SEARXNG_DEFAULT_LANGUAGE', 'en');
+    envManager.set('SEARXNG_DEFAULT_SAFESEARCH', '1');
+    envManager.set('SEARXNG_MAX_RESULT_CHARS', '30');
+
+    const mockServer = createMockServer();
+    let searchFetchCount = 0;
+    fetchMocker.mock(async (url, options) => {
+      const parsedUrl = new URL(url.toString());
+      if (parsedUrl.pathname.endsWith('/config')) {
+        return createMockFetch({ json: makeConfigWithEngines() })(url, options);
+      }
+
+      searchFetchCount++;
+      return createMockFetch({
+        json: {
+          query: parsedUrl.searchParams.get('q'),
+          results: [
+            {
+              title: `Variant ${searchFetchCount}`,
+              content: `Variant content ${searchFetchCount}`,
+              url: `https://example.com/variant-${searchFetchCount}`,
+              score: 1,
+            },
+          ],
+        },
+      })(url, options);
+    });
+
+    await performWebSearch(mockServer as any, 'variant query', 1, undefined, undefined, undefined, undefined, 1, 'News', undefined, 'text');
+    await performWebSearch(mockServer as any, 'variant query', 1, undefined, undefined, undefined, undefined, 2, 'News', undefined, 'text');
+    await performWebSearch(mockServer as any, 'variant query', 1, undefined, undefined, undefined, undefined, 2, 'News', undefined, 'json');
+    await performWebSearch(mockServer as any, 'variant query', 1, undefined, 'fr', undefined, undefined, 2, 'News', undefined, 'json');
+    await performWebSearch(mockServer as any, 'variant query', 1, undefined, 'fr', 2, undefined, 2, 'News', 'Google', 'json');
+    envManager.set('SEARXNG_FANOUT', 'true');
+    await performWebSearch(mockServer as any, 'variant query', 1, undefined, 'fr', 2, undefined, 2, 'News', 'Google', 'json');
+    envManager.set('SEARXNG_URL', 'https://cache-c.example.com;https://cache-d.example.com');
+    await performWebSearch(mockServer as any, 'variant query', 1, undefined, 'fr', 2, undefined, 2, 'News', 'Google', 'json');
+
+    assert.equal(searchFetchCount, 9);
+
+    fetchMocker.restore();
+    envManager.restore();
+    searchCache.clear();
+    clearInstanceInfoCacheForTests();
+    clearSearxngInstanceStateForTests();
   }, results);
 
   await testFunction('min_score filters out lower relevance results', async () => {

--- a/src/cache.ts
+++ b/src/cache.ts
@@ -1,3 +1,5 @@
+import { parsePositiveInteger, normalizePositiveInteger } from "./env-int.js";
+
 interface CacheEntry {
   htmlContent: string;
   markdownContent: string;
@@ -8,19 +10,6 @@ interface CacheEntry {
 const DEFAULT_CACHE_TTL_MS = 86400000;
 const DEFAULT_CACHE_MAX_ENTRIES = 500;
 const DEFAULT_CLEANUP_INTERVAL_MS = 60000;
-
-function parsePositiveInteger(value: string | undefined, fallback: number): number {
-  if (value === undefined || value.trim() === "") {
-    return fallback;
-  }
-
-  const parsed = parseInt(value, 10);
-  return Number.isNaN(parsed) || parsed <= 0 ? fallback : parsed;
-}
-
-function normalizePositiveInteger(value: number, fallback: number): number {
-  return !Number.isFinite(value) || !Number.isInteger(value) || value <= 0 ? fallback : value;
-}
 
 class SimpleCache {
   private cache = new Map<string, CacheEntry>();

--- a/src/env-int.ts
+++ b/src/env-int.ts
@@ -1,0 +1,18 @@
+/**
+ * Shared positive-integer parsing/normalization for environment-configured
+ * numeric settings. Used by both the URL cache (`cache.ts`) and the search
+ * cache (`search-cache.ts`) so their env-parsing behavior stays identical.
+ */
+
+export function parsePositiveInteger(value: string | undefined, fallback: number): number {
+  if (value === undefined || value.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = parseInt(value, 10);
+  return Number.isNaN(parsed) || parsed <= 0 ? fallback : parsed;
+}
+
+export function normalizePositiveInteger(value: number, fallback: number): number {
+  return !Number.isFinite(value) || !Number.isInteger(value) || value <= 0 ? fallback : value;
+}

--- a/src/search-cache.ts
+++ b/src/search-cache.ts
@@ -1,0 +1,126 @@
+import { createHash } from "crypto";
+import { parsePositiveInteger, normalizePositiveInteger } from "./env-int.js";
+
+interface SearchCacheEntry {
+  result: string;
+  timestamp: number;
+  hitCount: number;
+}
+
+const DEFAULT_SEARCH_CACHE_TTL_MS = 86400000;
+const DEFAULT_SEARCH_CACHE_MAX_ENTRIES = 200;
+
+function stableCanonicalize(value: unknown): unknown {
+  if (Array.isArray(value)) {
+    return value.map(stableCanonicalize);
+  }
+
+  if (value !== null && typeof value === "object") {
+    const canonical: Record<string, unknown> = {};
+    for (const key of Object.keys(value).sort()) {
+      canonical[key] = stableCanonicalize((value as Record<string, unknown>)[key]);
+    }
+    return canonical;
+  }
+
+  return value;
+}
+
+export class SearchCache {
+  private cache = new Map<string, SearchCacheEntry>();
+  private readonly ttlMs: number;
+  private readonly maxEntries: number;
+
+  constructor(
+    ttlMs: number = parsePositiveInteger(process.env.SEARCH_CACHE_TTL_MS, DEFAULT_SEARCH_CACHE_TTL_MS),
+    maxEntries: number = parsePositiveInteger(process.env.SEARCH_CACHE_MAX_ENTRIES, DEFAULT_SEARCH_CACHE_MAX_ENTRIES),
+  ) {
+    this.ttlMs = normalizePositiveInteger(ttlMs, DEFAULT_SEARCH_CACHE_TTL_MS);
+    this.maxEntries = normalizePositiveInteger(maxEntries, DEFAULT_SEARCH_CACHE_MAX_ENTRIES);
+  }
+
+  private key(toolName: string, args: Record<string, unknown>): string {
+    const canonical = JSON.stringify([toolName, stableCanonicalize(args)]);
+    return createHash("sha256").update(canonical).digest("hex");
+  }
+
+  get(toolName: string, args: Record<string, unknown>): string | null {
+    const key = this.key(toolName, args);
+    const entry = this.cache.get(key);
+    if (!entry) {
+      return null;
+    }
+
+    if (Date.now() - entry.timestamp > this.ttlMs) {
+      this.cache.delete(key);
+      return null;
+    }
+
+    entry.hitCount++;
+    return entry.result;
+  }
+
+  set(toolName: string, args: Record<string, unknown>, result: string): void {
+    this.cache.set(this.key(toolName, args), {
+      result,
+      timestamp: Date.now(),
+      hitCount: 0,
+    });
+    this.evictIfNeeded();
+  }
+
+  private cleanupExpired(): void {
+    const now = Date.now();
+    for (const [key, entry] of this.cache.entries()) {
+      if (now - entry.timestamp > this.ttlMs) {
+        this.cache.delete(key);
+      }
+    }
+  }
+
+  private evictIfNeeded(): void {
+    this.cleanupExpired();
+
+    while (this.cache.size > this.maxEntries) {
+      let evictionKey: string | null = null;
+      let evictionEntry: SearchCacheEntry | null = null;
+
+      for (const [key, entry] of this.cache.entries()) {
+        if (
+          evictionEntry === null ||
+          entry.hitCount < evictionEntry.hitCount ||
+          (entry.hitCount === evictionEntry.hitCount && entry.timestamp < evictionEntry.timestamp)
+        ) {
+          evictionKey = key;
+          evictionEntry = entry;
+        }
+      }
+
+      if (evictionKey === null) {
+        return;
+      }
+
+      this.cache.delete(evictionKey);
+    }
+  }
+
+  clear(): void {
+    this.cache.clear();
+  }
+
+  getStats(): { size: number; entries: Array<{ key: string; age: number; hitCount: number }> } {
+    const now = Date.now();
+    const entries = Array.from(this.cache.entries()).map(([key, entry]) => ({
+      key,
+      age: now - entry.timestamp,
+      hitCount: entry.hitCount,
+    }));
+
+    return {
+      size: this.cache.size,
+      entries,
+    };
+  }
+}
+
+export const searchCache = new SearchCache();

--- a/src/search.ts
+++ b/src/search.ts
@@ -4,6 +4,7 @@ import { SearXNGWeb } from "./types.js";
 import { getKnownCategories, getKnownEngines } from "./instance-info.js";
 import { applySearchRequestConfig } from "./proxy.js";
 import { logMessage } from "./logging.js";
+import { searchCache } from "./search-cache.js";
 import {
   getHealthySearxngInstances,
   getSearxngInstances,
@@ -437,6 +438,25 @@ function buildSearchRequestOptions(url: URL): RequestInit {
   return requestOptions;
 }
 
+export function formatCachedSearchResult(result: string, responseFormat: "text" | "json"): string {
+  if (responseFormat === "json") {
+    try {
+      return JSON.stringify({
+        ...JSON.parse(result),
+        cached: true,
+      }, null, 2);
+    } catch {
+      // A cache hit must never turn a previously successful call into a hard
+      // failure. Stored JSON is always valid in practice (only successful JSON
+      // responses are cached under a JSON key), but set() is public, so if the
+      // stored value somehow isn't valid JSON, serve it unannotated.
+      return result;
+    }
+  }
+
+  return `${result}\n\n_Cached result_`;
+}
+
 async function fetchSearchFromInstance(
   mcpServer: McpServer,
   instanceUrl: string,
@@ -690,6 +710,7 @@ export async function performWebSearch(
 
   const SEARCH_TIMEOUT_MS = parseInt(process.env.SEARXNG_TIMEOUT_MS ?? "10000", 10);
   const instances = getSearxngInstances();
+  const fanoutEnabled = isSearxngFanoutEnabled();
   const includeProvenance = instances.length > 1;
   const request: SearchRequest = {
     query,
@@ -700,6 +721,24 @@ export async function performWebSearch(
     filters,
     timeoutMs: SEARCH_TIMEOUT_MS,
   };
+  const cacheArgs: Record<string, unknown> = {
+    query,
+    pageno,
+    time_range,
+    effectiveLanguage,
+    effectiveSafesearch,
+    filters,
+    min_score,
+    effectiveMax,
+    maxResultChars,
+    response_format,
+    instances,
+    searxngFanout: fanoutEnabled,
+  };
+  const cachedResult = searchCache.get("searxng_web_search", cacheArgs);
+  if (cachedResult !== null) {
+    return formatCachedSearchResult(cachedResult, response_format);
+  }
 
   let data: SearXNGWeb;
   let servedBy: string[] = [];
@@ -708,7 +747,7 @@ export async function performWebSearch(
     const result = await fetchSearchFromInstance(mcpServer, instances[0], request);
     data = result.data;
   } else {
-    const multiResult = isSearxngFanoutEnabled()
+    const multiResult = fanoutEnabled
       ? await performFanoutSearch(mcpServer, instances, request)
       : await performFailoverSearch(mcpServer, instances, request);
     data = multiResult.data;
@@ -723,12 +762,14 @@ export async function performWebSearch(
     : results;
 
   if (response_format === "json") {
-    return JSON.stringify({
+    const result = JSON.stringify({
       ...data,
       results: slicedResults,
       ...(filters.validationWarning ? { warnings: [filters.validationWarning] } : {}),
       ...(includeProvenance ? { servedBy: redactedServedBy } : {}),
     }, null, 2);
+    searchCache.set("searxng_web_search", cacheArgs, result);
+    return result;
   }
 
   const metadata = formatSearchMetadata(data);
@@ -749,7 +790,9 @@ export async function performWebSearch(
     const filterNote = appliedFilters ? ` after applying ${appliedFilters}` : "";
     logMessage(mcpServer, "info", `No results found for query: "${query}"${filterNote}`);
     const noResultsMessage = createNoResultsMessage(query);
-    return leadingSections ? `${leadingSections}\n\n---\n\n${noResultsMessage}` : noResultsMessage;
+    const result = leadingSections ? `${leadingSections}\n\n---\n\n${noResultsMessage}` : noResultsMessage;
+    searchCache.set("searxng_web_search", cacheArgs, result);
+    return result;
   }
 
   const duration = Date.now() - startTime;
@@ -771,5 +814,7 @@ export async function performWebSearch(
     })
     .join("\n\n");
 
-  return leadingSections ? `${leadingSections}\n\n---\n\n${formattedResults}` : formattedResults;
+  const result = leadingSections ? `${leadingSections}\n\n---\n\n${formattedResults}` : formattedResults;
+  searchCache.set("searxng_web_search", cacheArgs, result);
+  return result;
 }


### PR DESCRIPTION
## TODO item

**FEAT-008** — Search result caching (`search-cache.ts`) (🟡 Medium, from TODO-features.md)

## Context

`src/cache.ts` only caches URL HTML→Markdown conversions. Identical repeated search queries — common in agent loops — always hit SearXNG, wasting bandwidth and potentially rate-limiting the instance. This adds an in-memory search cache with a configurable TTL that eliminates redundant outbound requests within a process.

## What changed

- **`src/search-cache.ts`** (new): `SearchCache` — a per-process in-memory cache. TTL/size defaults are env-validated via the shared `env-int.ts` helpers; the key is a **recursive stable canonicalization** over all args (normalizes nested-object/array order — more robust than a top-level-only `JSON.stringify` replacer). Read-time TTL expiry, and eviction that **purges expired entries first**, then LFU with an oldest-entry tie-break. Exports the class, a `searchCache` singleton, and `clear()`/`getStats()` for tests.
- **`src/search.ts`**: `performWebSearch` checks the cache after env validation + filter normalization and stores the final formatted string on every successful return path (JSON, no-results, formatted). Errors are never cached (they throw before `set`). The key includes every output-affecting input: `query`, `pageno`, `time_range`, effective language/safesearch, normalized `filters`, `min_score`, effective max results, `maxResultChars`, `response_format`, the configured instance list, and the fanout flag. Cache hits are marked at serve time: text gets a `\n\n_Cached result_` suffix; JSON stays parseable and gains a top-level `"cached": true` field. The JSON-annotation path guards `JSON.parse` so a hit can never turn a successful call into a throw.
- **`src/env-int.ts`** (new): shared `parsePositiveInteger` / `normalizePositiveInteger`, imported by both `cache.ts` and `search-cache.ts` so their env-parsing can't drift.
- **`src/cache.ts`**: now imports the two helpers from `env-int.ts` instead of defining local copies (no behavior change).
- **`__tests__/unit/search-cache.test.ts`** (new): set/get, hitCount, TTL expiry (deterministic clock), expired-purge-before-eviction, both eviction paths (LFU + oldest tie-break), nested arg-order normalization, invalid-env fallback, singleton.
- **`__tests__/unit/search.test.ts`**: `formatCachedSearchResult` unit test (text/JSON/malformed-JSON) plus search-level tests — second identical call does not re-fetch and carries exactly one marker (no stacking), cached JSON stays parseable with `cached: true`, TTL expiry re-fetches, and a 9-call isolation test proving distinct `num_results`/format/language/`min_score`/engines/fanout/instance sets never share an entry.
- **`__tests__/helpers/mock-fetch.ts`**: `FetchMocker.restore()` clears the search cache so existing search tests stay isolated.
- **`__tests__/run-all.ts`**: registers the new unit suite.
- **`CONFIGURATION.md`**: documents `SEARCH_CACHE_TTL_MS` and `SEARCH_CACHE_MAX_ENTRIES` (Search Result Controls table + Full Example block), the per-process in-memory scope, and the cache-hit markers.

## How it was verified

Verified independently in a clean worktree:

- `npm run build` — pass
- `npm run test:coverage` — pass, **501/501 tests**; coverage **96.2% lines / 92.33% branch** (gate: 90 lines / 85 branch)
- `npm run test:e2e` (local) — 2/2 pass
- `SEARXNG_LIVE_URL=https://searxng.ihor.top npm run test:e2e` — 11/11 pass, no skipped live suites
- `npm run lint` — clean

## Documentation

`CONFIGURATION.md` documents both new environment variables with defaults (`86400000` / `200`), notes the cache is per-process and in-memory only (not persisted across restarts), and explains the `_Cached result_` text marker and `"cached": true` JSON field. README needed no change (no new tool/parameter surfaced to callers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
