### PR TITLE
fix(http-server): route POSTs through one rate limiter

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -156,13 +156,13 @@ HTTP sessions are stored in memory per process. A stale or unknown `mcp-session-
 
 ## Rate Limiting (HTTP mode)
 
-Rate limiting is always active in HTTP mode to prevent resource exhaustion. Two separate limits protect different request types. A non-numeric or non-positive value for any `MCP_RATE_*` variable is ignored with a startup warning and the documented default is used, so a typo cannot silently disable rate limiting. (A blank or unset variable uses the default silently.)
+Rate limiting is always active in HTTP mode to prevent resource exhaustion. Before the MCP handler runs, each request is counted by resolved client IP against exactly one limit: POST requests without a currently live session use the initialization limit, while requests associated with an established session use the session limit. A non-numeric or non-positive value for any `MCP_RATE_*` variable is ignored with a startup warning and the documented default is used, so a typo cannot silently disable rate limiting. (A blank or unset variable uses the default silently.)
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `MCP_RATE_WINDOW_MS` | No | `60000` | Sliding window duration in milliseconds for all rate limits |
-| `MCP_RATE_INIT_MAX` | No | `20` | Max POST `/mcp` requests per window (applied to all POSTs, guards against session-init flooding) |
-| `MCP_RATE_SESSION_MAX` | No | `300` | Max GET/DELETE `/mcp` requests per window (per-session calls; intentionally generous for AI agents) |
+| `MCP_RATE_INIT_MAX` | No | `20` | Max POST `/mcp` requests per window when `mcp-session-id` is missing or does not identify a currently live session. Guards initialization, invalid, unknown-session, and stale-session flooding. |
+| `MCP_RATE_SESSION_MAX` | No | `300` | Max POST/GET/DELETE `/mcp` requests per window for established-session traffic. Intentionally generous for AI agents. |
 
 Requests exceeding a limit receive HTTP 429 with a JSON-RPC error body (`code: -32029`). `/health` has a fixed limit of 60 requests per minute. Standard `RateLimit-*` headers are included on all responses.
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -156,13 +156,13 @@ HTTP sessions are stored in memory per process. A stale or unknown `mcp-session-
 
 ## Rate Limiting (HTTP mode)
 
-Rate limiting is always active in HTTP mode to prevent resource exhaustion. Before the MCP handler runs, each request is counted by resolved client IP against exactly one limit: POST requests without a currently live session use the initialization limit, while requests associated with an established session use the session limit. A non-numeric or non-positive value for any `MCP_RATE_*` variable is ignored with a startup warning and the documented default is used, so a typo cannot silently disable rate limiting. (A blank or unset variable uses the default silently.)
+Rate limiting is always active in HTTP mode to prevent resource exhaustion. Before the MCP handler runs, each request is counted by resolved client IP against exactly one limit: POST requests with a currently live session use the session limit, other POST requests use the initialization limit, and GET/DELETE requests always use the session limit. A non-numeric or non-positive value for any `MCP_RATE_*` variable is ignored with a startup warning and the documented default is used, so a typo cannot silently disable rate limiting. (A blank or unset variable uses the default silently.)
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `MCP_RATE_WINDOW_MS` | No | `60000` | Sliding window duration in milliseconds for all rate limits |
 | `MCP_RATE_INIT_MAX` | No | `20` | Max POST `/mcp` requests per window when `mcp-session-id` is missing or does not identify a currently live session. Guards initialization, invalid, unknown-session, and stale-session flooding. |
