### PR TITLE
fix(http-server): port-aware hardened Host allowlist (BUG-012)

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -179,9 +179,11 @@ Opt-in security layer for when you expose the HTTP transport on a network. Defau
 | `MCP_HTTP_HARDEN` | No | `false` | Set to `true` to enable all hardening features |
 | `MCP_HTTP_AUTH_TOKEN` | No | — | Required bearer token for all HTTP requests in hardened mode |
 | `MCP_HTTP_ALLOWED_ORIGINS` | No | — | Comma-separated CORS origin allowlist (e.g. `https://app.example.com`) |
-| `MCP_HTTP_ALLOWED_HOSTS` | No | — | Comma-separated DNS rebinding protection allowlist override |
+| `MCP_HTTP_ALLOWED_HOSTS` | No | `127.0.0.1`, `localhost`, `[::1]` (+ their `:PORT` forms) | Comma-separated DNS-rebinding allowlist. Entries are matched **exactly** against the request `Host` header, **including the port** (e.g. `app.example.com:8443`). Setting this replaces the default entirely. |
 | `MCP_HTTP_ALLOW_PRIVATE_URLS` | No | `false` | Allow `web_url_read` to fetch internal/private URLs, including hostnames that DNS-resolve to private/internal addresses. Private URL reads are blocked by default in all modes. |
 | `MCP_HTTP_EXPOSE_FULL_CONFIG` | No | `false` | Expose full config details in `/health` response (for debugging) |
+
+`MCP_HTTP_ALLOWED_HOSTS` is compared against the raw `Host` header, which includes the port. The default already covers loopback access on the configured `MCP_HTTP_PORT` (`127.0.0.1:PORT`, `localhost:PORT`, `[::1]:PORT`) plus the bare hostnames for the port-80/443 case. When you set it explicitly, list the exact `Host` the client (or your reverse proxy) sends — e.g. `app.example.com` if the proxy forwards `Host: app.example.com` on 443, or `app.example.com:8443` if it forwards a port.
 
 ## URL Reader Security
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -183,7 +183,7 @@ Opt-in security layer for when you expose the HTTP transport on a network. Defau
 | `MCP_HTTP_ALLOW_PRIVATE_URLS` | No | `false` | Allow `web_url_read` to fetch internal/private URLs, including hostnames that DNS-resolve to private/internal addresses. Private URL reads are blocked by default in all modes. |
 | `MCP_HTTP_EXPOSE_FULL_CONFIG` | No | `false` | Expose full config details in `/health` response (for debugging) |
 
-`MCP_HTTP_ALLOWED_HOSTS` is compared against the raw `Host` header, which includes the port. The default already covers loopback access on the configured `MCP_HTTP_PORT` (`127.0.0.1:PORT`, `localhost:PORT`, `[::1]:PORT`) plus the bare hostnames for the port-80/443 case. When you set it explicitly, list the exact `Host` the client (or your reverse proxy) sends — e.g. `app.example.com` if the proxy forwards `Host: app.example.com` on 443, or `app.example.com:8443` if it forwards a port.
+`MCP_HTTP_ALLOWED_HOSTS` is compared against the raw `Host` header, which includes the port. The default already covers loopback access on the configured `MCP_HTTP_PORT` (`127.0.0.1:PORT`, `localhost:PORT`, `[::1]:PORT`) plus the bare hostnames, which match a portless `Host` — a client or reverse proxy that omits the port (as on ports 80/443). When you set it explicitly, list the exact `Host` the client (or your reverse proxy) sends — e.g. `app.example.com` if the proxy forwards `Host: app.example.com` on 443, or `app.example.com:8443` if it forwards a port.
 
 ## URL Reader Security
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,7 +70,7 @@ Hardened mode enforces:
 
 - **Bearer token authentication** on every request (`Authorization: Bearer <token>`)
 - **CORS origin allowlist** — requests from unlisted origins are rejected
