### PR TITLE
docs: sync README/docs with current features, fix HTTP transport example

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,8 +27,8 @@ npm run build   # One-off build
 - Write concise, informative error messages
 - Include unit tests for new functionality
 - Keep coverage above the enforced gate — **90% lines, 85% branches** (CI runs `npm run test:coverage` and fails below it)
-- Test with MCP inspector before submitting
-- Run evals to verify functionality
+- Run `npm run lint` (or `npm run security` for lint + dependency audit) before submitting
+- Test with the MCP inspector (`npm run inspector`) before submitting
 
 ## Testing
 

--- a/README.md
+++ b/README.md
@@ -238,10 +238,13 @@ Or with Docker (bind to all interfaces so the port is reachable from the host):
 
 ```bash
 docker run --rm -p 3000:3000 \
+  --add-host=host.docker.internal:host-gateway \
   -e MCP_HTTP_PORT=3000 -e MCP_HTTP_HOST=0.0.0.0 \
   -e SEARXNG_URL=http://host.docker.internal:8080 \
   isokoliuk/mcp-searxng:latest
 ```
+
+The `--add-host` mapping lets the container reach a SearXNG instance on the host via `host.docker.internal`; it resolves automatically on Docker Desktop but needs this flag on native Linux. Point `SEARXNG_URL` at your actual instance if it runs elsewhere.
 
 **Connect an HTTP-capable MCP client** to the `/mcp` endpoint by URL:
 

