### PR TITLE
security(http-server): validate MCP_RATE_* env vars (SEC-025)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -156,7 +156,7 @@ HTTP sessions are stored in memory per process. A stale or unknown `mcp-session-
 
 ## Rate Limiting (HTTP mode)
 
-Rate limiting is always active in HTTP mode to prevent resource exhaustion. Two separate limits protect different request types. Invalid or non-positive values for any `MCP_RATE_*` variable are ignored with a startup warning and the documented default is used, so a typo cannot silently disable rate limiting.
+Rate limiting is always active in HTTP mode to prevent resource exhaustion. Two separate limits protect different request types. A non-numeric or non-positive value for any `MCP_RATE_*` variable is ignored with a startup warning and the documented default is used, so a typo cannot silently disable rate limiting. (A blank or unset variable uses the default silently.)
 
 | Variable | Required | Default | Description |
 |---|---|---|---|

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -156,7 +156,7 @@ HTTP sessions are stored in memory per process. A stale or unknown `mcp-session-
 
 ## Rate Limiting (HTTP mode)
 
-Rate limiting is always active in HTTP mode to prevent resource exhaustion. Two separate limits protect different request types.
+Rate limiting is always active in HTTP mode to prevent resource exhaustion. Two separate limits protect different request types. Invalid or non-positive values for any `MCP_RATE_*` variable are ignored with a startup warning and the documented default is used, so a typo cannot silently disable rate limiting.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -446,9 +446,9 @@ async function runTests() {
         .send({ jsonrpc: '2.0', method: 'tools/list', id: i });
       lastStatus = res.status;
     }
-    assert.equal(lastStatus, 429, 'limiter must stay active (default 20) on invalid input, not fail open');
-
+    // Restore env before asserting so a failed assertion can't leak MCP_RATE_* into later tests.
     envManager.restore();
