### PR TITLE
security(deps): patch vulnerable transitive packages

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -595,12 +595,12 @@
             }
         },
         "node_modules/@hono/node-server": {
-            "version": "1.19.14",
-            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-1.19.14.tgz",
-            "integrity": "sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==",
+            "version": "2.0.11",
+            "resolved": "https://registry.npmjs.org/@hono/node-server/-/node-server-2.0.11.tgz",
+            "integrity": "sha512-bjD221KPLoJTWUwso1J6fGKiTXEUFedG/s0visavY4zakFPkeGURMRNly+FhBHs7T8Dz4qHaZIMX9ZoJHSJtKA==",
             "license": "MIT",
             "engines": {
-                "node": ">=18.14.1"
+                "node": ">=20"
             },
             "peerDependencies": {
                 "hono": "^4"
@@ -1360,16 +1360,16 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.7",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.7.tgz",
-            "integrity": "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA==",
+            "version": "5.0.8",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
+            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "balanced-match": "^4.0.2"
             },
             "engines": {
-                "node": "18 || 20 || >=22"
+                "node": "20 || >=22"
             }
         },
         "node_modules/braces": {
@@ -2489,9 +2489,9 @@
             "license": "MIT"
         },
         "node_modules/fast-uri": {
-            "version": "3.1.2",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.2.tgz",
-            "integrity": "sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==",
+            "version": "3.1.4",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.4.tgz",
+            "integrity": "sha512-8JnbkQ4juDyvYs4mgFGQqg4yCYtFDtUtmp2QIQq11ZZe5CFQ5wcqm1rqDgAh/QdMySuBnPzMUiJUNZG5N/AiQw==",
             "funding": [
                 {
                     "type": "github",

--- a/package.json
+++ b/package.json
@@ -74,6 +74,7 @@
         "typescript": "^5.8.3"
     },
     "overrides": {
+        "@hono/node-server": "2.0.11",
         "hono": ">=4.12.31"
     }
 }


### PR DESCRIPTION
## Summary

- refresh `fast-uri` to 3.1.4, fixing both host-confusion advisories
- override `@hono/node-server` to patched 2.0.11 and verify MCP HTTP lifecycle compatibility
- refresh dev-only `brace-expansion` to 5.0.8 so the aggregate dependency audit is clean

## Downstream npm caveat

The `@hono/node-server` override is root-install policy. It protects this repository's lockfile, CI, and Docker image, but npm ignores overrides declared by dependencies. Applications that install `mcp-searxng` as a dependency may need their own `@hono/node-server` 2.0.11 override until `@modelcontextprotocol/sdk` officially admits a patched 2.x adapter. This change does not claim to force that transitive resolution in another application's root graph.

## Verification

- `npm ci --ignore-scripts`
- `npm audit --audit-level=moderate` — zero vulnerabilities
- exact dependency-tree and `npm explain` checks
- Ajv external-reference and ESM/CJS adapter smokes
- HTTP lifecycle integration — 36/36
- full unit/integration suite — 530/530
- lint and TypeScript build
- Node 20 and Node 24 coverage — 96.28% lines, 92.57% branches
- local MCP e2e — 2/2
- built Docker image health check and production adapter-version inspection

The OpenSSF Scorecard alert runs only on `main`; its closure must be verified on the first Scorecard run for the merged commit.
