### PR TITLE
fix(search): validate SEARXNG_TIMEOUT_MS, fall back to default (BUG-013)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -38,7 +38,7 @@ Percent-encode special characters in usernames or passwords before placing them 
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `SEARXNG_TIMEOUT_MS` | No | `10000` | Maximum time in milliseconds to wait for a SearXNG search response. The request is aborted and a network error is returned if the server does not respond within this window. |
+| `SEARXNG_TIMEOUT_MS` | No | `10000` | Maximum time in milliseconds to wait for a SearXNG search response. The request is aborted and a network error is returned if the server does not respond within this window. Invalid or non-positive values fall back to the default. |
 | `FETCH_TIMEOUT_MS` | No | `10000` | Maximum time in milliseconds to wait for a `web_url_read` fetch. The request is aborted and an error is returned if the server does not respond within this window. |
 
 ## Tool Schema

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -38,7 +38,7 @@ Percent-encode special characters in usernames or passwords before placing them 
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `SEARXNG_TIMEOUT_MS` | No | `10000` | Maximum time in milliseconds to wait for a SearXNG search response. The request is aborted and a network error is returned if the server does not respond within this window. Invalid or non-positive values fall back to the default. |
+| `SEARXNG_TIMEOUT_MS` | No | `10000` | Maximum time in milliseconds to wait for a SearXNG search response. The request is aborted and a network error is returned if the server does not respond within this window. Invalid, non-positive, or out-of-range values (above `2147483647`) fall back to the default. |
 | `FETCH_TIMEOUT_MS` | No | `10000` | Maximum time in milliseconds to wait for a `web_url_read` fetch. The request is aborted and an error is returned if the server does not respond within this window. |
 
 ## Tool Schema

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -1178,6 +1178,14 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('getSearchTimeoutMs falls back to default above the setTimeout ceiling', () => {
+    // > 2^31-1 ms: Node clamps setTimeout to 1 ms, so treat it as invalid.
+    envManager.set('SEARXNG_TIMEOUT_MS', '99999999999');
+    const mockServer = createMockServer();
+    assert.equal(getSearchTimeoutMs(mockServer as any), 10000);
+    envManager.restore();
+  }, results);
+
   await testFunction('getSearchTimeoutMs honors a valid value', () => {
     envManager.set('SEARXNG_TIMEOUT_MS', '5000');
     const mockServer = createMockServer();

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -1163,6 +1163,21 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('getSearchTimeoutMs falls back to default for a unit-suffixed value', () => {
+    // parseInt("10s") would be 10 (a 10ms timeout) — Number() rejects it.
+    envManager.set('SEARXNG_TIMEOUT_MS', '10s');
+    const mockServer = createMockServer();
+    assert.equal(getSearchTimeoutMs(mockServer as any), 10000);
+    envManager.restore();
+  }, results);
+
+  await testFunction('getSearchTimeoutMs falls back to default for a decimal value', () => {
+    envManager.set('SEARXNG_TIMEOUT_MS', '1.5');
+    const mockServer = createMockServer();
+    assert.equal(getSearchTimeoutMs(mockServer as any), 10000);
+    envManager.restore();
+  }, results);
+
   await testFunction('getSearchTimeoutMs honors a valid value', () => {
     envManager.set('SEARXNG_TIMEOUT_MS', '5000');
     const mockServer = createMockServer();

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -9,7 +9,7 @@
 import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
-import { performWebSearch, formatCachedSearchResult } from '../../src/search.js';
+import { performWebSearch, formatCachedSearchResult, getSearchTimeoutMs } from '../../src/search.js';
 import { searchCache } from '../../src/search-cache.js';
 import { clearInstanceInfoCacheForTests } from '../../src/instance-info.js';
 import {
@@ -1142,6 +1142,44 @@ async function runTests() {
     assert.ok(result.includes('Description: abcdefghijklmnopqrstuvwxyz'));
 
     fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  // A NaN/non-positive timeout makes setTimeout(abort, ms) fire on the next tick,
+  // aborting every search. These assert the parser guards it. Tested directly
+  // because the mock fetch resolves on a microtask and ignores the abort signal,
+  // so an end-to-end search can't distinguish the bug from the fix (BUG-013).
+  await testFunction('getSearchTimeoutMs falls back to default for non-numeric value', () => {
+    envManager.set('SEARXNG_TIMEOUT_MS', 'abc');
+    const mockServer = createMockServer();
+    assert.equal(getSearchTimeoutMs(mockServer as any), 10000);
+    envManager.restore();
+  }, results);
+
+  await testFunction('getSearchTimeoutMs falls back to default for non-positive value', () => {
+    envManager.set('SEARXNG_TIMEOUT_MS', '-5');
+    const mockServer = createMockServer();
+    assert.equal(getSearchTimeoutMs(mockServer as any), 10000);
+    envManager.restore();
+  }, results);
+
+  await testFunction('getSearchTimeoutMs honors a valid value', () => {
+    envManager.set('SEARXNG_TIMEOUT_MS', '5000');
+    const mockServer = createMockServer();
+    assert.equal(getSearchTimeoutMs(mockServer as any), 5000);
+    envManager.restore();
+  }, results);
+
+  await testFunction('getSearchTimeoutMs warns on invalid value', () => {
+    envManager.set('SEARXNG_TIMEOUT_MS', 'abc');
+    const { server, getLoggingCalls } = createMockServerWithTracking();
+    getSearchTimeoutMs(server as any);
+    const warning = getLoggingCalls().find(
+      (call) => call.level === 'warning'
+        && typeof call.data?.message === 'string'
+        && call.data.message.includes('Ignoring invalid SEARXNG_TIMEOUT_MS="abc"'),
+    );
+    assert.ok(warning, 'Expected a warning for invalid SEARXNG_TIMEOUT_MS');
     envManager.restore();
   }, results);
 

--- a/src/search.ts
+++ b/src/search.ts
@@ -69,8 +69,11 @@ export function getSearchTimeoutMs(mcpServer: McpServer): number {
     return 10000;
   }
 
-  const parsed = parseInt(rawValue, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
+  // Number() (not parseInt) so unit/decimal strings like "10s" or "1.5" fall
+  // back instead of silently truncating to a tiny timeout — "10s" is the exact
+  // misconfiguration BUG-013 was reported against.
+  const parsed = Number(rawValue.trim());
+  if (!Number.isInteger(parsed) || parsed <= 0) {
     logMessage(
       mcpServer,
       "warning",

--- a/src/search.ts
+++ b/src/search.ts
@@ -71,13 +71,15 @@ export function getSearchTimeoutMs(mcpServer: McpServer): number {
 
   // Number() (not parseInt) so unit/decimal strings like "10s" or "1.5" fall
   // back instead of silently truncating to a tiny timeout — "10s" is the exact
-  // misconfiguration BUG-013 was reported against.
+  // misconfiguration BUG-013 was reported against. Upper bound is the 32-bit
+  // setTimeout ceiling: Node clamps a larger delay to 1 ms, which would again
+  // abort almost immediately.
   const parsed = Number(rawValue.trim());
-  if (!Number.isInteger(parsed) || parsed <= 0) {
+  if (!Number.isInteger(parsed) || parsed <= 0 || parsed > 2_147_483_647) {
     logMessage(
       mcpServer,
       "warning",
-      `Ignoring invalid SEARXNG_TIMEOUT_MS="${rawValue}". Expected a positive integer. Using default 10000.`,
+      `Ignoring invalid SEARXNG_TIMEOUT_MS="${rawValue}". Expected a positive integer up to 2147483647. Using default 10000.`,
     );
     return 10000;
   }

--- a/src/search.ts
+++ b/src/search.ts
@@ -63,6 +63,25 @@ function getMaxResultChars(mcpServer: McpServer): number | undefined {
   return parsed;
 }
 
+export function getSearchTimeoutMs(mcpServer: McpServer): number {
+  const rawValue = process.env.SEARXNG_TIMEOUT_MS;
+  if (rawValue === undefined || rawValue.trim() === "") {
+    return 10000;
+  }
+
+  const parsed = parseInt(rawValue, 10);
+  if (Number.isNaN(parsed) || parsed <= 0) {
+    logMessage(
+      mcpServer,
+      "warning",
+      `Ignoring invalid SEARXNG_TIMEOUT_MS="${rawValue}". Expected a positive integer. Using default 10000.`,
+    );
+    return 10000;
+  }
+
+  return parsed;
+}
+
 function truncateResultContent(content: string, maxResultChars?: number): string {
   if (maxResultChars === undefined || content.length <= maxResultChars) {
     return content;
@@ -708,7 +727,7 @@ export async function performWebSearch(
   
   logMessage(mcpServer, "info", `Starting web search: "${query}" (${searchParams})`);
 
-  const SEARCH_TIMEOUT_MS = parseInt(process.env.SEARXNG_TIMEOUT_MS ?? "10000", 10);
+  const SEARCH_TIMEOUT_MS = getSearchTimeoutMs(mcpServer);
   const instances = getSearxngInstances();
   const fanoutEnabled = isSearxngFanoutEnabled();
   const includeProvenance = instances.length > 1;


### PR DESCRIPTION
## Summary

`SEARXNG_TIMEOUT_MS` was parsed with a raw `parseInt` and no guard:

```ts
const SEARCH_TIMEOUT_MS = parseInt(process.env.SEARXNG_TIMEOUT_MS ?? "10000", 10);
```

A value like `SEARXNG_TIMEOUT_MS=10s` yields `NaN`, and `setTimeout(() => controller.abort(), NaN)` fires on the next tick — so **100% of searches abort immediately** with a network error and nothing points at the misconfigured env var.

This adds a validating `getSearchTimeoutMs(mcpServer)` helper that mirrors the existing `getFetchTimeoutMs` (`src/index.ts`): unset/blank → default `10000`; invalid (non-integer, non-positive, or > 2147483647) → log a warning and fall back to `10000`; valid positive integer within range → honored.

The parser uses `Number()` (not `parseInt`) so unit-suffixed strings like `"10s"` and decimals like `"1.5"` are rejected rather than silently truncated. It also caps values at 2147483647 (2^31-1) because Node clamps larger `setTimeout` delays to 1 ms, which would again cause immediate abort.

## Changes

- `src/search.ts`: new exported `getSearchTimeoutMs()` with strict validation (integer check, positive, ≤ 2147483647); the search path now calls it instead of the raw `parseInt`.
- `CONFIGURATION.md`: note that invalid/non-positive/overflow values fall back to the default.
- `__tests__/unit/search.test.ts`: 7 unit tests covering non-numeric, non-positive, unit-suffixed, decimal, overflow, valid values, and warning emission.

## Testing

- `npm run test:coverage` — 511 pass, 0 fail; exit 0 (gate `--lines 90 --branches 85`; `search.ts` 96.9% lines / 92.8% branches).
- `npm run build && npm run test:e2e` — 11 pass, 0 fail (incl. the `searxng_web_search` timeout suite).
- `npm run lint` — clean.

Live e2e is N/A: this is an internal env-parsing guard — a valid or unset timeout behaves exactly as before, so it changes no live-observable behaviour.

> Note: the tests exercise the parser directly rather than end-to-end. The mock fetch resolves on a microtask and ignores the abort signal, so a `NaN`-timeout search resolves before the `setTimeout(abort, 0)` macrotask — an end-to-end mock cannot distinguish the bug from the fix. A direct parser test is deterministic and covers every branch.

🤖 Generated with <a href="https://claude.com/claude-code">Claude Code</a>