-| `MCP_RATE_SESSION_MAX` | No | `300` | Max POST/GET/DELETE `/mcp` requests per window for established-session traffic. Intentionally generous for AI agents. |
+| `MCP_RATE_SESSION_MAX` | No | `300` | Max POST `/mcp` requests for currently live sessions and all GET/DELETE `/mcp` requests per window, including GET/DELETE requests with missing or invalid session IDs. Intentionally generous for AI agents. |
 
 Requests exceeding a limit receive HTTP 429 with a JSON-RPC error body (`code: -32029`). `/health` has a fixed limit of 60 requests per minute. Standard `RateLimit-*` headers are included on all responses.
 

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -496,6 +496,133 @@ async function runTests() {
 
   // --- Rate Limiting ---
 
+  await testFunction('Rate limiting: established-session POSTs use only the session limiter', async () => {
+    envManager.set('MCP_RATE_INIT_MAX', '2');
+    envManager.set('MCP_RATE_SESSION_MAX', '3');
+    envManager.set('MCP_RATE_WINDOW_MS', '60000');
+    const app = await createHttpServer(() => createTestMcpServer());
+
+    const initRes = await request(app)
+      .post('/mcp')
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .send({
+        jsonrpc: '2.0', id: 1, method: 'initialize',
+        params: { protocolVersion: '2024-11-05', capabilities: {},
+          clientInfo: { name: 'rate-limit-client', version: '1.0.0' } }
+      });
+    assert.equal(initRes.status, 200);
+    assert.equal(initRes.headers['ratelimit-limit'], '2');
+    const sessionId = initRes.headers['mcp-session-id'];
+    assert.ok(sessionId, 'initialize should return a session id');
+
+    for (let id = 2; id <= 4; id++) {
+      const res = await request(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .set('mcp-session-id', sessionId)
+        .send({ jsonrpc: '2.0', id, method: 'tools/list', params: {} });
+      assert.equal(res.status, 200, `Established-session request ${id - 1} should succeed`);
+      assert.equal(res.headers['ratelimit-limit'], '3');
+    }
+
+    const blocked = await request(app)
+      .post('/mcp')
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('mcp-session-id', sessionId)
+      .send({ jsonrpc: '2.0', id: 5, method: 'tools/list', params: {} });
+    envManager.restore();
+
+    assert.equal(blocked.status, 429);
+    assert.equal(blocked.headers['ratelimit-limit'], '3');
+    assert.equal(blocked.body.error.code, -32029);
+  }, results);
+
+  await testFunction('Rate limiting: non-live session identifiers use the init limiter', async () => {
+    envManager.set('MCP_RATE_INIT_MAX', '7');
+    envManager.set('MCP_RATE_SESSION_MAX', '11');
+    envManager.set('MCP_RATE_WINDOW_MS', '60000');
+    const app = await createHttpServer(() => createTestMcpServer());
+    const headers: Array<string | undefined> = [undefined, '', 'first, second'];
+
+    for (const sessionId of headers) {
+      let pending = request(app).post('/mcp').set('Content-Type', 'application/json');
+      if (sessionId !== undefined) pending = pending.set('mcp-session-id', sessionId);
+      const res = await pending.send({ jsonrpc: '2.0', method: 'tools/list', id: 1 });
+      assert.equal(res.headers['ratelimit-limit'], '7');
+    }
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('Rate limiting: unknown-session POSTs exhaust the init limiter', async () => {
+    envManager.set('MCP_RATE_INIT_MAX', '2');
+    envManager.set('MCP_RATE_SESSION_MAX', '10');
+    envManager.set('MCP_RATE_WINDOW_MS', '60000');
+    const app = await createHttpServer(() => createTestMcpServer());
+
+    for (let id = 1; id <= 2; id++) {
+      const res = await request(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('mcp-session-id', 'plausible-unknown-session')
+        .send({ jsonrpc: '2.0', method: 'tools/list', id });
+      assert.equal(res.status, 404);
+      assert.equal(res.headers['ratelimit-limit'], '2');
+    }
+
+    const blocked = await request(app)
+      .post('/mcp')
+      .set('Content-Type', 'application/json')
+      .set('mcp-session-id', 'plausible-unknown-session')
+      .send({ jsonrpc: '2.0', method: 'tools/list', id: 3 });
+    envManager.restore();
+
+    assert.equal(blocked.status, 429);
+    assert.equal(blocked.headers['ratelimit-limit'], '2');
+    assert.equal(blocked.body.error.code, -32029);
+  }, results);
+
+  await testFunction('Rate limiting: stale-header initialize stays on the init limiter', async () => {
+    envManager.set('MCP_RATE_INIT_MAX', '2');
+    envManager.set('MCP_RATE_SESSION_MAX', '10');
+    envManager.set('MCP_RATE_WINDOW_MS', '60000');
+    const app = await createHttpServer(() => createTestMcpServer());
+    const staleId = 'stale-session-id';
+    const initializeBody = (id: number) => ({
+      jsonrpc: '2.0', id, method: 'initialize',
+      params: { protocolVersion: '2024-11-05', capabilities: {},
+        clientInfo: { name: 'stale-client', version: '1.0.0' } }
+    });
+
+    for (let id = 1; id <= 2; id++) {
+      const res = await request(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .set('mcp-session-id', staleId)
+        .send(initializeBody(id));
+      assert.equal(res.status, 200);
+      assert.equal(res.headers['ratelimit-limit'], '2');
+      assert.ok(res.headers['mcp-session-id']);
+      assert.notEqual(res.headers['mcp-session-id'], staleId);
+    }
+
+    const blocked = await request(app)
+      .post('/mcp')
+      .set('Content-Type', 'application/json')
+      .set('Accept', 'application/json, text/event-stream')
+      .set('mcp-session-id', staleId)
+      .send(initializeBody(3));
+    envManager.restore();
+
+    assert.equal(blocked.status, 429);
+    assert.equal(blocked.headers['ratelimit-limit'], '2');
+    assert.equal(blocked.body.error.code, -32029);
+  }, results);
+
   await testFunction('Rate limiting: POST /mcp returns 429 after exceeding initLimiter limit', async () => {
     envManager.set('MCP_RATE_INIT_MAX', '3');
     envManager.set('MCP_RATE_WINDOW_MS', '60000');

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -133,8 +133,18 @@ export async function createHttpServer(
   // Map to store sessions by session ID
   const sessions = new Map<string, Session>();
 
+  const postRateLimiter: express.RequestHandler = (req, res, next) => {
+    const sessionId = req.headers['mcp-session-id'];
+    // Node comma-joins duplicate custom headers. Only one exact live session ID
+    // selects the generous bucket; every other value stays initialization-limited.
+    const selectedLimiter = typeof sessionId === 'string' && sessions.has(sessionId)
+      ? sessionLimiter
+      : initLimiter;
+    selectedLimiter(req, res, next);
+  };
+
   // Handle POST requests for client-to-server communication
-  app.post('/mcp', initLimiter, sessionLimiter, async (req, res) => {
+  app.post('/mcp', postRateLimiter, async (req, res) => {
     if (!isRequestAuthorized(req.headers.authorization as string | undefined, security)) {
       rejectUnauthorized(res);
       return;

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -141,12 +141,12 @@ export async function createHttpServer(
       contentType: req.headers['content-type'],
       accept: req.headers['accept']
     });
-    const sessionNotFound = Boolean(sessionId);
-    res.status(sessionNotFound ? 404 : 400).json({
+    const hasSessionId = Boolean(sessionId);
+    res.status(hasSessionId ? 404 : 400).json({
       jsonrpc: '2.0',
       error: {
-        code: sessionNotFound ? -32001 : -32000,
-        message: sessionNotFound ? 'Session not found' : 'Bad Request: No valid session ID provided',
+        code: hasSessionId ? -32001 : -32000,
+        message: hasSessionId ? 'Session not found' : 'Bad Request: No valid session ID provided',
       },
       id: null,
     });

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -128,6 +128,51 @@ export async function createHttpServer(
     });
   }
 
+  function rejectInvalidPost(
+    req: express.Request,
+    res: express.Response,
+    sessionId: string | undefined,
+  ) {
+    console.warn(`⚠️  POST request rejected - invalid request:`, {
+      clientIP: req.ip || req.socket.remoteAddress,
+      sessionId: sessionId || 'undefined',
+      hasInitializeRequest: isInitializeRequest(req.body),
+      userAgent: req.headers['user-agent'],
+      contentType: req.headers['content-type'],
+      accept: req.headers['accept']
+    });
+    const sessionNotFound = Boolean(sessionId);
+    res.status(sessionNotFound ? 404 : 400).json({
+      jsonrpc: '2.0',
+      error: {
+        code: sessionNotFound ? -32001 : -32000,
+        message: sessionNotFound ? 'Session not found' : 'Bad Request: No valid session ID provided',
+      },
+      id: null,
+    });
+  }
+
+  async function handleTransportRequest(
+    transport: StreamableHTTPServerTransport,
+    req: express.Request,
+    res: express.Response,
+  ) {
+    try {
+      await transport.handleRequest(req, res, req.body);
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('accept')) {
+        console.warn(`⚠️  Connection rejected due to missing headers:`, {
+          clientIP: req.ip || req.socket.remoteAddress,
+          userAgent: req.headers['user-agent'],
+          contentType: req.headers['content-type'],
+          accept: req.headers['accept'],
+          error: error.message
+        });
+      }
+      throw error;
+    }
+  }
+
   const { initLimiter, sessionLimiter, healthLimiter } = makeRateLimiters();
 
   // Map to store sessions by session ID
@@ -185,43 +230,11 @@ export async function createHttpServer(
       // Connect this session's McpServer to its transport
       await mcpServer.connect(transport);
     } else {
-      // Invalid request
-      console.warn(`⚠️  POST request rejected - invalid request:`, {
-        clientIP: req.ip || req.socket.remoteAddress,
-        sessionId: sessionId || 'undefined',
-        hasInitializeRequest: isInitializeRequest(req.body),
-        userAgent: req.headers['user-agent'],
-        contentType: req.headers['content-type'],
-        accept: req.headers['accept']
-      });
-      const sessionNotFound = Boolean(sessionId);
-      res.status(sessionNotFound ? 404 : 400).json({
-        jsonrpc: '2.0',
-        error: {
-          code: sessionNotFound ? -32001 : -32000,
-          message: sessionNotFound ? 'Session not found' : 'Bad Request: No valid session ID provided',
-        },
-        id: null,
-      });
+      rejectInvalidPost(req, res, sessionId);
       return;
     }
 
-    // Handle the request
-    try {
-      await transport.handleRequest(req, res, req.body);
-    } catch (error) {
-      // Log header-related rejections for debugging
-      if (error instanceof Error && error.message.includes('accept')) {
-        console.warn(`⚠️  Connection rejected due to missing headers:`, {
-          clientIP: req.ip || req.socket.remoteAddress,
-          userAgent: req.headers['user-agent'],
-          contentType: req.headers['content-type'],
-          accept: req.headers['accept'],
-          error: error.message
-        });
-      }
-      throw error;
-    }
+    await handleTransportRequest(transport, req, res);
   });
 
   // Handle GET requests for server-to-client notifications via SSE


### PR DESCRIPTION
## What changed

- Route each HTTP `POST /mcp` request through exactly one rate limiter.
- Use the generous session limiter only when `mcp-session-id` identifies a currently live session.
- Keep missing, empty, malformed, unknown, and stale session identifiers on the initialization limiter.
- Document the revised rate-limit behavior and add regression coverage for established, unknown, malformed, and stale session traffic.
- Extract existing POST error branches so the changed handler stays within static-analysis complexity limits.

## Why

The HTTP route previously stacked both the initialization and session limiters on every POST. As a result, established MCP sessions still exhausted the stricter initialization bucket during normal tool traffic.

## Impact

Established-session POST traffic now receives the configured session allowance, while initialization and invalid-session traffic retain the stricter resource-exhaustion protection. GET, DELETE, authorization ordering, client-IP keying, health limiting, and defaults are unchanged.

## Validation

- `npm test` — 530/530 passed
- coverage — 96.28% lines, 92.57% branches
- `npm run lint`
- `npm run build`
- configured and explicit live end-to-end suites — 11/11 passed each
