### PR TITLE
docs(readme): remove broken Star History card

### DIFF
--- a/README.md
+++ b/README.md
@@ -321,16 +321,6 @@ Enabling JSON on an instance you control (above) remains the recommended setup â
 
 See [CONTRIBUTING.md](CONTRIBUTING.md)
 
-## Star History
-
-<a href="https://www.star-history.com/?repos=ihor-sokoliuk%2Fmcp-searxng&type=date&legend=top-left">
- <picture>
-   <source media="(prefers-color-scheme: dark)" srcset="https://api.star-history.com/chart?repos=ihor-sokoliuk/mcp-searxng&type=date&theme=dark&legend=top-left&sealed_token=3PM12jxtCH_kuy0dBqtrsBjLGrqf7OTAhSgMHJirQw6hLbxosGxQ5hmJYmUVepCP7Z6KkDwwhn6M6Eokf6MwWlfoSvA7cRjGy4WF__yy0T5cDTWCJ3f4IPtYwcKuwWX3dhc_kTdIyqbv18F9byr3lW-EHAAr5v0nD1iKspFfEnpMnkfvMzTBhLu5XLJG" />
-   <source media="(prefers-color-scheme: light)" srcset="https://api.star-history.com/chart?repos=ihor-sokoliuk/mcp-searxng&type=date&legend=top-left&sealed_token=3PM12jxtCH_kuy0dBqtrsBjLGrqf7OTAhSgMHJirQw6hLbxosGxQ5hmJYmUVepCP7Z6KkDwwhn6M6Eokf6MwWlfoSvA7cRjGy4WF__yy0T5cDTWCJ3f4IPtYwcKuwWX3dhc_kTdIyqbv18F9byr3lW-EHAAr5v0nD1iKspFfEnpMnkfvMzTBhLu5XLJG" />
-   <img alt="Star History Chart" src="https://api.star-history.com/chart?repos=ihor-sokoliuk/mcp-searxng&type=date&legend=top-left&sealed_token=3PM12jxtCH_kuy0dBqtrsBjLGrqf7OTAhSgMHJirQw6hLbxosGxQ5hmJYmUVepCP7Z6KkDwwhn6M6Eokf6MwWlfoSvA7cRjGy4WF__yy0T5cDTWCJ3f4IPtYwcKuwWX3dhc_kTdIyqbv18F9byr3lW-EHAAr5v0nD1iKspFfEnpMnkfvMzTBhLu5XLJG" />
- </picture>
-</a>
-
 ## License
 
 MIT â€” see [LICENSE](LICENSE) for details.


### PR DESCRIPTION
## Summary

- remove the broken Star History section from the end of the README
- keep the existing GitHub Stars badge unchanged

## Why

The external historical chart no longer renders reliably after GitHub restricted access to stargazer history. Removing it avoids showing a broken third-party card in the project documentation.

## Impact

Documentation only. Runtime behavior and configuration are unchanged.

## Validation

- confirmed the README contains no Star History heading or `star-history.com` URL
- confirmed the README still flows from Contributing to License
- `git diff --check` passed

Project test suites were not run because this change only deletes an external README card.