-- **DNS rebinding protection** — the `Host` header is validated against `MCP_HTTP_ALLOWED_HOSTS`. The default allows loopback access on the configured port (`127.0.0.1`, `localhost`, `[::1]` and their `:PORT` forms). A custom list is matched exactly against `Host`, so each entry must include the port if the client or proxy sends one (e.g. `app.example.com:8443`).
+- **DNS rebinding protection** — the `Host` header is validated against `MCP_HTTP_ALLOWED_HOSTS`. The default allows loopback access on the configured port (`127.0.0.1`, `localhost`, `[::1]` and their `:PORT` forms). A custom list is matched exactly against `Host`: an entry matches only when it carries the same port the client or proxy sends (e.g. `app.example.com:8443`).
 
 `MCP_HTTP_HARDEN=true` will fail to start if `MCP_HTTP_AUTH_TOKEN` or `MCP_HTTP_ALLOWED_ORIGINS` are missing.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,7 +70,7 @@ Hardened mode enforces:
 
 - **Bearer token authentication** on every request (`Authorization: Bearer <token>`)
 - **CORS origin allowlist** — requests from unlisted origins are rejected
-- **DNS rebinding protection** — `Host` header is validated against `MCP_HTTP_ALLOWED_HOSTS` (defaults to `127.0.0.1,localhost`)
+- **DNS rebinding protection** — the `Host` header is validated against `MCP_HTTP_ALLOWED_HOSTS`. The default allows loopback access on the configured port (`127.0.0.1`, `localhost`, `[::1]` and their `:PORT` forms). A custom list is matched exactly against `Host`, so each entry must include the port if the client or proxy sends one (e.g. `app.example.com:8443`).
 
 `MCP_HTTP_HARDEN=true` will fail to start if `MCP_HTTP_AUTH_TOKEN` or `MCP_HTTP_ALLOWED_ORIGINS` are missing.
 
@@ -121,7 +121,7 @@ MCP_HTTP_HOST=127.0.0.1             # put a reverse proxy in front
 MCP_HTTP_TRUST_PROXY=1              # trust one reverse-proxy hop
 MCP_HTTP_AUTH_TOKEN=<random-256bit>
 MCP_HTTP_ALLOWED_ORIGINS=https://your-app.example.com