+    assert.equal(lastStatus, 429, 'limiter must stay active (default 20) on invalid input, not fail open');
   }, results);
 
   await testFunction('Rate limiting: GET /mcp returns 429 after exceeding sessionLimiter limit', async () => {

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -431,6 +431,26 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('Rate limiting: invalid MCP_RATE_INIT_MAX falls back to default (does not fail open)', async () => {
+    // 'abc' has no leading digit → raw parseInt yields NaN → pre-fix the limiter
+    // was disabled (fail-open). With validation it falls back to the default of 20.
+    envManager.set('MCP_RATE_INIT_MAX', 'abc');
+    envManager.set('MCP_RATE_WINDOW_MS', '60000');
+    const app = await createHttpServer(() => createTestMcpServer());
+
+    let lastStatus = 0;
+    for (let i = 0; i < 21; i++) {
+      const res = await request(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .send({ jsonrpc: '2.0', method: 'tools/list', id: i });
+      lastStatus = res.status;
+    }
+    assert.equal(lastStatus, 429, 'limiter must stay active (default 20) on invalid input, not fail open');
+
+    envManager.restore();
+  }, results);
+
   await testFunction('Rate limiting: GET /mcp returns 429 after exceeding sessionLimiter limit', async () => {
     envManager.set('MCP_RATE_SESSION_MAX', '3');
     envManager.set('MCP_RATE_WINDOW_MS', '60000');

--- a/__tests__/unit/http-server.test.ts
+++ b/__tests__/unit/http-server.test.ts
@@ -15,6 +15,19 @@ import { EnvManager } from '../helpers/env-utils.js';
 const results = createTestResults();
 const envManager = new EnvManager();
 
+/** Runs `fn` with `console.warn` captured, returns the captured lines, and always restores console.warn. */
+function captureWarnings(fn: () => void): string[] {
+  const warnings: string[] = [];
+  const original = console.warn;
+  console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
+  try {
+    fn();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
+
 export async function runTests(): Promise<TestResult> {
   console.log('🧪 Testing: http-server.ts\n');
 
@@ -69,75 +82,51 @@ export async function runTests(): Promise<TestResult> {
   // --- parseRateLimitEnv() ---
 
   await testFunction('parseRateLimitEnv: unset env var → fallback, no warning', () => {
-    delete process.env.MCP_RATE_TEST;
-    const warnings: string[] = [];
-    const original = console.warn;
-    console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
-    try {
-      assert.equal(parseRateLimitEnv('MCP_RATE_TEST', 20), 20);
-    } finally {
-      console.warn = original;
-    }
+    envManager.delete('MCP_RATE_TEST');
+    let result = 0;
+    const warnings = captureWarnings(() => { result = parseRateLimitEnv('MCP_RATE_TEST', 20); });
+    envManager.restore();
+    assert.equal(result, 20);
     assert.equal(warnings.length, 0, 'absent value must not warn');
   }, results);
 
   await testFunction('parseRateLimitEnv: whitespace-only → fallback, no warning', () => {
-    process.env.MCP_RATE_TEST = '   ';
-    const warnings: string[] = [];
-    const original = console.warn;
-    console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
-    try {
-      assert.equal(parseRateLimitEnv('MCP_RATE_TEST', 20), 20);
-    } finally {
-      console.warn = original;
-      delete process.env.MCP_RATE_TEST;
-    }
+    envManager.set('MCP_RATE_TEST', '   ');
+    let result = 0;
+    const warnings = captureWarnings(() => { result = parseRateLimitEnv('MCP_RATE_TEST', 20); });
+    envManager.restore();
+    assert.equal(result, 20);
     assert.equal(warnings.length, 0, 'blank value must not warn');
   }, results);
 
   await testFunction('parseRateLimitEnv: non-numeric → fallback AND warns', () => {
-    process.env.MCP_RATE_TEST = 'abc'; // no leading digit → parseInt yields NaN (the fail-open case)
-    const warnings: string[] = [];
-    const original = console.warn;
-    console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
-    try {
-      assert.equal(parseRateLimitEnv('MCP_RATE_TEST', 20), 20);
-    } finally {
-      console.warn = original;
-      delete process.env.MCP_RATE_TEST;
-    }
+    envManager.set('MCP_RATE_TEST', 'abc'); // no leading digit → parseInt yields NaN (the fail-open case)
+    let result = 0;
+    const warnings = captureWarnings(() => { result = parseRateLimitEnv('MCP_RATE_TEST', 20); });
+    envManager.restore();
+    assert.equal(result, 20);
     assert.equal(warnings.length, 1, 'invalid value must warn once');
     assert.ok(warnings[0].includes('MCP_RATE_TEST'), 'warning names the variable');
     assert.ok(warnings[0].includes('20'), 'warning names the default used');
   }, results);
 
   await testFunction('parseRateLimitEnv: zero and negative → fallback AND warns', () => {
-    const original = console.warn;
     for (const bad of ['0', '-5']) {
-      process.env.MCP_RATE_TEST = bad;
-      const warnings: string[] = [];
-      console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
-      try {
-        assert.equal(parseRateLimitEnv('MCP_RATE_TEST', 300), 300, `${bad} → fallback`);
-      } finally {
-        console.warn = original;
-        delete process.env.MCP_RATE_TEST;
-      }
+      envManager.set('MCP_RATE_TEST', bad);
+      let result = 0;
+      const warnings = captureWarnings(() => { result = parseRateLimitEnv('MCP_RATE_TEST', 300); });
+      envManager.restore();
+      assert.equal(result, 300, `${bad} → fallback`);
       assert.equal(warnings.length, 1, `${bad} must warn`);
     }
   }, results);
 
   await testFunction('parseRateLimitEnv: valid positive integer is honored, no warning', () => {
-    process.env.MCP_RATE_TEST = '50';
-    const warnings: string[] = [];
-    const original = console.warn;
-    console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
-    try {
-      assert.equal(parseRateLimitEnv('MCP_RATE_TEST', 20), 50);
-    } finally {
-      console.warn = original;
-      delete process.env.MCP_RATE_TEST;
-    }
+    envManager.set('MCP_RATE_TEST', '50');
+    let result = 0;
+    const warnings = captureWarnings(() => { result = parseRateLimitEnv('MCP_RATE_TEST', 20); });
+    envManager.restore();
+    assert.equal(result, 50);
     assert.equal(warnings.length, 0, 'valid value must not warn');
   }, results);
 

--- a/__tests__/unit/http-server.test.ts
+++ b/__tests__/unit/http-server.test.ts
@@ -8,7 +8,7 @@
 
 import { strict as assert } from 'node:assert';
 import { fileURLToPath } from 'node:url';
-import { resolveBindHost } from '../../src/http-server.js';
+import { resolveBindHost, parseRateLimitEnv } from '../../src/http-server.js';
 import { testFunction, createTestResults, printTestSummary, TestResult } from '../helpers/test-utils.js';
 import { EnvManager } from '../helpers/env-utils.js';
 
@@ -64,6 +64,81 @@ export async function runTests(): Promise<TestResult> {
 
   await testFunction('Surrounding whitespace is trimmed from valid value', () => {
     assert.equal(resolveBindHost('  127.0.0.1  '), '127.0.0.1');
+  }, results);
+
+  // --- parseRateLimitEnv() ---
+
+  await testFunction('parseRateLimitEnv: unset env var → fallback, no warning', () => {
+    delete process.env.MCP_RATE_TEST;
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
+    try {
+      assert.equal(parseRateLimitEnv('MCP_RATE_TEST', 20), 20);
+    } finally {
+      console.warn = original;
+    }
+    assert.equal(warnings.length, 0, 'absent value must not warn');
+  }, results);
+
+  await testFunction('parseRateLimitEnv: whitespace-only → fallback, no warning', () => {
+    process.env.MCP_RATE_TEST = '   ';
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
+    try {
+      assert.equal(parseRateLimitEnv('MCP_RATE_TEST', 20), 20);
+    } finally {
+      console.warn = original;
+      delete process.env.MCP_RATE_TEST;
+    }
+    assert.equal(warnings.length, 0, 'blank value must not warn');
+  }, results);
+
+  await testFunction('parseRateLimitEnv: non-numeric → fallback AND warns', () => {
+    process.env.MCP_RATE_TEST = 'abc'; // no leading digit → parseInt yields NaN (the fail-open case)
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
+    try {
+      assert.equal(parseRateLimitEnv('MCP_RATE_TEST', 20), 20);
+    } finally {
+      console.warn = original;
+      delete process.env.MCP_RATE_TEST;
+    }
+    assert.equal(warnings.length, 1, 'invalid value must warn once');
+    assert.ok(warnings[0].includes('MCP_RATE_TEST'), 'warning names the variable');
+    assert.ok(warnings[0].includes('20'), 'warning names the default used');
+  }, results);
+
+  await testFunction('parseRateLimitEnv: zero and negative → fallback AND warns', () => {
+    const original = console.warn;
+    for (const bad of ['0', '-5']) {
+      process.env.MCP_RATE_TEST = bad;
+      const warnings: string[] = [];
+      console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
+      try {
+        assert.equal(parseRateLimitEnv('MCP_RATE_TEST', 300), 300, `${bad} → fallback`);
+      } finally {
+        console.warn = original;
+        delete process.env.MCP_RATE_TEST;
+      }
+      assert.equal(warnings.length, 1, `${bad} must warn`);
+    }
+  }, results);
+
+  await testFunction('parseRateLimitEnv: valid positive integer is honored, no warning', () => {
+    process.env.MCP_RATE_TEST = '50';
+    const warnings: string[] = [];
+    const original = console.warn;
+    console.warn = (...a: unknown[]) => { warnings.push(a.map(String).join(' ')); };
+    try {
+      assert.equal(parseRateLimitEnv('MCP_RATE_TEST', 20), 50);
+    } finally {
+      console.warn = original;
+      delete process.env.MCP_RATE_TEST;
+    }
+    assert.equal(warnings.length, 0, 'valid value must not warn');
   }, results);
 
   printTestSummary(results, 'HTTP Server');

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -32,12 +32,34 @@ export function resolveBindHost(envValue: string | undefined): string {
   return trimmed;
 }
 
+/**
+ * Parses a positive-integer rate-limit setting from the environment.
+ * Absent/blank → fallback silently. Present-but-invalid (NaN or <= 0) →
+ * fallback plus a one-line console.warn so an operator typo cannot silently
+ * disable rate limiting (a fail-open control). Uses console.warn, not the MCP
+ * logMessage path, because makeRateLimiters runs without an McpServer in scope.
+ */
+export function parseRateLimitEnv(name: string, fallback: number): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const parsed = parseInt(raw, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    console.warn(
+      `⚠️  Ignoring invalid ${name}="${raw}". Expected a positive integer. Using default ${fallback}.`,
+    );
+    return fallback;
+  }
+  return parsed;
+}
+
 function makeRateLimiters() {
-  const windowMs = parseInt(process.env.MCP_RATE_WINDOW_MS ?? "60000", 10);
+  const windowMs = parseRateLimitEnv("MCP_RATE_WINDOW_MS", 60000);
 
   const initLimiter = rateLimit({
     windowMs,
-    max: parseInt(process.env.MCP_RATE_INIT_MAX ?? "20", 10),
+    max: parseRateLimitEnv("MCP_RATE_INIT_MAX", 20),
     standardHeaders: true,
     legacyHeaders: false,
     message: {
@@ -49,7 +71,7 @@ function makeRateLimiters() {
 
   const sessionLimiter = rateLimit({
     windowMs,
-    max: parseInt(process.env.MCP_RATE_SESSION_MAX ?? "300", 10),
+    max: parseRateLimitEnv("MCP_RATE_SESSION_MAX", 300),
     standardHeaders: true,
     legacyHeaders: false,
     message: {


### PR DESCRIPTION
## Summary

Fixes a **fail-open** in HTTP-mode rate limiting. `makeRateLimiters()` parsed `MCP_RATE_WINDOW_MS` / `MCP_RATE_INIT_MAX` / `MCP_RATE_SESSION_MAX` with raw `parseInt` and no validation. A non-numeric value (e.g. `MCP_RATE_INIT_MAX=xyz`) yields `max: NaN`; express-rate-limit accepts it, `hits > max` is never true, and the limiter documented as "always active in HTTP mode" is silently **off**.

This routes all three knobs through a small validated helper, `parseRateLimitEnv(name, fallback)`, which falls back to the documented default on absent/invalid input and emits a one-line `console.warn` on invalid input so an operator typo can't silently disable the control. Mirrors the existing invalid-value handling of `getFetchTimeoutMs` / `getOperatorMaxResults`; uses `console.warn` because `makeRateLimiters` runs with no `McpServer` in scope.

## Changes

- `src/http-server.ts` — new exported `parseRateLimitEnv`; `makeRateLimiters` uses it for all three knobs (defaults unchanged: 60000 / 20 / 300). `healthLimiter` (hardcoded, not env-driven) untouched.
- `__tests__/unit/http-server.test.ts` — 5 unit tests covering absent / blank / non-numeric / zero+negative / valid, incl. the `console.warn` behavior.
- `__tests__/integration/http-server.test.ts` — regression test: invalid `MCP_RATE_INIT_MAX` → limiter stays active at the default (21st POST → 429), proving it no longer fails open.
- `CONFIGURATION.md` — Rate Limiting section notes the invalid-value fallback + warning.

## Testing

- `npm run test:coverage` — all pass; 96.22% lines (gate 80%), `http-server.ts` functions 100%.
- `npm run build && npm run test:e2e` — 11/11.
- `npm run lint` — clean.
- Live e2e (Layer 3): N/A — pure HTTP rate-limit config validation, no SearXNG/upstream behavior change.

## Note

The tracked TODO's Context used `MCP_RATE_INIT_MAX=2O` as the "yields NaN" example, but `parseInt("2O", 10)` returns `2` (leading digit), not `NaN` — that's fail-*strict*, not fail-open. The genuine fail-open input has no leading digit (`xyz`/`abc` → `NaN` → uncapped); tests use `abc`. The fix keeps lenient `parseInt` for consistency with every other numeric env parser in the codebase; the security concern (NaN → uncapped) is fully closed.

Closes SEC-025.

🤖 Generated with [Claude Code](https://claude.com/claude-code)