--- a/README.md
+++ b/README.md
@@ -42,19 +42,18 @@ Replace `YOUR_SEARXNG_INSTANCE_URL` with the URL of your SearXNG instance (e.g. 
 
 ## Features
 
-- **Web Search**: General queries, news, articles, with pagination.
-- **Instance Failover**: Configure multiple interchangeable SearXNG replicas in `SEARXNG_URL`; searches fail over by default and can optionally fan out in parallel.
-- **Structured Search Output**: Choose formatted text or raw SearXNG-shaped JSON with `response_format`.
-- **Direct Answers & Metadata**: Text results surface SearXNG answers, corrections, suggestions, and infoboxes before result lists.
+- **Web Search**: General, news, and article queries with pagination, time-range/language/safe-search filters, relevance filtering (`min_score`), and formatted-text or raw-JSON output (`response_format`).
+- **Instance Failover & Fan-out**: Configure interchangeable SearXNG replicas in `SEARXNG_URL`; searches fail over in order by default, or query all healthy replicas in parallel and merge results with `SEARXNG_FANOUT`.
+- **Direct Answers & Metadata**: Text results surface SearXNG answers, corrections, suggestions, and infoboxes before the result list.
 - **Search Suggestions**: Query autocomplete via SearXNG's `/autocompleter` endpoint.
 - **Instance Capability Discovery**: Inspect configured categories, engines, defaults, locales, and plugins from `/config`.
-- **URL Content Reading**: Advanced content extraction with pagination, section filtering, and heading extraction.
-- **Intelligent Caching**: URL content is cached with TTL (Time-To-Live) to improve performance and reduce redundant requests.
-- **Pagination**: Control which page of results to retrieve.
-- **Time Filtering**: Filter results by time range (day, week, month, year).
-- **Language Selection**: Filter results by preferred language.
-- **Safe Search**: Control content filtering level for search results.
-- **Relevance Filtering**: Filter out low-scoring search results with `min_score`.
+- **URL Content Reading**: Content-type-aware Markdown conversion with pagination, section filtering, paragraph ranges, and heading extraction.
+- **Intelligent Caching**: Both search results and URL content are cached in memory with configurable TTL and LRU eviction, reducing redundant requests.
+- **SSRF Protection**: `web_url_read` blocks private/internal URLs and redirects by default in all transport modes.
+- **HTTP Transport**: Optional Streamable HTTP mode with opt-in hardening — bearer-token auth, CORS allowlist, and rate limiting.
+- **HTML Fallback**: Optionally parse results from the HTML page for public instances that reject `format=json`.
+- **Lite Tools Mode**: Minimal tool schemas for local models with small context windows.
+- **Proxy Support**: Global or per-tool HTTP/HTTPS proxies for search and URL-reader traffic.
 
 ## Why mcp-searxng?
 
@@ -227,17 +226,31 @@ MCP client config:
 <details>
 <summary>HTTP Transport</summary>
 
-By default the server uses STDIO. Set `MCP_HTTP_PORT` to enable HTTP mode:
+By default the server uses STDIO, launched by your MCP client. To use HTTP instead, run `mcp-searxng` as a **standalone process** with `MCP_HTTP_PORT` set. In this mode it serves the MCP protocol over HTTP and does not speak STDIO, so your client connects to it by URL rather than spawning it.
+
+**Start the server:**
+
+```bash
+MCP_HTTP_PORT=3000 SEARXNG_URL=http://localhost:8080 mcp-searxng
+```
+
+Or with Docker (bind to all interfaces so the port is reachable from the host):
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e MCP_HTTP_PORT=3000 -e MCP_HTTP_HOST=0.0.0.0 \
+  -e SEARXNG_URL=http://host.docker.internal:8080 \
+  isokoliuk/mcp-searxng:latest
+```
+
+**Connect an HTTP-capable MCP client** to the `/mcp` endpoint by URL:
 
 ```json
 {
   "mcpServers": {
     "searxng-http": {
-      "command": "mcp-searxng",
-      "env": {
-        "SEARXNG_URL": "YOUR_SEARXNG_INSTANCE_URL",
-        "MCP_HTTP_PORT": "3000"
-      }
+      "type": "streamable-http",
+      "url": "http://localhost:3000/mcp"
     }
   }
 }
@@ -245,22 +258,21 @@ By default the server uses STDIO. Set `MCP_HTTP_PORT` to enable HTTP mode:
 
 **Endpoints:** `POST/GET/DELETE /mcp` (MCP protocol), `GET /health` (health check)
 
-For reverse-proxy deployments, see [CONFIGURATION.md](CONFIGURATION.md) for `MCP_HTTP_TRUST_PROXY` so rate limiting and logs use the correct client IP.
-
 **Test it:**
 
 ```bash
-MCP_HTTP_PORT=3000 SEARXNG_URL=http://localhost:8080 mcp-searxng
 curl http://localhost:3000/health
 ```
+
+The server binds to `127.0.0.1` by default; set `MCP_HTTP_HOST=0.0.0.0` for remote or containerized deployments. Before exposing it on a network, enable hardened mode (`MCP_HTTP_HARDEN`) and see [CONFIGURATION.md](CONFIGURATION.md) for `MCP_HTTP_TRUST_PROXY` so rate limiting and logs use the correct client IP.
 
 </details>
 
 ## Configuration
 
-Set `SEARXNG_URL` to your SearXNG instance URL. For Basic Auth, embed credentials per instance, for example `https://user:password@search.example.com`. For failover, set it to semicolon-separated interchangeable replica URLs; each entry can carry its own credentials. Set `SEARXNG_FANOUT=true` to query all healthy replicas in parallel and merge results. All other variables are optional.
+`SEARXNG_URL` is the only required variable — set it to your SearXNG instance URL (or a semicolon-separated list of interchangeable replicas). Everything else is optional.
 
-Full environment variable reference: [CONFIGURATION.md](CONFIGURATION.md)
+See **[CONFIGURATION.md](CONFIGURATION.md)** for the full environment variable reference, including authentication, failover/fan-out, caching, timeouts, proxies, TLS, HTTP transport, and hardening.
 
 ## Troubleshooting
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -2,24 +2,20 @@
 
 ## User Guides
 
-- **[README](../README.md)** — Quick start, installation, tool reference, and troubleshooting
-- **[CONFIGURATION](../CONFIGURATION.md)** — All environment variables with defaults and examples
+- **[README](../README.md)** — Quick start, features, installation, tool reference, and troubleshooting
+- **[CONFIGURATION](../CONFIGURATION.md)** — Every environment variable with defaults and examples
+- **[SECURITY](../SECURITY.md)** — Threat model, SSRF protection, HTTP hardening, and vulnerability reporting
 
 ## Topics
 
 ### Installation
-See [README § Installation](../README.md#installation) for setup instructions for Claude Desktop, Cursor, VS Code, and Docker.
+See [README § Installation](../README.md#installation) for NPM, Docker, Docker Compose, and HTTP transport setup.
 
 ### Configuration
-See [CONFIGURATION.md](../CONFIGURATION.md) for all supported environment variables:
-- `SEARXNG_URL` — SearXNG instance URL (required)
-- `MCP_HTTP_PORT` / `MCP_HTTP_HOST` — HTTP transport settings
-- `MCP_HTTP_AUTH_TOKEN` — Bearer token authentication
-- `MCP_RATE_*` — Rate limiting controls
-- `HTTPS_PROXY` / `NO_PROXY` — Proxy settings
+See [CONFIGURATION.md](../CONFIGURATION.md) for the full list of supported environment variables — the single source of truth for defaults and behavior.
 
 ### Tools
-See [README § Tools](../README.md#tools) for the `searxng_web_search` and `web_url_read` tool reference.
+See [README § Tools](../README.md#tools) for the full reference on `searxng_web_search`, `searxng_search_suggestions`, `searxng_instance_info`, and `web_url_read`.
 
 ### Security
-See [SECURITY.md](../SECURITY.md) for the vulnerability reporting policy.
+See [SECURITY.md](../SECURITY.md) for the threat model, SSRF/hardening guidance, and the vulnerability reporting policy.

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -130,6 +130,7 @@ Reads and converts web page content to Markdown format.
 - \`SEARXNG_URL\`: URL of your SearXNG instance (e.g., http://localhost:8080). For Basic Auth, embed credentials in the URL (e.g., https://user:password@search.example.com); percent-encode special characters in the username or password (e.g. \`@\` as \`%40\`). Multi-instance lists can use different credentials per semicolon-separated URL.
 
 ### Optional Environment Variables
+Common ones are listed below. This is not exhaustive — see CONFIGURATION.md in the project repository for the full reference (failover/fan-out, caching, timeouts, result limits, per-tool proxies, TLS, HTTP transport, and hardening).
 - \`AUTH_USERNAME\` & \`AUTH_PASSWORD\`: Legacy global Basic Auth fallback when \`SEARXNG_URL\` has no userinfo
 - \`HTTP_PROXY\` / \`HTTPS_PROXY\`: Proxy server configuration
 - \`NO_PROXY\` / \`no_proxy\`: Comma-separated list of hosts to bypass proxy
@@ -185,7 +186,7 @@ Args: {"includeEngines": true}
 1. **"SEARXNG_URL not set"**: Configure the SEARXNG_URL environment variable
 2. **Network errors**: Check if SearXNG is running and accessible
 3. **Empty results**: Try different search terms or check SearXNG instance
-4. **Timeout errors**: The server has a 10-second timeout for URL fetching
+4. **Timeout errors**: Search and URL fetches time out after 10 seconds by default; tune with \`SEARXNG_TIMEOUT_MS\` and \`FETCH_TIMEOUT_MS\`
 
 Use logging level "debug" for detailed request information.
 


### PR DESCRIPTION
## Summary

Documentation consistency pass. The recurring problem was the same feature/env-var list copy-pasted into several places (README features, README config blurb, `docs/index.md`, the `help://usage-guide` resource), each drifting independently while `CONFIGURATION.md` — the actual source of truth — stayed correct. This makes the other docs thin pointers and fixes the stale content.

## Changes

**README**
- **Features list rewritten** — folded per-call parameters into their parent tool lines (removing pagination duplicated across three bullets) and added the genuinely-missing headline features: **search-result caching** (previously only URL caching was mentioned), **SSRF protection**, **HTTP/hardened transport**, **HTML fallback**, **lite tools mode**, and **proxy support**.
- **HTTP Transport example fixed (functional bug)** — the old example put `MCP_HTTP_PORT` inside a `command`-launched `mcpServers` block. Setting that port makes the process start an HTTP server and **never connect STDIO**, so a client spawning it via `command` would hang. Replaced with a standalone launch (shell + Docker) and a URL-based client config pointing at `/mcp`.
- **Configuration section slimmed** to the one required variable plus a link to `CONFIGURATION.md`, instead of duplicating a subset that drifts.

**docs/index.md** — slimmed to pure pointers (no enumerated lists left to drift); fixed the wrong tool count (listed 2 of 4), removed the promise of Cursor/VS Code install sections that don't exist, and added a SECURITY.md link.

**help://usage-guide resource (`src/resources.ts`)** — fixed the stale "10-second timeout for URL fetching" line (it's configurable via `SEARXNG_TIMEOUT_MS`/`FETCH_TIMEOUT_MS`) and marked the optional-env list as non-exhaustive with a pointer to `CONFIGURATION.md`.

**CONTRIBUTING.md** — replaced the "Run evals to verify functionality" step (no such script exists) with the `lint`/`security` scripts that do.

## Verification

- `npm run build` — clean
- `npm test` — all suites pass (resources unit 18/18 included)

No behavior changes; the only code touched is the help-resource text, whose tests assert structure (tool sections, parameter names, auth notes) and stay green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)