### PR TITLE
fix(logging): honor all MCP severity levels

### DIFF
--- a/__tests__/unit/logging.test.ts
+++ b/__tests__/unit/logging.test.ts
@@ -53,16 +53,18 @@ async function runTests() {
   }, results);
 
   await testFunction('RFC 5424 thresholds filter lower-severity messages', () => {
-    setLogLevel('notice');
-    assert.equal(shouldLog('info'), false);
-    assert.equal(shouldLog('notice'), true);
-    assert.equal(shouldLog('warning'), true);
+    try {
+      setLogLevel('notice');
+      assert.equal(shouldLog('info'), false);
+      assert.equal(shouldLog('notice'), true);
+      assert.equal(shouldLog('warning'), true);
 
-    setLogLevel('emergency');
-    assert.equal(shouldLog('error'), false);
-    assert.equal(shouldLog('emergency'), true);
-
-    setLogLevel('info');
+      setLogLevel('emergency');
+      assert.equal(shouldLog('error'), false);
+      assert.equal(shouldLog('emergency'), true);
+    } finally {
+      setLogLevel('info');
+    }
   }, results);
 
   await testFunction('logMessage with different levels and mock server', () => {

--- a/__tests__/unit/logging.test.ts
+++ b/__tests__/unit/logging.test.ts
@@ -41,12 +41,21 @@ async function runTests() {
   }, results);
 
   await testFunction('All log levels work correctly', () => {
-    const levels = ['error', 'warning', 'info', 'debug'];
+    const levels = [
+      'debug',
+      'info',
+      'notice',
+      'warning',
+      'error',
+      'critical',
+      'alert',
+      'emergency',
+    ] as const;
     
     for (const level of levels) {
-      setLogLevel(level as any);
+      setLogLevel(level);
       for (const testLevel of levels) {
-        const result = shouldLog(testLevel as any);
+        const result = shouldLog(testLevel);
         assert.equal(typeof result, 'boolean');
       }
     }

--- a/__tests__/unit/logging.test.ts
+++ b/__tests__/unit/logging.test.ts
@@ -52,6 +52,19 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('RFC 5424 thresholds filter lower-severity messages', () => {
+    setLogLevel('notice');
+    assert.equal(shouldLog('info'), false);
+    assert.equal(shouldLog('notice'), true);
+    assert.equal(shouldLog('warning'), true);
+
+    setLogLevel('emergency');
+    assert.equal(shouldLog('error'), false);
+    assert.equal(shouldLog('emergency'), true);
+
+    setLogLevel('info');
+  }, results);
+
   await testFunction('logMessage with different levels and mock server', () => {
     const { server, getLoggingCalls } = createMockServerWithTracking();
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -30,7 +30,16 @@ export function logMessage(mcpServer: McpServer, level: LoggingLevel, message: s
 }
 
 export function shouldLog(level: LoggingLevel): boolean {
-  const levels: LoggingLevel[] = ["debug", "info", "warning", "error"];
+  const levels: LoggingLevel[] = [
+    "debug",
+    "info",
+    "notice",
+    "warning",
+    "error",
+    "critical",
+    "alert",
+    "emergency",
+  ];
   return levels.indexOf(level) >= levels.indexOf(currentLogLevel);
 }
 

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -4,6 +4,17 @@ import { LoggingLevel } from "@modelcontextprotocol/sdk/types.js";
 // Logging state
 let currentLogLevel: LoggingLevel = "info";
 
+const LOG_LEVELS: LoggingLevel[] = [
+  "debug",
+  "info",
+  "notice",
+  "warning",
+  "error",
+  "critical",
+  "alert",
+  "emergency",
+];
+
 // Shared handler for sendLoggingMessage errors
 function handleSendError(error: unknown): void {
   if (error instanceof Error && error.message !== "Not connected") {
@@ -30,17 +41,7 @@ export function logMessage(mcpServer: McpServer, level: LoggingLevel, message: s
 }
 
 export function shouldLog(level: LoggingLevel): boolean {
-  const levels: LoggingLevel[] = [
-    "debug",
-    "info",
-    "notice",
-    "warning",
-    "error",
-    "critical",
-    "alert",
-    "emergency",
-  ];
-  return levels.indexOf(level) >= levels.indexOf(currentLogLevel);
+  return LOG_LEVELS.indexOf(level) >= LOG_LEVELS.indexOf(currentLogLevel);
 }
 
 export function setLogLevel(level: LoggingLevel): void {


### PR DESCRIPTION
## Summary

- add the complete eight-level MCP severity ordering to the logging filter
- add regression coverage for `notice` and `emergency` thresholds
- preserve existing logging interfaces and default behavior

## Root cause

The comparator listed only `debug`, `info`, `warning`, and `error`. When a client selected one of the other valid MCP levels, `indexOf` returned `-1`, so lower-severity messages incorrectly passed the filter.

## Validation

- `npx -y -p node@24 -c "npm run test:coverage"` — 526/526 tests, 96.24% lines, 92.53% branches
- `npm run build`
- `npm run test:e2e` — 11/11 local and configured live tests
- `npm run lint`
- `git diff --check`