### PR TITLE
security(tests): replace ambiguous URL substring assertions

### DIFF
--- a/__tests__/integration/diagnostic-security.test.ts
+++ b/__tests__/integration/diagnostic-security.test.ts
@@ -12,6 +12,17 @@ import {
 } from "../helpers/test-utils.js";
 
 const results = createTestResults();
+const EXPECTED_PROTOCOL_ERROR_MESSAGE =
+  "MCP error -32603: ⚠️ Configuration Issues: "
+  + "SEARXNG_URL entry 1 uses unsupported protocol ftp: for search.example.com. "
+  + "Set SEARXNG_URL (e.g., http://localhost:8080 or https://search.example.com)";
+type LoggingNotification = {
+  method?: unknown;
+  params?: {
+    level?: unknown;
+    data?: { message?: unknown };
+  };
+};
 
 async function connectCli(
   searxngUrl: string,
@@ -54,22 +65,38 @@ async function runTests() {
     await client.close();
 
     const output = `${JSON.stringify(logs)}\n${getStderr()}`;
+    const startupMessages = logs
+      .map((notification) => notification as LoggingNotification)
+      .filter((notification) => (
+        notification.method === "notifications/message"
+        && notification.params?.level === "info"
+      ))
+      .map((notification) => notification.params?.data?.message)
+      .filter((message): message is string => typeof message === "string");
     assert.ok(!output.includes("cli-user"), output);
     assert.ok(!output.includes("cli-secret"), output);
-    assert.ok(output.includes("https://search.example.com/path"), output);
+    assert.ok(startupMessages.length > 0, output);
+    assert.equal(
+      startupMessages.filter(
+        (message) => message === "SearXNG URLs: https://search.example.com/path",
+      ).length,
+      1,
+      output,
+    );
   }, results);
 
   await testFunction("real CLI JSON-RPC errors remove invalid URL credentials", async () => {
     const markerUrl = "ftp://rpc-user:rpc-secret@search.example.com/path";
     const { client, logs, getStderr } = await connectCli(markerUrl);
+    let caughtError: unknown;
     let errorText = "";
     try {
       await client.callTool({
         name: "searxng_web_search",
         arguments: { query: "test" },
       });
-      assert.fail("Expected invalid protocol error");
     } catch (error) {
+      caughtError = error;
       errorText = error instanceof Error ? `${error.message}\n${error.stack}` : String(error);
     }
     await new Promise((resolve) => setTimeout(resolve, 20));
@@ -79,7 +106,8 @@ async function runTests() {
     assert.ok(!output.includes("rpc-user"), output);
     assert.ok(!output.includes("rpc-secret"), output);
     assert.ok(output.includes("ftp:"), output);
-    assert.ok(output.includes("search.example.com"), output);
+    assert.ok(caughtError instanceof Error, "Expected invalid protocol error");
+    assert.equal(caughtError.message, EXPECTED_PROTOCOL_ERROR_MESSAGE, output);
   }, results);
 
   await testFunction("outbound network failures never echo Basic Auth material", async () => {

--- a/__tests__/integration/diagnostic-security.test.ts
+++ b/__tests__/integration/diagnostic-security.test.ts
@@ -36,6 +36,8 @@ async function connectCli(
     cwd: process.cwd(),
     env: {
       ...process.env,
+      AUTH_USERNAME: "",
+      AUTH_PASSWORD: "",
       SEARXNG_URL: searxngUrl,
       ...extraEnv,
     } as Record<string, string>,

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -25,6 +25,10 @@ import { testFunction, createTestResults, printTestSummary } from '../helpers/te
 
 const results = createTestResults();
 const fetchMocker = new FetchMocker();
+const EXPECTED_PROTOCOL_ERROR_MESSAGE =
+  'MCP error -32603: ⚠️ Configuration Issues: '
+  + 'SEARXNG_URL entry 1 uses unsupported protocol ftp: for search.example.com. '
+  + 'Set SEARXNG_URL (e.g., http://localhost:8080 or https://search.example.com)';
 
 /** Spin up a fresh Client↔Server pair for each test. Call client.close() when done. */
 async function connect() {
@@ -471,6 +475,7 @@ async function runTests() {
     resetDiagnosticSanitizerForTests();
     initializeDiagnosticSanitizer();
     const { client, logs } = await connectWithLogs();
+    let caughtError: unknown;
     let errorText = '';
 
     try {
@@ -478,8 +483,8 @@ async function runTests() {
         name: 'searxng_web_search',
         arguments: { query: 'test' },
       });
-      assert.fail('Expected configuration error');
     } catch (error) {
+      caughtError = error;
       errorText = error instanceof Error ? `${error.message}\n${error.stack}` : String(error);
     } finally {
       await new Promise(resolve => setTimeout(resolve, 10));
@@ -493,7 +498,8 @@ async function runTests() {
     assert.ok(!output.includes('protocol-user'), output);
     assert.ok(!output.includes('protocol-secret'), output);
     assert.ok(output.includes('ftp:'), output);
-    assert.ok(output.includes('search.example.com'), output);
+    assert.ok(caughtError instanceof Error, 'Expected configuration error');
+    assert.equal(caughtError.message, EXPECTED_PROTOCOL_ERROR_MESSAGE, output);
   }, results);
 
   // ── tools/call: web_url_read ─────────────────────────────────────────────────
@@ -807,12 +813,13 @@ async function runTests() {
     resetDiagnosticSanitizerForTests();
     initializeDiagnosticSanitizer();
     const { client } = await connect();
+    let caughtError: unknown;
     let output = '';
 
     try {
       await client.readResource({ uri: markerUrl });
-      assert.fail('Expected error was not thrown');
     } catch (error) {
+      caughtError = error;
       output = error instanceof Error ? `${error.message}\n${error.stack}` : String(error);
     } finally {
       await client.close();
@@ -823,7 +830,12 @@ async function runTests() {
 
     assert.ok(!output.includes('resource-user'), output);
     assert.ok(!output.includes('resource-secret'), output);
-    assert.ok(output.includes('search.example.com'), output);
+    assert.ok(caughtError instanceof Error, 'Expected resource error');
+    assert.equal(
+      caughtError.message,
+      'MCP error -32603: Unknown resource: https://search.example.com/',
+      output,
+    );
   }, results);
 
   printTestSummary(results, 'MCP Handler Dispatch');

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -471,6 +471,10 @@ async function runTests() {
 
   await testFunction('tool errors and MCP logs never expose configured Basic Auth material', async () => {
     const originalUrl = process.env.SEARXNG_URL;
+    const originalUsername = process.env.AUTH_USERNAME;
+    const originalPassword = process.env.AUTH_PASSWORD;
+    delete process.env.AUTH_USERNAME;
+    delete process.env.AUTH_PASSWORD;
     process.env.SEARXNG_URL = 'ftp://protocol-user:protocol-secret@search.example.com/path';
     resetDiagnosticSanitizerForTests();
     initializeDiagnosticSanitizer();
@@ -491,6 +495,10 @@ async function runTests() {
       await client.close();
       if (originalUrl === undefined) delete process.env.SEARXNG_URL;
       else process.env.SEARXNG_URL = originalUrl;
+      if (originalUsername === undefined) delete process.env.AUTH_USERNAME;
+      else process.env.AUTH_USERNAME = originalUsername;
+      if (originalPassword === undefined) delete process.env.AUTH_PASSWORD;
+      else process.env.AUTH_PASSWORD = originalPassword;
       resetDiagnosticSanitizerForTests();
     }
 


### PR DESCRIPTION
## Summary
- replace four ambiguous URL substring assertions with exact structured notification and complete MCP error-message checks
- require the expected MCP errors to be thrown before comparing their redacted messages
- preserve all synthetic credential non-disclosure assertions across errors, stacks, notifications, and stderr

This is a test-only change; production URL validation and diagnostic sanitization are unchanged. It addresses code-scanning alerts 63, 64, 65, and 66.

## Verification
- Node 20 focused integration: 3/3 credential diagnostics and 31/31 MCP handlers
- mutation checks: altered positive expectations and injected credential leaks each failed as required
- Node 20 full suite: 551/551
- coverage: 96.17% lines, 92.87% branches
- npm run lint
- npm run build
- npm run audit:deps: 0 vulnerabilities
- npm run test:e2e: 11/11
- independent security code review