### PR TITLE
security(http-security): enforce constant-time bearer auth

### DIFF
--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -326,6 +326,34 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('hardened mode rejects the undocumented raw authorization token', async () => {
+    envManager.set('MCP_HTTP_HARDEN', 'true');
+    envManager.set('MCP_HTTP_AUTH_TOKEN', 'secret-token');
+    envManager.set('MCP_HTTP_ALLOWED_ORIGINS', 'https://app.example.com');
+
+    const app = await createHttpServer(() => createTestMcpServer());
+    const res = await request(app)
+      .post('/mcp')
+      .set('Origin', 'https://app.example.com')
+      .set('Authorization', 'secret-token')
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({
+        jsonrpc: '2.0',
+        id: 1,
+        method: 'initialize',
+        params: {
+          protocolVersion: '2024-11-05',
+          capabilities: {},
+          clientInfo: { name: 'test-client', version: '1.0.0' }
+        }
+      });
+
+    envManager.restore();
+    assert.equal(res.status, 401);
+    assert.equal(res.body.error.code, -32001);
+  }, results);
+
   await testFunction('hardened mode + valid bearer + default hosts + matching Host:port initializes (BUG-012 regression)', async () => {
     envManager.set('MCP_HTTP_HARDEN', 'true');
     envManager.set('MCP_HTTP_AUTH_TOKEN', 'secret-token');

--- a/__tests__/unit/http-security.test.ts
+++ b/__tests__/unit/http-security.test.ts
@@ -141,6 +141,33 @@ async function runTests() {
     assert.equal(isRequestAuthorized(undefined, config), true);
   }, results);
 
+  await testFunction('authorization accepts the exact Bearer token in hardened mode', () => {
+    const config = { harden: true, requireAuth: true, authToken: 'secret-token' } as any;
+    assert.equal(isRequestAuthorized('Bearer secret-token', config), true);
+  }, results);
+
+  await testFunction('authorization rejects non-exact Bearer scheme casing and spacing', () => {
+    const config = { harden: true, requireAuth: true, authToken: 'secret-token' } as any;
+    assert.equal(isRequestAuthorized('bearer secret-token', config), false);
+    assert.equal(isRequestAuthorized('Bearer  secret-token', config), false);
+  }, results);
+
+  await testFunction('authorization rejects the undocumented raw token form', () => {
+    const config = { harden: true, requireAuth: true, authToken: 'secret-token' } as any;
+    assert.equal(isRequestAuthorized('secret-token', config), false);
+  }, results);
+
+  await testFunction('authorization rejects a wrong-length Bearer token', () => {
+    const config = { harden: true, requireAuth: true, authToken: 'secret-token' } as any;
+    assert.equal(isRequestAuthorized('Bearer wrong', config), false);
+  }, results);
+
+  await testFunction('authorization fails closed when the configured token is absent', () => {
+    const config = { harden: true, requireAuth: true, authToken: undefined } as any;
+    assert.equal(isRequestAuthorized(undefined, config), false);
+    assert.equal(isRequestAuthorized('Bearer undefined', config), false);
+  }, results);
+
   await testFunction('authorization rejects missing token in hardened mode', () => {
     const config = { harden: true, requireAuth: true, authToken: 'secret-token' } as any;
     assert.equal(isRequestAuthorized(undefined, config), false);

--- a/src/http-security.ts
+++ b/src/http-security.ts
@@ -1,3 +1,5 @@
+import { createHash, timingSafeEqual } from "node:crypto";
+
 export interface HttpSecurityConfig {
   harden: boolean;
   requireAuth: boolean;
@@ -91,7 +93,13 @@ export function isRequestAuthorized(headerValue: string | undefined, config: Htt
     return true;
   }
 
-  return headerValue === `Bearer ${config.authToken}` || headerValue === config.authToken;
+  if (typeof headerValue !== "string" || !config.authToken) {
+    return false;
+  }
+
+  const providedDigest = createHash("sha256").update(headerValue).digest();
+  const expectedDigest = createHash("sha256").update(`Bearer ${config.authToken}`).digest();
+  return timingSafeEqual(providedDigest, expectedDigest);
 }
 
 export function isOriginAllowed(origin: string | undefined, config: HttpSecurityConfig): boolean {


### PR DESCRIPTION
## Summary
- compare hardened HTTP authorization values through fixed-length SHA-256 digests and timing-safe equality
- enforce the documented Bearer-only authentication contract and reject raw-token headers
- fail closed when the request header or configured credential is absent
- add helper and HTTP integration regression coverage

## Verification
- Node 24: npm run test:coverage — 525/525 tests, 96.23% lines, 92.53% branches
- npm run lint
- npm run build
- npm run test:e2e — 11/11 local and live scenarios
- npm run audit:deps — 0 vulnerabilities