### PR TITLE
fix(tests): run TypeScript launchers portably on Windows

### DIFF
--- a/__tests__/integration/cli.test.ts
+++ b/__tests__/integration/cli.test.ts
@@ -14,11 +14,9 @@
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import path from 'node:path';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 
 const results = createTestResults();
-const tsxBin = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
 
 async function runTests() {
   console.log('🧪 Integration Testing: cli.ts\n');
@@ -27,8 +25,8 @@ async function runTests() {
     // MCP_HTTP_HARDEN=true without MCP_HTTP_AUTH_TOKEN causes validateHttpSecurityConfig
     // to throw inside createHttpServer, which propagates through main() to the .catch handler.
     const result = spawnSync(
-      tsxBin,
-      ['src/cli.ts'],
+      process.execPath,
+      ['--import', 'tsx', 'src/cli.ts'],
       {
         cwd: process.cwd(),
         env: {

--- a/__tests__/integration/index.test.ts
+++ b/__tests__/integration/index.test.ts
@@ -9,7 +9,6 @@
 import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
-import path from 'node:path';
 import { packageVersion } from '../../src/version.js';
 import {
   isWebUrlReadArgs,
@@ -241,10 +240,9 @@ async function runTests() {
       params: { protocolVersion: '2024-11-05', capabilities: {}, clientInfo: { name: 'test', version: '0.1.0' } },
     }) + '\n';
 
-    const tsxBin = path.join(process.cwd(), 'node_modules', '.bin', 'tsx');
     const result = spawnSync(
-      tsxBin,
-      ['src/cli.ts'],
+      process.execPath,
+      ['--import', 'tsx', 'src/cli.ts'],
       {
         cwd: process.cwd(),
         env: { ...process.env, MCP_HTTP_PORT: '', SEARXNG_URL: 'https://test-searx.example.com' },

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
         "watch": "tsc --watch",
         "test": "cross-env SEARXNG_URL=https://test-searx.example.com tsx __tests__/run-all.ts",
         "test:coverage": "cross-env SEARXNG_URL=https://test-searx.example.com c8 --reporter=text --include 'src/**' --check-coverage --lines 90 --branches 85 tsx __tests__/run-all.ts",
-        "test:e2e": "node --env-file-if-exists=.env.e2e node_modules/.bin/tsx __tests__/e2e/run-e2e.ts",
+        "test:e2e": "node --env-file-if-exists=.env.e2e --import tsx __tests__/e2e/run-e2e.ts",
         "bootstrap": "npm install && npm run build",
         "inspector": "DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector node dist/cli.js",
         "lint": "eslint src __tests__",


### PR DESCRIPTION
## Summary

- launch TypeScript subprocesses through `node --import tsx` in the CLI integration tests
- use the same portable loader pattern for the local e2e npm script
- remove direct execution of npm's platform-specific `.bin/tsx` shim

## Why

On Windows, `node_modules/.bin/tsx` is not a directly executable Unix-style binary. The integration tests could fail to spawn it, and the e2e script passed the POSIX shim to Node as JavaScript. Using Node's module loader works consistently across Windows, Linux, and WSL.

## Impact

This changes development and CI test launchers only. Production code, public APIs, dependencies, and runtime behavior are unchanged.

## Validation

- `npm run test:coverage` — 519/519 passed; 96.23% lines, 92.52% branches
- `npm run lint`
- `npm run build`
- `npm run test:e2e` — 11/11 passed on Windows, including configured live SearXNG checks