-MCP_HTTP_ALLOWED_HOSTS=your-app.example.com
+MCP_HTTP_ALLOWED_HOSTS=your-app.example.com   # exact Host match; add ":port" if the proxy forwards one
 MCP_HTTP_ALLOW_PRIVATE_URLS=false   # default, keep this off
 ```
 

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -361,11 +361,12 @@ async function runTests() {
     envManager.set('MCP_HTTP_HARDEN', 'true');
     envManager.set('MCP_HTTP_AUTH_TOKEN', 'secret-token');
     envManager.set('MCP_HTTP_ALLOWED_ORIGINS', 'https://app.example.com');
-    envManager.set('MCP_HTTP_ALLOWED_HOSTS', 'allowed.example.com'); // supertest sends 127.0.0.1:<ephemeral>, which will not match
+    envManager.set('MCP_HTTP_ALLOWED_HOSTS', 'allowed.example.com');
 
     const app = await createHttpServer(() => createTestMcpServer(), 3000);
     const res = await request(app)
       .post('/mcp')
+      .set('Host', 'evil.example.com') // explicit disallowed Host so the 403 is deterministic across supertest/node versions
       .set('Origin', 'https://app.example.com')
       .set('Authorization', 'Bearer secret-token')
       .set('Content-Type', 'application/json')

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -326,6 +326,66 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('hardened mode + valid bearer + default hosts + matching Host:port initializes (BUG-012 regression)', async () => {
+    envManager.set('MCP_HTTP_HARDEN', 'true');
+    envManager.set('MCP_HTTP_AUTH_TOKEN', 'secret-token');
+    envManager.set('MCP_HTTP_ALLOWED_ORIGINS', 'https://app.example.com');
+    envManager.delete('MCP_HTTP_ALLOWED_HOSTS'); // use the port-aware default
+
+    const app = await createHttpServer(() => createTestMcpServer(), 3000);
+    const res = await request(app)
+      .post('/mcp')
+      .set('Host', '127.0.0.1:3000')
+      .set('Origin', 'https://app.example.com')
+      .set('Authorization', 'Bearer secret-token')
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' }
+        }
+      });
+
+    // Restore before asserting so a failure cannot leak MCP_HTTP_* into later tests.
+    envManager.restore();
+    assert.equal(res.status, 200);
+    assert.ok(res.headers['mcp-session-id'], 'Expected mcp-session-id header on a successful hardened init');
+  }, results);
+
+  await testFunction('hardened mode rejects a Host not in MCP_HTTP_ALLOWED_HOSTS with 403', async () => {
+    envManager.set('MCP_HTTP_HARDEN', 'true');
+    envManager.set('MCP_HTTP_AUTH_TOKEN', 'secret-token');
+    envManager.set('MCP_HTTP_ALLOWED_ORIGINS', 'https://app.example.com');
+    envManager.set('MCP_HTTP_ALLOWED_HOSTS', 'allowed.example.com'); // supertest sends 127.0.0.1:<ephemeral>, which will not match
+
+    const app = await createHttpServer(() => createTestMcpServer(), 3000);
+    const res = await request(app)
+      .post('/mcp')
+      .set('Origin', 'https://app.example.com')
+      .set('Authorization', 'Bearer secret-token')
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' }
+        }
+      });
+
+    envManager.restore();
+    assert.equal(res.status, 403);
+    assert.equal(res.body.error.code, -32000);
+  }, results);
+
   await testFunction('multiple sessions can initialize without "Already connected" error', async () => {
     const app = await createHttpServer(() => createTestMcpServer());
     const initBody = (clientName: string) => ({

--- a/__tests__/unit/http-security.test.ts
+++ b/__tests__/unit/http-security.test.ts
@@ -102,6 +102,40 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('default allowed-hosts includes loopback hosts and their port variants', () => {
+    envManager.delete('MCP_HTTP_ALLOWED_HOSTS');
+
+    const config = getHttpSecurityConfig(3000);
+    assert.deepEqual(config.allowedHosts, [
+      '127.0.0.1',
+      'localhost',
+      '[::1]',
+      '127.0.0.1:3000',
+      'localhost:3000',
+      '[::1]:3000',
+    ]);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('default allowed-hosts without a port omits the port variants', () => {
+    envManager.delete('MCP_HTTP_ALLOWED_HOSTS');
+
+    const config = getHttpSecurityConfig();
+    assert.deepEqual(config.allowedHosts, ['127.0.0.1', 'localhost', '[::1]']);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('explicit MCP_HTTP_ALLOWED_HOSTS overrides the port-aware default exactly', () => {
+    envManager.set('MCP_HTTP_ALLOWED_HOSTS', 'app.example.com:8443, other.example.com');
+
+    const config = getHttpSecurityConfig(3000);
+    assert.deepEqual(config.allowedHosts, ['app.example.com:8443', 'other.example.com']);
+
+    envManager.restore();
+  }, results);
+
   await testFunction('authorization passes in compatibility mode', () => {
     const config = { harden: false, requireAuth: false } as any;
     assert.equal(isRequestAuthorized(undefined, config), true);

--- a/src/http-security.ts
+++ b/src/http-security.ts
@@ -41,8 +41,9 @@ function parseTrustProxy(value: string | undefined): boolean | number | string {
 // Default DNS-rebinding allowlist when MCP_HTTP_ALLOWED_HOSTS is unset. The SDK
 // transport matches the raw Host header (port included) with exact Array.includes,
 // so the bind port must be baked into the loopback defaults or hardened mode 403s
-// every request on any non-80 port (BUG-012). Bare hostnames are kept for the
-// port-80/default-port case; [::1] mirrors the SDK's own localhost default.
+// every request on any non-80 port (BUG-012). The bare hostnames are always kept
+// too: they match a portless Host — a client or reverse proxy that omits the port
+// (as on default ports 80/443). [::1] mirrors the SDK's own localhost default.
 function defaultAllowedHosts(port?: number): string[] {
   const hosts = ["127.0.0.1", "localhost", "[::1]"];
   if (port !== undefined) {

--- a/src/http-security.ts
+++ b/src/http-security.ts
@@ -38,7 +38,20 @@ function parseTrustProxy(value: string | undefined): boolean | number | string {
   return trimmed;
 }
 
-export function getHttpSecurityConfig(): HttpSecurityConfig {
+// Default DNS-rebinding allowlist when MCP_HTTP_ALLOWED_HOSTS is unset. The SDK
+// transport matches the raw Host header (port included) with exact Array.includes,
+// so the bind port must be baked into the loopback defaults or hardened mode 403s
+// every request on any non-80 port (BUG-012). Bare hostnames are kept for the
+// port-80/default-port case; [::1] mirrors the SDK's own localhost default.
+function defaultAllowedHosts(port?: number): string[] {
+  const hosts = ["127.0.0.1", "localhost", "[::1]"];
+  if (port !== undefined) {
+    hosts.push(`127.0.0.1:${port}`, `localhost:${port}`, `[::1]:${port}`);
+  }
+  return hosts;
+}
+
+export function getHttpSecurityConfig(port?: number): HttpSecurityConfig {
   const harden = isEnabled(process.env.MCP_HTTP_HARDEN);
   const authToken = process.env.MCP_HTTP_AUTH_TOKEN;
   const allowedOrigins = parseCsv(process.env.MCP_HTTP_ALLOWED_ORIGINS);
@@ -51,7 +64,7 @@ export function getHttpSecurityConfig(): HttpSecurityConfig {
     restrictOrigins: harden,
     allowedOrigins,
     enableDnsRebindingProtection: harden,
-    allowedHosts: allowedHosts.length > 0 ? allowedHosts : ["127.0.0.1", "localhost"],
+    allowedHosts: allowedHosts.length > 0 ? allowedHosts : defaultAllowedHosts(port),
     trustProxy: parseTrustProxy(process.env.MCP_HTTP_TRUST_PROXY),
     exposeFullConfig: isEnabled(process.env.MCP_HTTP_EXPOSE_FULL_CONFIG),
     allowPrivateUrls: isEnabled(process.env.MCP_HTTP_ALLOW_PRIVATE_URLS),

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -92,10 +92,11 @@ function makeRateLimiters() {
 }
 
 export async function createHttpServer(
-  createMcpServer: () => McpServer
+  createMcpServer: () => McpServer,
+  port?: number
 ): Promise<express.Application> {
   const app = express();
-  const security = getHttpSecurityConfig();
+  const security = getHttpSecurityConfig(port);
   validateHttpSecurityConfig(security);
   if (security.trustProxy !== false) {
     app.set('trust proxy', security.trustProxy);

--- a/src/index.ts
+++ b/src/index.ts
@@ -346,7 +346,7 @@ export async function main() {
 
     const host = resolveBindHost(process.env.MCP_HTTP_HOST);
     console.log(`Starting HTTP transport on ${host}:${port}`);
-    const app = await createHttpServer(createMcpServer);
+    const app = await createHttpServer(createMcpServer, port);
     
     const httpServer = app.listen(port, host, () => {
       console.log(`HTTP server listening on ${host}:${port}`);


### PR DESCRIPTION
## Summary

`MCP_HTTP_HARDEN=true` — the documented setup for any network-exposed deployment — made the server reject **every** authorized request with `403 Invalid Host header` on any deployment not served on port 80.

Root cause: the MCP SDK transport (`StreamableHTTPServerTransport`, 1.29.0) validates the **raw** `Host` header — port included — with an exact `Array.includes` against `allowedHosts`. The default allowlist was bare hostnames `["127.0.0.1", "localhost"]`, so `127.0.0.1:3000` never matched. Fails closed (no exposure), but makes the flagship hardening feature unusable out of the box, and the docs steer operators straight into it.

## Fix

- `getHttpSecurityConfig(port?)` builds a **port-aware default** allowlist: loopback hosts + their `:PORT` forms + IPv6 loopback — `["127.0.0.1", "localhost", "[::1]", "127.0.0.1:PORT", "localhost:PORT", "[::1]:PORT"]`.
- The already-validated bind port is threaded `main()` → `createHttpServer(createMcpServer, port)` → `getHttpSecurityConfig(port)`. No re-parsing (HTTP mode only runs when `MCP_HTTP_PORT` is set and validated).
- Operator-set `MCP_HTTP_ALLOWED_HOSTS` is unchanged: an exact list, now documented as matched against `Host` **including the port**.
- Docs corrected: `CONFIGURATION.md` listed the default as `—` while `SECURITY.md` said `127.0.0.1,localhost`; neither mentioned the port. Both now state the port-aware default and the exact-match-with-port rule.

DNS-rebinding protection is preserved — a forged `Host: evil.example.com` still gets `403`.

## Testing

- **Unit** (`http-security.ts` now 100% coverage): port-aware default with/without port; explicit override wins exactly.
- **Integration** (the CI blind spot the audit found — the old hardened test 401s before reaching Host validation): valid-bearer + matching `Host:port` + default allowlist → **200 + session id** (the missing regression test); mismatched `Host` → **403**.
- **Live smoke against built `dist/`**, hardened mode on non-80 port `8765`: valid request → `200` + session id; forged `Host: evil.example.com` → `403 Invalid Host header`.
- Coverage 96.25% (no drop; `http-security.ts` 100%). Local e2e 11/0. Lint clean.

Closes BUG-012.

🤖 Generated with [Claude Code](https://claude.com/claude-code)