### PR TITLE
security(deps): verify published consumer dependencies

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -59,11 +59,17 @@ jobs:
       - name: Install dependencies
         run: npm ci --ignore-scripts
 
+      - name: Test package
+        run: npm run test:coverage
+
       - name: Build package
         run: npm run build
 
+      - name: Verify packed consumer dependencies
+        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"
+
       - name: Publish to npm
-        run: npm publish --access public --provenance
+        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance
 
   publish-mcp-registry:
     name: Publish to MCP Registry

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -180,6 +180,16 @@ npm run audit:deps
 
 The `npm run security` script combines linting (including `eslint-plugin-security` rules) with the dependency audit.
 
+### Published npm Dependency Verification
+
+npm applies `overrides` only from the installing root project, so an override in this package cannot guarantee the dependency tree selected by another application. Before publication, the release workflow packs the actual npm artifact, installs it into an isolated clean consumer whose only direct dependency is that artifact, and verifies that every resolved `@hono/node-server` copy is at least the first patched version, `2.0.5`. The same gate requires a zero-vulnerability production audit and completes an MCP initialize and tools-list smoke test against the installed artifact. npm then publishes that exact verified tarball rather than packing the working tree again.
+
+This guarantee describes the isolated single-dependency installation checked by the release workflow. An existing or newly created application can retain or introduce a different tree through sibling dependency constraints, its lockfile, or root overrides. Consumers should review those constraints after upgrading and run:
+
+```bash
+npm audit --omit=dev
+```
+
 ## Container Image Security
 
 The published Docker image (`isokoliuk/mcp-searxng`) is built from a digest-pinned `node:lts-alpine` base. Base-image updates are automated:

--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -28,6 +28,7 @@ import { runTests as runTlsConfigTests } from './unit/tls-config.test.js';
 import { runTests as runHttpServerUnitTests } from './unit/http-server.test.js';
 import { runTests as runVersionTests } from './unit/version.test.js';
 import { runTests as runHttpSecurityTests } from './unit/http-security.test.js';
+import { runTests as runPackedConsumerTests } from './unit/packed-consumer.test.js';
 import { runTests as runFuzzTests } from './fuzz/search-params.fuzz.js';
 import { runTests as runHttpServerTests } from './integration/http-server.test.js';
 import { runTests as runIndexTests } from './integration/index.test.js';
@@ -62,6 +63,7 @@ const testSuites: TestSuite[] = [
   { name: 'HTTP Server', category: 'unit', run: runHttpServerUnitTests },
   { name: 'Version', category: 'unit', run: runVersionTests },
   { name: 'HTTP Security', category: 'unit', run: runHttpSecurityTests },
+  { name: 'Packed Consumer Verification', category: 'unit', run: runPackedConsumerTests },
   { name: 'Fuzz Properties', category: 'unit', run: runFuzzTests },
 
   // Integration Tests

--- a/__tests__/unit/packed-consumer-fixtures.ts
+++ b/__tests__/unit/packed-consumer-fixtures.ts
@@ -1,0 +1,102 @@
+export const safeTree = {
+  name: 'consumer',
+  version: '1.0.0',
+  dependencies: {
+    'mcp-searxng': {
+      version: '1.12.0',
+      dependencies: {
+        '@modelcontextprotocol/sdk': {
+          version: '1.30.0',
+          dependencies: {
+            '@hono/node-server': { version: '2.0.12' },
+          },
+        },
+      },
+    },
+  },
+};
+
+export const validWorkflow = `name: Publish
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test package
+        run: npm run test:coverage
+      - name: Build package
+        run: npm run build
+      - name: Verify packed consumer
+        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"
+      - name: Publish to npm
+        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance
+  publish-registry:
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo complete
+`;
+
+export const zeroAudit = {
+  metadata: {
+    vulnerabilities: {
+      info: 0,
+      low: 0,
+      moderate: 0,
+      high: 0,
+      critical: 0,
+      total: 0,
+    },
+  },
+};
+
+export function commandResult(overrides: object): object {
+  return {
+    error: undefined,
+    status: 0,
+    signal: null,
+    stdout: '',
+    stderr: '',
+    ...overrides,
+  };
+}
+
+export function treeWithNodeServer(nodeServer: object): object {
+  return {
+    ...safeTree,
+    dependencies: {
+      'mcp-searxng': {
+        version: '1.12.0',
+        dependencies: {
+          '@modelcontextprotocol/sdk': {
+            version: '1.30.0',
+            dependencies: {
+              '@hono/node-server': nodeServer,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+export function validMcpSmokeOutput(): string {
+  return [
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 1,
+      result: { protocolVersion: '2024-11-05' },
+    }),
+    JSON.stringify({
+      jsonrpc: '2.0',
+      id: 2,
+      result: {
+        tools: [
+          { name: 'searxng_web_search' },
+          { name: 'web_url_read' },
+          { name: 'searxng_search_suggestions' },
+          { name: 'searxng_instance_info' },
+        ],
+      },
+    }),
+  ].join('\n');
+}

--- a/__tests__/unit/packed-consumer-fixtures.ts
+++ b/__tests__/unit/packed-consumer-fixtures.ts
@@ -36,8 +36,7 @@ jobs:
       - run: echo complete
 `;
 
-export function invalidPublishWorkflows(): string[] {
-  return [
+export const invalidPublishWorkflows = Object.freeze([
     validWorkflow.replace(
       '      - name: Test package\n        run: npm run test:coverage\n',
       '',
@@ -86,8 +85,19 @@ export function invalidPublishWorkflows(): string[] {
       '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
       '      - name: Publish to npm\n        if: always() # forbidden\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
     ),
-  ];
-}
+    validWorkflow.replace(
+      '    runs-on: ubuntu-latest',
+      '    continue-on-error: ${{ true }}\n    runs-on: ubuntu-latest',
+    ),
+    validWorkflow.replace(
+      '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+      '      - name: Publish to npm\n        if: ${{ always() }}\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+    ),
+    validWorkflow.replace(
+      '        run: npm run verify:packed-consumer',
+      '        run: npm run verify:packed-consumer||true',
+    ),
+]);
 
 export interface SpawnCall {
   command: string;

--- a/__tests__/unit/packed-consumer-fixtures.ts
+++ b/__tests__/unit/packed-consumer-fixtures.ts
@@ -36,6 +36,65 @@ jobs:
       - run: echo complete
 `;
 
+export function invalidPublishWorkflows(): string[] {
+  return [
+    validWorkflow.replace(
+      '      - name: Test package\n        run: npm run test:coverage\n',
+      '',
+    ),
+    validWorkflow.replace(
+      '      - name: Verify packed consumer\n        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"',
+      '  verify:\n    runs-on: ubuntu-latest\n    steps:\n      - run: npm run verify:packed-consumer',
+    ),
+    validWorkflow.replace(
+      '      - name: Build package\n        run: npm run build\n      - name: Verify packed consumer\n        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"',
+      '      - name: Verify packed consumer\n        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"\n      - name: Build package\n        run: npm run build',
+    ),
+    validWorkflow.replace(
+      '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+      '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance\n        continue-on-error: true',
+    ),
+    validWorkflow.replace(
+      '    runs-on: ubuntu-latest',
+      '    continue-on-error: true\n    runs-on: ubuntu-latest',
+    ),
+    validWorkflow.replace(
+      '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+      '      - name: Publish to npm\n        if: always()\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+    ),
+    validWorkflow.replace(
+      '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+      '      - name: Publish to npm\n        if: failure()\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+    ),
+    validWorkflow.replace(
+      '        run: npm run verify:packed-consumer',
+      '        run: set +e; npm run verify:packed-consumer',
+    ),
+    validWorkflow.replace(
+      '        run: npm run verify:packed-consumer',
+      '        run: npm run verify:packed-consumer || true',
+    ),
+    validWorkflow.replace(
+      'npm publish "$RUNNER_TEMP/verified-package.tgz"',
+      'npm publish .',
+    ),
+    validWorkflow.replace(
+      '    runs-on: ubuntu-latest',
+      '    continue-on-error: true # forbidden\n    runs-on: ubuntu-latest',
+    ),
+    validWorkflow.replace(
+      '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+      '      - name: Publish to npm\n        if: always() # forbidden\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+    ),
+  ];
+}
+
+export interface SpawnCall {
+  command: string;
+  args: string[];
+  options: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number };
+}
+
 export const zeroAudit = {
   metadata: {
     vulnerabilities: {

--- a/__tests__/unit/packed-consumer.test.ts
+++ b/__tests__/unit/packed-consumer.test.ts
@@ -211,7 +211,7 @@ async function runWorkflowContractTests(): Promise<void> {
   await testFunction('requires an unsuppressed verifier before publish in the same job', () => {
     assert.equal(assertPublishWorkflowContract(validWorkflow), true);
 
-    for (const workflow of invalidPublishWorkflows()) {
+    for (const workflow of invalidPublishWorkflows) {
       assert.throws(
         () => assertPublishWorkflowContract(workflow),
         /workflow_contract:/,

--- a/__tests__/unit/packed-consumer.test.ts
+++ b/__tests__/unit/packed-consumer.test.ts
@@ -1,0 +1,642 @@
+#!/usr/bin/env tsx
+
+import { strict as assert } from 'node:assert';
+import {
+  existsSync,
+  mkdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+import {
+  assertMcpSmokeResponses,
+  assertArtifactMetadata,
+  assertPublishWorkflowContract,
+  assertSafeDependencyTree,
+  assertZeroProductionAudit,
+  runCheckedCommand,
+  verifyPackedConsumer,
+} from '../../scripts/verify-packed-consumer.mjs';
+import {
+  createTestResults,
+  printTestSummary,
+  testFunction,
+  TestResult,
+} from '../helpers/test-utils.js';
+
+const results = createTestResults();
+
+const safeTree = {
+  name: 'consumer',
+  version: '1.0.0',
+  dependencies: {
+    'mcp-searxng': {
+      version: '1.12.0',
+      dependencies: {
+        '@modelcontextprotocol/sdk': {
+          version: '1.30.0',
+          dependencies: {
+            '@hono/node-server': { version: '2.0.12' },
+          },
+        },
+      },
+    },
+  },
+};
+
+const validWorkflow = `name: Publish
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Test package
+        run: npm run test:coverage
+      - name: Build package
+        run: npm run build
+      - name: Verify packed consumer
+        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"
+      - name: Publish to npm
+        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance
+  publish-registry:
+    needs: build-and-publish
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo complete
+`;
+
+const zeroAudit = {
+  metadata: {
+    vulnerabilities: {
+      info: 0,
+      low: 0,
+      moderate: 0,
+      high: 0,
+      critical: 0,
+      total: 0,
+    },
+  },
+};
+
+function treeWithNodeServer(nodeServer: object): object {
+  return {
+    ...safeTree,
+    dependencies: {
+      'mcp-searxng': {
+        version: '1.12.0',
+        dependencies: {
+          '@modelcontextprotocol/sdk': {
+            version: '1.30.0',
+            dependencies: {
+              '@hono/node-server': nodeServer,
+            },
+          },
+        },
+      },
+    },
+  };
+}
+
+export async function runTests(): Promise<TestResult> {
+  console.log('Testing: packed consumer release verification\n');
+
+  await testFunction('accepts a clean dependency tree containing only patched adapter copies', () => {
+    assert.deepEqual(assertSafeDependencyTree(safeTree), ['2.0.12']);
+    const duplicateSafeTree = {
+      ...safeTree,
+      dependencies: {
+        ...safeTree.dependencies,
+        '@hono/node-server': { version: '2.0.5' },
+      },
+    };
+    assert.deepEqual(
+      assertSafeDependencyTree(duplicateSafeTree),
+      ['2.0.5', '2.0.12'],
+    );
+  }, results);
+
+  await testFunction('rejects every vulnerable, prerelease, missing, or malformed adapter tree', () => {
+    assert.throws(
+      () => assertSafeDependencyTree(treeWithNodeServer({ version: '1.19.17' })),
+      /unsafe_dependency_tree:.*1\.19\.17/,
+    );
+    assert.throws(
+      () => assertSafeDependencyTree(treeWithNodeServer({ version: '2.0.5-beta.1' })),
+      /unsafe_dependency_tree:.*2\.0\.5-beta\.1/,
+    );
+    assert.throws(
+      () => assertSafeDependencyTree({ name: 'consumer', dependencies: {} }),
+      /unsafe_dependency_tree:.*missing/,
+    );
+    assert.throws(
+      () => assertSafeDependencyTree(treeWithNodeServer({})),
+      /unsafe_dependency_tree:.*version/,
+    );
+    assert.throws(
+      () => assertSafeDependencyTree(treeWithNodeServer({ version: 'not-semver' })),
+      /unsafe_dependency_tree:.*not-semver/,
+    );
+  }, results);
+
+  await testFunction('rejects invalid, extraneous, npm-problem, and mixed-version trees', () => {
+    assert.throws(
+      () => assertSafeDependencyTree(treeWithNodeServer({ version: '2.0.12', invalid: true })),
+      /unsafe_dependency_tree:.*invalid/,
+    );
+    assert.throws(
+      () => assertSafeDependencyTree(treeWithNodeServer({ version: '2.0.12', extraneous: true })),
+      /unsafe_dependency_tree:.*extraneous/,
+    );
+    assert.throws(
+      () => assertSafeDependencyTree({
+        ...safeTree,
+        problems: ['invalid: dependency tree'],
+      }),
+      /unsafe_dependency_tree:.*problems/,
+    );
+    assert.throws(
+      () => assertSafeDependencyTree({
+        ...safeTree,
+        dependencies: {
+          ...safeTree.dependencies,
+          '@hono/node-server': { version: '1.19.17' },
+        },
+      }),
+      /unsafe_dependency_tree:.*1\.19\.17/,
+    );
+  }, results);
+
+  await testFunction('accepts only a well-formed zero-total production audit', () => {
+    assert.deepEqual(
+      assertZeroProductionAudit({
+        metadata: {
+          vulnerabilities: {
+            info: 0,
+            low: 0,
+            moderate: 0,
+            high: 0,
+            critical: 0,
+            total: 0,
+          },
+        },
+      }),
+      {
+        info: 0,
+        low: 0,
+        moderate: 0,
+        high: 0,
+        critical: 0,
+        total: 0,
+      },
+    );
+    assert.throws(
+      () => assertZeroProductionAudit({
+        metadata: { vulnerabilities: { total: 1 } },
+      }),
+      /audit_gate:.*1/,
+    );
+    assert.throws(
+      () => assertZeroProductionAudit({ metadata: {} }),
+      /audit_gate:.*metadata/,
+    );
+    assert.throws(
+      () => assertZeroProductionAudit({
+        metadata: { vulnerabilities: { total: '0' } },
+      }),
+      /audit_gate:.*numeric/,
+    );
+  }, results);
+
+  await testFunction('classifies command timeout, spawn, signal, and exit failures as infrastructure errors', () => {
+    const baseOptions = { cwd: '.', env: {}, timeoutMs: 1000 };
+    assert.throws(
+      () => runCheckedCommand('npm', ['install'], {
+        ...baseOptions,
+        spawn: () => ({
+          error: Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }),
+          status: null,
+          signal: null,
+          stdout: '',
+          stderr: '',
+        }),
+      }),
+      /infrastructure:.*timeout/,
+    );
+    assert.throws(
+      () => runCheckedCommand('npm', ['install'], {
+        ...baseOptions,
+        spawn: () => ({
+          error: new Error('spawn failed'),
+          status: null,
+          signal: null,
+          stdout: '',
+          stderr: '',
+        }),
+      }),
+      /infrastructure:.*spawn failed/,
+    );
+    assert.throws(
+      () => runCheckedCommand('npm', ['install'], {
+        ...baseOptions,
+        spawn: () => ({
+          error: undefined,
+          status: null,
+          signal: 'SIGTERM',
+          stdout: '',
+          stderr: '',
+        }),
+      }),
+      /infrastructure:.*SIGTERM/,
+    );
+    assert.throws(
+      () => runCheckedCommand('npm', ['install'], {
+        ...baseOptions,
+        spawn: () => ({
+          error: undefined,
+          status: 1,
+          signal: null,
+          stdout: '',
+          stderr: 'registry unavailable',
+        }),
+      }),
+      /infrastructure:.*status 1/,
+    );
+  }, results);
+
+  await testFunction('accepts successful MCP initialize and tools/list responses from the packed CLI', () => {
+    const stdout = [
+      JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2024-11-05' } }),
+      JSON.stringify({
+        jsonrpc: '2.0',
+        id: 2,
+        result: {
+          tools: [
+            { name: 'searxng_web_search' },
+            { name: 'web_url_read' },
+            { name: 'searxng_search_suggestions' },
+            { name: 'searxng_instance_info' },
+          ],
+        },
+      }),
+    ].join('\n');
+    assert.equal(assertMcpSmokeResponses(stdout), 4);
+    assert.throws(
+      () => assertMcpSmokeResponses(JSON.stringify({ jsonrpc: '2.0', id: 2, result: { tools: [] } })),
+      /mcp_smoke:.*initialize/,
+    );
+    assert.throws(
+      () => assertMcpSmokeResponses([
+        JSON.stringify({ jsonrpc: '2.0', id: 1, error: { code: -1 } }),
+        JSON.stringify({ jsonrpc: '2.0', id: 2, result: { tools: [] } }),
+      ].join('\n')),
+      /mcp_smoke:.*error/,
+    );
+    assert.throws(
+      () => assertMcpSmokeResponses([
+        JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }),
+        JSON.stringify({ jsonrpc: '2.0', id: 2, result: { tools: 'invalid' } }),
+      ].join('\n')),
+      /mcp_smoke:.*tools/,
+    );
+    assert.throws(
+      () => assertMcpSmokeResponses([
+        JSON.stringify({ jsonrpc: '2.0', id: 1, result: {} }),
+        JSON.stringify({ jsonrpc: '2.0', id: 2, result: { tools: [] } }),
+      ].join('\n')),
+      /mcp_smoke:.*expected/,
+    );
+  }, results);
+
+  await testFunction('requires an unsuppressed verifier before publish in the same job', () => {
+    assert.equal(assertPublishWorkflowContract(validWorkflow), true);
+
+    const invalidWorkflows = [
+      validWorkflow.replace(
+        '      - name: Test package\n        run: npm run test:coverage\n',
+        '',
+      ),
+      validWorkflow.replace(
+        '      - name: Verify packed consumer\n        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"',
+        '  verify:\n    runs-on: ubuntu-latest\n    steps:\n      - run: npm run verify:packed-consumer',
+      ),
+      validWorkflow.replace(
+        '      - name: Build package\n        run: npm run build\n      - name: Verify packed consumer\n        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"',
+        '      - name: Verify packed consumer\n        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"\n      - name: Build package\n        run: npm run build',
+      ),
+      validWorkflow.replace(
+        '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+        '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance\n        continue-on-error: true',
+      ),
+      validWorkflow.replace(
+        '    runs-on: ubuntu-latest',
+        '    continue-on-error: true\n    runs-on: ubuntu-latest',
+      ),
+      validWorkflow.replace(
+        '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+        '      - name: Publish to npm\n        if: always()\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+      ),
+      validWorkflow.replace(
+        '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+        '      - name: Publish to npm\n        if: failure()\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
+      ),
+      validWorkflow.replace(
+        '        run: npm run verify:packed-consumer',
+        '        run: set +e; npm run verify:packed-consumer',
+      ),
+      validWorkflow.replace(
+        '        run: npm run verify:packed-consumer',
+        '        run: npm run verify:packed-consumer || true',
+      ),
+      validWorkflow.replace(
+        'npm publish "$RUNNER_TEMP/verified-package.tgz"',
+        'npm publish .',
+      ),
+    ];
+
+    for (const workflow of invalidWorkflows) {
+      assert.throws(
+        () => assertPublishWorkflowContract(workflow),
+        /workflow_contract:/,
+      );
+    }
+  }, results);
+
+  await testFunction('rejects forbidden metadata from the packed artifact', () => {
+    assert.equal(
+      assertArtifactMetadata(
+        {
+          filename: 'mcp-searxng-1.12.0.tgz',
+          files: [
+            { path: 'package.json' },
+            { path: 'dist/cli.js' },
+          ],
+        },
+        {
+          name: 'mcp-searxng',
+          dependencies: {
+            '@modelcontextprotocol/sdk': '1.30.0',
+          },
+        },
+      ),
+      true,
+    );
+    assert.throws(
+      () => assertArtifactMetadata(
+        {
+          filename: 'mcp-searxng-1.12.0.tgz',
+          files: [
+            { path: 'package.json' },
+            { path: 'npm-shrinkwrap.json' },
+          ],
+        },
+        { name: 'mcp-searxng', dependencies: {} },
+      ),
+      /artifact_metadata:.*shrinkwrap/,
+    );
+    assert.throws(
+      () => assertArtifactMetadata(
+        {
+          filename: 'mcp-searxng-1.12.0.tgz',
+          files: [{ path: 'package.json' }],
+        },
+        {
+          name: 'mcp-searxng',
+          dependencies: { '@hono/node-server': '2.0.12' },
+        },
+      ),
+      /artifact_metadata:.*direct/,
+    );
+  }, results);
+
+  await testFunction('the public npm release workflow enforces the packed-consumer gate', () => {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- repository-relative URL is a fixed test input
+    const workflow = readFileSync(
+      new URL('../../.github/workflows/npm-publish.yml', import.meta.url),
+      'utf8',
+    );
+    assert.equal(assertPublishWorkflowContract(workflow), true);
+  }, results);
+
+  await testFunction('packs, installs, validates, audits, and smokes an isolated consumer in order', () => {
+    const calls: Array<{
+      command: string;
+      args: string[];
+      options: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number };
+    }> = [];
+    let temporaryRoot = '';
+    const artifactOutput = path.join(
+      tmpdir(),
+      `mcp-searxng-verified-${process.pid}-${Date.now()}.tgz`,
+    );
+    const credentialVariable = ['NODE', 'AUTH', 'TOKEN'].join('_');
+    const previousCredential = process.env[credentialVariable];
+    process.env[credentialVariable] = 'fixture-release-credential';
+    const spawn = (
+      command: string,
+      args: string[],
+      options: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number },
+    ) => {
+      calls.push({ command, args, options });
+      if (args.includes('pack')) {
+        const destination = args[args.indexOf('--pack-destination') + 1];
+        temporaryRoot = path.dirname(destination);
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- destination is the verifier-created temporary artifact directory
+        writeFileSync(path.join(destination, 'mcp-searxng-1.12.0.tgz'), 'fixture');
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify([{
+            filename: 'mcp-searxng-1.12.0.tgz',
+            files: [
+              { path: 'package.json' },
+              { path: 'dist/cli.js' },
+            ],
+          }]),
+          stderr: '',
+        };
+      }
+      if (args.includes('install')) {
+        const consumerPackage = JSON.parse(
+          // eslint-disable-next-line security/detect-non-literal-fs-filename -- cwd is the verifier-created temporary consumer directory
+          readFileSync(path.join(options.cwd!, 'package.json'), 'utf8'),
+        );
+        assert.match(
+          consumerPackage.dependencies['mcp-searxng'],
+          /^file:.*mcp-searxng-1\.12\.0\.tgz$/,
+        );
+        const installedPackageDirectory = path.join(
+          options.cwd!,
+          'node_modules',
+          'mcp-searxng',
+        );
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- directory belongs to the verifier-created temporary consumer
+        mkdirSync(installedPackageDirectory, { recursive: true });
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- directory belongs to the verifier-created temporary consumer
+        writeFileSync(
+          path.join(installedPackageDirectory, 'package.json'),
+          JSON.stringify({
+            name: 'mcp-searxng',
+            dependencies: { '@modelcontextprotocol/sdk': '1.30.0' },
+          }),
+        );
+        return { status: 0, signal: null, stdout: '', stderr: '' };
+      }
+      if (args.includes('ls')) {
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify(safeTree),
+          stderr: '',
+        };
+      }
+      if (args.includes('audit')) {
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify(zeroAudit),
+          stderr: '',
+        };
+      }
+      return {
+        status: 0,
+        signal: null,
+        stdout: [
+          JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2024-11-05' } }),
+          JSON.stringify({
+            jsonrpc: '2.0',
+            id: 2,
+            result: {
+              tools: [
+                { name: 'searxng_web_search' },
+                { name: 'web_url_read' },
+                { name: 'searxng_search_suggestions' },
+                { name: 'searxng_instance_info' },
+              ],
+            },
+          }),
+        ].join('\n'),
+        stderr: '',
+      };
+    };
+
+    let outcome;
+    try {
+      outcome = verifyPackedConsumer({
+        projectRoot: process.cwd(),
+        artifactOutput,
+        spawn,
+      });
+    } finally {
+      if (previousCredential === undefined) {
+        delete process.env[credentialVariable];
+      } else {
+        process.env[credentialVariable] = previousCredential;
+      }
+    }
+
+    assert.deepEqual(outcome.adapterVersions, ['2.0.12']);
+    assert.equal(outcome.auditTotal, 0);
+    assert.equal(outcome.toolCount, 4);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- unique test output is created under the OS temporary directory
+    assert.equal(readFileSync(artifactOutput, 'utf8'), 'fixture');
+    assert.deepEqual(
+      calls.map(({ args }) => (
+        args.find((argument) => ['pack', 'install', 'ls', 'audit'].includes(argument))
+        ?? args[0]
+      )),
+      ['pack', 'install', 'ls', 'audit', path.join('node_modules', 'mcp-searxng', 'dist', 'cli.js')],
+    );
+    const installCall = calls[1];
+    assert.ok(installCall.args.includes('--ignore-scripts'));
+    assert.ok(installCall.args.includes('--fetch-retries=2'));
+    assert.ok(installCall.args.includes('--fetch-timeout=60000'));
+    assert.equal(installCall.options.timeout, 300_000);
+    assert.equal(installCall.options.env?.NPM_CONFIG_REGISTRY, 'https://registry.npmjs.org/');
+    for (const call of calls) {
+      assert.equal(call.options.env?.[credentialVariable], undefined);
+    }
+    const lsCall = calls.find(({ args }) => args.includes('ls'));
+    assert.deepEqual(lsCall?.args.slice(lsCall.args.indexOf('ls')), ['ls', '--all', '--json']);
+    assert.ok(installCall.options.env?.NPM_CONFIG_CACHE?.startsWith(temporaryRoot));
+    assert.ok(installCall.options.env?.NPM_CONFIG_USERCONFIG?.startsWith(temporaryRoot));
+    assert.ok(installCall.options.env?.NPM_CONFIG_GLOBALCONFIG?.startsWith(temporaryRoot));
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path was captured from the verifier-created temporary directory
+    assert.equal(existsSync(temporaryRoot), false);
+    rmSync(artifactOutput, { force: true });
+  }, results);
+
+  await testFunction('removes the isolated consumer after a command failure', () => {
+    let temporaryRoot = '';
+    const spawn = (
+      _command: string,
+      args: string[],
+      _options: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number },
+    ) => {
+      if (args.includes('pack')) {
+        const destination = args[args.indexOf('--pack-destination') + 1];
+        temporaryRoot = path.dirname(destination);
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- destination is the verifier-created temporary artifact directory
+        writeFileSync(path.join(destination, 'mcp-searxng-1.12.0.tgz'), 'fixture');
+        return {
+          status: 0,
+          signal: null,
+          stdout: JSON.stringify([{
+            filename: 'mcp-searxng-1.12.0.tgz',
+            files: [
+              { path: 'package.json' },
+              { path: 'dist/cli.js' },
+            ],
+          }]),
+          stderr: '',
+        };
+      }
+      if (args.includes('install')) {
+        const installedPackageDirectory = path.join(
+          _options.cwd!,
+          'node_modules',
+          'mcp-searxng',
+        );
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- directory belongs to the verifier-created temporary consumer
+        mkdirSync(installedPackageDirectory, { recursive: true });
+        // eslint-disable-next-line security/detect-non-literal-fs-filename -- directory belongs to the verifier-created temporary consumer
+        writeFileSync(
+          path.join(installedPackageDirectory, 'package.json'),
+          JSON.stringify({
+            name: 'mcp-searxng',
+            dependencies: { '@modelcontextprotocol/sdk': '1.30.0' },
+          }),
+        );
+      }
+      if (args.includes('ls')) {
+        return {
+          status: 1,
+          signal: null,
+          stdout: JSON.stringify(safeTree),
+          stderr: 'dependency tree unavailable',
+        };
+      }
+      return { status: 0, signal: null, stdout: '', stderr: '' };
+    };
+
+    assert.throws(
+      () => verifyPackedConsumer({ projectRoot: process.cwd(), spawn }),
+      /infrastructure:.*status 1/,
+    );
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path was captured from the verifier-created temporary directory
+    assert.equal(existsSync(temporaryRoot), false);
+  }, results);
+
+  printTestSummary(results, 'Packed Consumer Verification');
+  return results;
+}
+
+if (
+  process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  runTests().then((result) => {
+    if (result.failed > 0) process.exitCode = 1;
+  });
+}

--- a/__tests__/unit/packed-consumer.test.ts
+++ b/__tests__/unit/packed-consumer.test.ts
@@ -17,8 +17,8 @@ import {
   TestResult,
 } from '../helpers/test-utils.js';
 import {
-  commandResult, safeTree, treeWithNodeServer,
-  validMcpSmokeOutput, validWorkflow, zeroAudit,
+  commandResult, invalidPublishWorkflows, safeTree, SpawnCall,
+  treeWithNodeServer, validMcpSmokeOutput, validWorkflow, zeroAudit,
 } from './packed-consumer-fixtures.js';
 
 const results = createTestResults();
@@ -211,50 +211,7 @@ async function runWorkflowContractTests(): Promise<void> {
   await testFunction('requires an unsuppressed verifier before publish in the same job', () => {
     assert.equal(assertPublishWorkflowContract(validWorkflow), true);
 
-    const invalidWorkflows = [
-      validWorkflow.replace(
-        '      - name: Test package\n        run: npm run test:coverage\n',
-        '',
-      ),
-      validWorkflow.replace(
-        '      - name: Verify packed consumer\n        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"',
-        '  verify:\n    runs-on: ubuntu-latest\n    steps:\n      - run: npm run verify:packed-consumer',
-      ),
-      validWorkflow.replace(
-        '      - name: Build package\n        run: npm run build\n      - name: Verify packed consumer\n        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"',
-        '      - name: Verify packed consumer\n        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"\n      - name: Build package\n        run: npm run build',
-      ),
-      validWorkflow.replace(
-        '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
-        '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance\n        continue-on-error: true',
-      ),
-      validWorkflow.replace(
-        '    runs-on: ubuntu-latest',
-        '    continue-on-error: true\n    runs-on: ubuntu-latest',
-      ),
-      validWorkflow.replace(
-        '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
-        '      - name: Publish to npm\n        if: always()\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
-      ),
-      validWorkflow.replace(
-        '      - name: Publish to npm\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
-        '      - name: Publish to npm\n        if: failure()\n        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance',
-      ),
-      validWorkflow.replace(
-        '        run: npm run verify:packed-consumer',
-        '        run: set +e; npm run verify:packed-consumer',
-      ),
-      validWorkflow.replace(
-        '        run: npm run verify:packed-consumer',
-        '        run: npm run verify:packed-consumer || true',
-      ),
-      validWorkflow.replace(
-        'npm publish "$RUNNER_TEMP/verified-package.tgz"',
-        'npm publish .',
-      ),
-    ];
-
-    for (const workflow of invalidWorkflows) {
+    for (const workflow of invalidPublishWorkflows()) {
       assert.throws(
         () => assertPublishWorkflowContract(workflow),
         /workflow_contract:/,
@@ -328,11 +285,7 @@ async function runWorkflowContractTests(): Promise<void> {
 
 async function runOrchestrationTests(): Promise<void> {
   await testFunction('packs, installs, validates, audits, and smokes an isolated consumer in order', () => {
-    const calls: Array<{
-      command: string;
-      args: string[];
-      options: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number };
-    }> = [];
+    const calls: SpawnCall[] = [];
     let temporaryRoot = '';
     const artifactOutput = path.join(tmpdir(), `mcp-searxng-verified-${process.pid}-${Date.now()}.tgz`);
     const credentialVariable = ['NODE', 'AUTH', 'TOKEN'].join('_');
@@ -519,7 +472,8 @@ export async function runTests(): Promise<TestResult> {
   await runProcessContractTests();
   await runWorkflowContractTests();
   await runOrchestrationTests();
-  printTestSummary(results, 'Packed Consumer Verification'); return results;
+  printTestSummary(results, 'Packed Consumer Verification');
+  return results;
 }
 
 if (

--- a/__tests__/unit/packed-consumer.test.ts
+++ b/__tests__/unit/packed-consumer.test.ts
@@ -1,23 +1,13 @@
 #!/usr/bin/env tsx
 
 import { strict as assert } from 'node:assert';
-import {
-  existsSync,
-  mkdirSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
 import {
-  assertMcpSmokeResponses,
-  assertArtifactMetadata,
-  assertPublishWorkflowContract,
-  assertSafeDependencyTree,
-  assertZeroProductionAudit,
-  runCheckedCommand,
+  assertMcpSmokeResponses, assertArtifactMetadata, assertPublishWorkflowContract,
+  assertSafeDependencyTree, assertZeroProductionAudit, runCheckedCommand,
   verifyPackedConsumer,
 } from '../../scripts/verify-packed-consumer.mjs';
 import {
@@ -26,82 +16,14 @@ import {
   testFunction,
   TestResult,
 } from '../helpers/test-utils.js';
+import {
+  commandResult, safeTree, treeWithNodeServer,
+  validMcpSmokeOutput, validWorkflow, zeroAudit,
+} from './packed-consumer-fixtures.js';
 
 const results = createTestResults();
 
-const safeTree = {
-  name: 'consumer',
-  version: '1.0.0',
-  dependencies: {
-    'mcp-searxng': {
-      version: '1.12.0',
-      dependencies: {
-        '@modelcontextprotocol/sdk': {
-          version: '1.30.0',
-          dependencies: {
-            '@hono/node-server': { version: '2.0.12' },
-          },
-        },
-      },
-    },
-  },
-};
-
-const validWorkflow = `name: Publish
-jobs:
-  build-and-publish:
-    runs-on: ubuntu-latest
-    steps:
-      - name: Test package
-        run: npm run test:coverage
-      - name: Build package
-        run: npm run build
-      - name: Verify packed consumer
-        run: npm run verify:packed-consumer -- --output "$RUNNER_TEMP/verified-package.tgz"
-      - name: Publish to npm
-        run: npm publish "$RUNNER_TEMP/verified-package.tgz" --access public --provenance
-  publish-registry:
-    needs: build-and-publish
-    runs-on: ubuntu-latest
-    steps:
-      - run: echo complete
-`;
-
-const zeroAudit = {
-  metadata: {
-    vulnerabilities: {
-      info: 0,
-      low: 0,
-      moderate: 0,
-      high: 0,
-      critical: 0,
-      total: 0,
-    },
-  },
-};
-
-function treeWithNodeServer(nodeServer: object): object {
-  return {
-    ...safeTree,
-    dependencies: {
-      'mcp-searxng': {
-        version: '1.12.0',
-        dependencies: {
-          '@modelcontextprotocol/sdk': {
-            version: '1.30.0',
-            dependencies: {
-              '@hono/node-server': nodeServer,
-            },
-          },
-        },
-      },
-    },
-  };
-}
-
-export async function runTests(): Promise<TestResult> {
-  console.log('Testing: packed consumer release verification\n');
-
+async function runDependencyContractTests(): Promise<void> {
   await testFunction('accepts a clean dependency tree containing only patched adapter copies', () => {
     assert.deepEqual(assertSafeDependencyTree(safeTree), ['2.0.12']);
     const duplicateSafeTree = {
@@ -208,18 +130,17 @@ export async function runTests(): Promise<TestResult> {
       /audit_gate:.*numeric/,
     );
   }, results);
+}
 
+async function runProcessContractTests(): Promise<void> {
   await testFunction('classifies command timeout, spawn, signal, and exit failures as infrastructure errors', () => {
     const baseOptions = { cwd: '.', env: {}, timeoutMs: 1000 };
     assert.throws(
       () => runCheckedCommand('npm', ['install'], {
         ...baseOptions,
-        spawn: () => ({
+        spawn: () => commandResult({
           error: Object.assign(new Error('timed out'), { code: 'ETIMEDOUT' }),
           status: null,
-          signal: null,
-          stdout: '',
-          stderr: '',
         }),
       }),
       /infrastructure:.*timeout/,
@@ -227,12 +148,9 @@ export async function runTests(): Promise<TestResult> {
     assert.throws(
       () => runCheckedCommand('npm', ['install'], {
         ...baseOptions,
-        spawn: () => ({
+        spawn: () => commandResult({
           error: new Error('spawn failed'),
           status: null,
-          signal: null,
-          stdout: '',
-          stderr: '',
         }),
       }),
       /infrastructure:.*spawn failed/,
@@ -240,12 +158,9 @@ export async function runTests(): Promise<TestResult> {
     assert.throws(
       () => runCheckedCommand('npm', ['install'], {
         ...baseOptions,
-        spawn: () => ({
-          error: undefined,
+        spawn: () => commandResult({
           status: null,
           signal: 'SIGTERM',
-          stdout: '',
-          stderr: '',
         }),
       }),
       /infrastructure:.*SIGTERM/,
@@ -253,35 +168,17 @@ export async function runTests(): Promise<TestResult> {
     assert.throws(
       () => runCheckedCommand('npm', ['install'], {
         ...baseOptions,
-        spawn: () => ({
-          error: undefined,
+        spawn: () => commandResult({
           status: 1,
-          signal: null,
-          stdout: '',
           stderr: 'registry unavailable',
         }),
       }),
-      /infrastructure:.*status 1/,
+      /infrastructure:.*npm install.*status 1/,
     );
   }, results);
 
   await testFunction('accepts successful MCP initialize and tools/list responses from the packed CLI', () => {
-    const stdout = [
-      JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2024-11-05' } }),
-      JSON.stringify({
-        jsonrpc: '2.0',
-        id: 2,
-        result: {
-          tools: [
-            { name: 'searxng_web_search' },
-            { name: 'web_url_read' },
-            { name: 'searxng_search_suggestions' },
-            { name: 'searxng_instance_info' },
-          ],
-        },
-      }),
-    ].join('\n');
-    assert.equal(assertMcpSmokeResponses(stdout), 4);
+    assert.equal(assertMcpSmokeResponses(validMcpSmokeOutput()), 4);
     assert.throws(
       () => assertMcpSmokeResponses(JSON.stringify({ jsonrpc: '2.0', id: 2, result: { tools: [] } })),
       /mcp_smoke:.*initialize/,
@@ -308,7 +205,9 @@ export async function runTests(): Promise<TestResult> {
       /mcp_smoke:.*expected/,
     );
   }, results);
+}
 
+async function runWorkflowContractTests(): Promise<void> {
   await testFunction('requires an unsuppressed verifier before publish in the same job', () => {
     assert.equal(assertPublishWorkflowContract(validWorkflow), true);
 
@@ -408,6 +307,13 @@ export async function runTests(): Promise<TestResult> {
       ),
       /artifact_metadata:.*direct/,
     );
+    assert.throws(
+      () => assertArtifactMetadata(
+        { filename: 'mcp-searxng-1.12.0.tgz', files: [null] },
+        { name: 'mcp-searxng', dependencies: {} },
+      ),
+      /artifact_metadata:.*file entry/,
+    );
   }, results);
 
   await testFunction('the public npm release workflow enforces the packed-consumer gate', () => {
@@ -418,7 +324,9 @@ export async function runTests(): Promise<TestResult> {
     );
     assert.equal(assertPublishWorkflowContract(workflow), true);
   }, results);
+}
 
+async function runOrchestrationTests(): Promise<void> {
   await testFunction('packs, installs, validates, audits, and smokes an isolated consumer in order', () => {
     const calls: Array<{
       command: string;
@@ -426,13 +334,11 @@ export async function runTests(): Promise<TestResult> {
       options: { cwd?: string; env?: NodeJS.ProcessEnv; timeout?: number };
     }> = [];
     let temporaryRoot = '';
-    const artifactOutput = path.join(
-      tmpdir(),
-      `mcp-searxng-verified-${process.pid}-${Date.now()}.tgz`,
-    );
+    const artifactOutput = path.join(tmpdir(), `mcp-searxng-verified-${process.pid}-${Date.now()}.tgz`);
     const credentialVariable = ['NODE', 'AUTH', 'TOKEN'].join('_');
     const previousCredential = process.env[credentialVariable];
     process.env[credentialVariable] = 'fixture-release-credential';
+    // #lizard forgives -- fake process dispatch mirrors five deterministic commands
     const spawn = (
       command: string,
       args: string[],
@@ -466,11 +372,7 @@ export async function runTests(): Promise<TestResult> {
           consumerPackage.dependencies['mcp-searxng'],
           /^file:.*mcp-searxng-1\.12\.0\.tgz$/,
         );
-        const installedPackageDirectory = path.join(
-          options.cwd!,
-          'node_modules',
-          'mcp-searxng',
-        );
+        const installedPackageDirectory = path.join(options.cwd!, 'node_modules', 'mcp-searxng');
         // eslint-disable-next-line security/detect-non-literal-fs-filename -- directory belongs to the verifier-created temporary consumer
         mkdirSync(installedPackageDirectory, { recursive: true });
         // eslint-disable-next-line security/detect-non-literal-fs-filename -- directory belongs to the verifier-created temporary consumer
@@ -502,21 +404,7 @@ export async function runTests(): Promise<TestResult> {
       return {
         status: 0,
         signal: null,
-        stdout: [
-          JSON.stringify({ jsonrpc: '2.0', id: 1, result: { protocolVersion: '2024-11-05' } }),
-          JSON.stringify({
-            jsonrpc: '2.0',
-            id: 2,
-            result: {
-              tools: [
-                { name: 'searxng_web_search' },
-                { name: 'web_url_read' },
-                { name: 'searxng_search_suggestions' },
-                { name: 'searxng_instance_info' },
-              ],
-            },
-          }),
-        ].join('\n'),
+        stdout: validMcpSmokeOutput(),
         stderr: '',
       };
     };
@@ -593,11 +481,7 @@ export async function runTests(): Promise<TestResult> {
         };
       }
       if (args.includes('install')) {
-        const installedPackageDirectory = path.join(
-          _options.cwd!,
-          'node_modules',
-          'mcp-searxng',
-        );
+        const installedPackageDirectory = path.join(_options.cwd!, 'node_modules', 'mcp-searxng');
         // eslint-disable-next-line security/detect-non-literal-fs-filename -- directory belongs to the verifier-created temporary consumer
         mkdirSync(installedPackageDirectory, { recursive: true });
         // eslint-disable-next-line security/detect-non-literal-fs-filename -- directory belongs to the verifier-created temporary consumer
@@ -627,9 +511,15 @@ export async function runTests(): Promise<TestResult> {
     // eslint-disable-next-line security/detect-non-literal-fs-filename -- path was captured from the verifier-created temporary directory
     assert.equal(existsSync(temporaryRoot), false);
   }, results);
+}
 
-  printTestSummary(results, 'Packed Consumer Verification');
-  return results;
+export async function runTests(): Promise<TestResult> {
+  console.log('Testing: packed consumer release verification\n');
+  await runDependencyContractTests();
+  await runProcessContractTests();
+  await runWorkflowContractTests();
+  await runOrchestrationTests();
+  printTestSummary(results, 'Packed Consumer Verification'); return results;
 }
 
 if (

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -37,4 +37,15 @@ export default [
       'security/detect-object-injection': 'off',
     },
   },
+  // Release scripts handle registry output and temporary paths, so keep the
+  // security rules active and require narrow, justified suppressions.
+  {
+    files: ['scripts/**/*.mjs'],
+    plugins: {
+      'security': security,
+    },
+    rules: {
+      ...security.configs.recommended.rules,
+    },
+  },
 ];

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -40,7 +40,7 @@ export default [
   // Release scripts handle registry output and temporary paths, so keep the
   // security rules active and require narrow, justified suppressions.
   {
-    files: ['scripts/**/*.mjs'],
+    files: ['scripts/**/*.{js,mjs}'],
     plugins: {
       'security': security,
     },

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
             "version": "1.12.0",
             "license": "MIT",
             "dependencies": {
-                "@modelcontextprotocol/sdk": "1.29.0",
+                "@modelcontextprotocol/sdk": "1.30.0",
                 "@types/cors": "^2.8.19",
                 "@types/express": "^5.0.6",
                 "cors": "^2.8.6",
@@ -711,12 +711,12 @@
             }
         },
         "node_modules/@modelcontextprotocol/sdk": {
-            "version": "1.29.0",
-            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.29.0.tgz",
-            "integrity": "sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==",
+            "version": "1.30.0",
+            "resolved": "https://registry.npmjs.org/@modelcontextprotocol/sdk/-/sdk-1.30.0.tgz",
+            "integrity": "sha512-xKd8OIzlqNzcqcNumGAa6g+PW2kjD5vrpcKOnfldAUPP3j7lnqMPwlTXQm8gF+UwH72z0lqaRbjr9hqGz0eITA==",
             "license": "MIT",
             "dependencies": {
-                "@hono/node-server": "^1.19.9",
+                "@hono/node-server": "^1.19.9 || ^2.0.5",
                 "ajv": "^8.17.1",
                 "ajv-formats": "^3.0.1",
                 "content-type": "^1.0.5",

--- a/package.json
+++ b/package.json
@@ -40,15 +40,16 @@
         "test": "cross-env SEARXNG_URL=https://test-searx.example.com tsx __tests__/run-all.ts",
         "test:coverage": "cross-env SEARXNG_URL=https://test-searx.example.com c8 --reporter=text --include 'src/**' --check-coverage --lines 90 --branches 85 tsx __tests__/run-all.ts",
         "test:e2e": "node --env-file-if-exists=.env.e2e --import tsx __tests__/e2e/run-e2e.ts",
+        "verify:packed-consumer": "node scripts/verify-packed-consumer.mjs",
         "bootstrap": "npm install && npm run build",
         "inspector": "DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector node dist/cli.js",
-        "lint": "eslint src __tests__",
+        "lint": "eslint src __tests__ scripts",
         "audit:deps": "npm audit --audit-level=moderate",
         "security": "npm run lint && npm run audit:deps",
         "postversion": "TAG=$(node scripts/update-version.js | tail -1) && git add src/version.ts .mcp/server.json && git commit --amend --no-edit && git tag -f $TAG"
     },
     "dependencies": {
-        "@modelcontextprotocol/sdk": "1.29.0",
+        "@modelcontextprotocol/sdk": "1.30.0",
         "@types/cors": "^2.8.19",
         "@types/express": "^5.0.6",
         "cors": "^2.8.6",
@@ -74,7 +75,6 @@
         "typescript": "^5.8.3"
     },
     "overrides": {
-        "@hono/node-server": "2.0.11",
         "hono": ">=4.12.31"
     }
 }

--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
         "verify:packed-consumer": "node scripts/verify-packed-consumer.mjs",
         "bootstrap": "npm install && npm run build",
         "inspector": "DANGEROUSLY_OMIT_AUTH=true npx @modelcontextprotocol/inspector node dist/cli.js",
-        "lint": "eslint src __tests__ scripts",
+        "lint": "eslint src __tests__ scripts --max-warnings=0",
         "audit:deps": "npm audit --audit-level=moderate",
         "security": "npm run lint && npm run audit:deps",
         "postversion": "TAG=$(node scripts/update-version.js | tail -1) && git add src/version.ts .mcp/server.json && git commit --amend --no-edit && git tag -f $TAG"

--- a/scripts/packed-consumer-contracts.mjs
+++ b/scripts/packed-consumer-contracts.mjs
@@ -1,0 +1,330 @@
+const PATCHED_NODE_SERVER = Object.freeze([2, 0, 5]);
+const EXPECTED_TOOLS = Object.freeze([
+  'searxng_web_search',
+  'web_url_read',
+  'searxng_search_suggestions',
+  'searxng_instance_info',
+]);
+
+export function fail(category, message) {
+  throw new Error(`${category}: ${message}`);
+}
+
+function parseStableSemver(value) {
+  if (typeof value !== 'string') {
+    fail('unsafe_dependency_tree', 'adapter version is missing');
+  }
+  if (value.length > 64) {
+    fail('unsafe_dependency_tree', 'adapter version is invalid');
+  }
+  // eslint-disable-next-line security/detect-unsafe-regex -- input is capped at 64 characters above
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:\+[0-9A-Za-z.-]+)?$/.exec(value);
+  if (!match) {
+    fail('unsafe_dependency_tree', `adapter version is invalid: ${value}`);
+  }
+  return match.slice(1, 4).map(Number);
+}
+
+function isAtLeastPatched(version) {
+  const [major, minor, patch] = version;
+  const [patchedMajor, patchedMinor, patchedPatch] = PATCHED_NODE_SERVER;
+  if (major !== patchedMajor) return major > patchedMajor;
+  if (minor !== patchedMinor) return minor > patchedMinor;
+  return patch >= patchedPatch;
+}
+
+function requireDependencyNode(node, message) {
+  if (!node || typeof node !== 'object' || Array.isArray(node)) {
+    fail('unsafe_dependency_tree', message);
+  }
+  return node;
+}
+
+function assertNoNpmProblems(node) {
+  if (Array.isArray(node.problems) && node.problems.length > 0) {
+    fail('unsafe_dependency_tree', `npm problems: ${node.problems.join('; ')}`);
+  }
+}
+
+function recordAdapterVersion(dependency, versions) {
+  if (dependency.invalid) {
+    fail('unsafe_dependency_tree', 'adapter is marked invalid');
+  }
+  if (dependency.extraneous) {
+    fail('unsafe_dependency_tree', 'adapter is marked extraneous');
+  }
+  const parsed = parseStableSemver(dependency.version);
+  if (!isAtLeastPatched(parsed)) {
+    fail(
+      'unsafe_dependency_tree',
+      `adapter version ${dependency.version} is below 2.0.5`,
+    );
+  }
+  versions.push(dependency.version);
+}
+
+function visitDependencyNode(node, versions) {
+  const dependencyNode = requireDependencyNode(
+    node,
+    'dependency node is malformed',
+  );
+  assertNoNpmProblems(dependencyNode);
+  const { dependencies } = dependencyNode;
+  if (dependencies === undefined) return;
+  requireDependencyNode(dependencies, 'dependencies map is malformed');
+  for (const [name, dependencyValue] of Object.entries(dependencies)) {
+    const dependency = requireDependencyNode(
+      dependencyValue,
+      `dependency ${name} is malformed`,
+    );
+    if (name === '@hono/node-server') {
+      recordAdapterVersion(dependency, versions);
+    }
+    visitDependencyNode(dependency, versions);
+  }
+}
+
+export function assertSafeDependencyTree(tree) {
+  requireDependencyNode(tree, 'npm ls output is not an object');
+  const versions = [];
+  visitDependencyNode(tree, versions);
+  if (versions.length === 0) {
+    fail('unsafe_dependency_tree', 'patched adapter dependency is missing');
+  }
+  return versions.sort((left, right) => left.localeCompare(right, undefined, {
+    numeric: true,
+  }));
+}
+
+export function assertZeroProductionAudit(report) {
+  const vulnerabilities = report?.metadata?.vulnerabilities;
+  if (!vulnerabilities || typeof vulnerabilities !== 'object') {
+    fail('audit_gate', 'vulnerability metadata is missing');
+  }
+  if (
+    typeof vulnerabilities.total !== 'number'
+    || !Number.isFinite(vulnerabilities.total)
+  ) {
+    fail('audit_gate', 'vulnerability total must be numeric');
+  }
+  if (vulnerabilities.total !== 0) {
+    fail(
+      'audit_gate',
+      `production audit reported ${vulnerabilities.total} vulnerabilities`,
+    );
+  }
+  return vulnerabilities;
+}
+
+export function assertArtifactMetadata(packReport, installedPackage) {
+  if (!packReport || typeof packReport !== 'object') {
+    fail('artifact_metadata', 'npm pack report is missing');
+  }
+  if (!Array.isArray(packReport.files)) {
+    fail('artifact_metadata', 'npm pack file list is missing');
+  }
+  let hasShrinkwrap = false;
+  for (const file of packReport.files) {
+    if (!file || typeof file !== 'object' || Array.isArray(file)) {
+      fail('artifact_metadata', 'npm pack file entry is malformed');
+    }
+    const { path: filePath } = file;
+    if (
+      typeof filePath === 'string'
+      && filePath.toLowerCase() === 'npm-shrinkwrap.json'
+    ) {
+      hasShrinkwrap = true;
+    }
+  }
+  if (hasShrinkwrap) {
+    fail('artifact_metadata', 'npm shrinkwrap is forbidden');
+  }
+  if (!installedPackage || typeof installedPackage !== 'object') {
+    fail('artifact_metadata', 'installed package manifest is missing');
+  }
+  if (installedPackage.dependencies?.['@hono/node-server'] !== undefined) {
+    fail('artifact_metadata', 'direct @hono/node-server dependency is forbidden');
+  }
+  return true;
+}
+
+function collectJsonRpcResponses(stdout) {
+  const responses = new Map();
+  for (const line of String(stdout).split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const message = JSON.parse(line);
+      if (message && typeof message === 'object' && message.id !== undefined) {
+        responses.set(message.id, message);
+      }
+    } catch {
+      // Diagnostic lines are intentionally ignored; only JSON-RPC IDs matter.
+    }
+  }
+  return responses;
+}
+
+function requireSuccessfulResponse(responses, id, label) {
+  const response = responses.get(id);
+  if (!response) fail('mcp_smoke', `${label} response is missing`);
+  if (response.error) fail('mcp_smoke', `${label} returned an error`);
+  return response;
+}
+
+function assertInitializeResponse(responses) {
+  const initialize = requireSuccessfulResponse(responses, 1, 'initialize');
+  if (!initialize.result || typeof initialize.result !== 'object') {
+    fail('mcp_smoke', 'initialize result is malformed');
+  }
+}
+
+function requireExpectedTools(responses) {
+  const toolsList = requireSuccessfulResponse(responses, 2, 'tools/list');
+  if (!Array.isArray(toolsList.result?.tools)) {
+    fail('mcp_smoke', 'tools/list tools result is malformed');
+  }
+  const toolNames = new Set(
+    toolsList.result.tools.map((tool) => tool?.name).filter(Boolean),
+  );
+  const missingTools = EXPECTED_TOOLS.filter((name) => !toolNames.has(name));
+  if (missingTools.length > 0) {
+    fail('mcp_smoke', `expected tools are missing: ${missingTools.join(', ')}`);
+  }
+  return toolsList.result.tools;
+}
+
+export function assertMcpSmokeResponses(stdout) {
+  const responses = collectJsonRpcResponses(stdout);
+  assertInitializeResponse(responses);
+  return requireExpectedTools(responses).length;
+}
+
+function isStepStart(line) {
+  return typeof line === 'string' && line.startsWith('      - ');
+}
+
+function findStepBlock(lines, commandIndex) {
+  let start = commandIndex;
+  while (start >= 0 && !isStepStart(lines.at(start))) start -= 1;
+  if (start < 0) fail('workflow_contract', 'command is not inside a step');
+  let end = commandIndex + 1;
+  while (end < lines.length && !isStepStart(lines.at(end))) end += 1;
+  return lines.slice(start, end);
+}
+
+function isTopLevelJob(line) {
+  return (
+    typeof line === 'string'
+    && line.startsWith('  ')
+    && !line.startsWith('    ')
+    && line.trimEnd().endsWith(':')
+  );
+}
+
+function findPublishJob(lines) {
+  const jobStart = lines.findIndex(
+    (line) => line.trimEnd() === '  build-and-publish:',
+  );
+  if (jobStart < 0) {
+    fail('workflow_contract', 'build-and-publish job is missing');
+  }
+  const nextJobOffset = lines
+    .slice(jobStart + 1)
+    .findIndex(isTopLevelJob);
+  const jobEnd = nextJobOffset < 0
+    ? lines.length
+    : jobStart + 1 + nextJobOffset;
+  return lines.slice(jobStart, jobEnd);
+}
+
+function findRunCommand(jobLines, command) {
+  return jobLines.findIndex((line) => (
+    line.trimStart().startsWith('run:')
+    && line.includes(command)
+  ));
+}
+
+function requireOrderedCommands(jobLines) {
+  const indexes = [
+    findRunCommand(jobLines, 'npm run test:coverage'),
+    findRunCommand(jobLines, 'npm run build'),
+    findRunCommand(jobLines, 'npm run verify:packed-consumer'),
+    findRunCommand(jobLines, 'npm publish'),
+  ];
+  if (indexes.some((index) => index < 0)) {
+    fail(
+      'workflow_contract',
+      'tests, build, verifier, and publish must share one job',
+    );
+  }
+  const [testIndex, buildIndex, verifierIndex, publishIndex] = indexes;
+  if (!(testIndex < buildIndex
+    && buildIndex < verifierIndex
+    && verifierIndex < publishIndex)) {
+    fail(
+      'workflow_contract',
+      'tests and build must run before the verifier, which must precede publish',
+    );
+  }
+  return { verifierIndex, publishIndex };
+}
+
+function assertFailClosed(jobLines, verifierIndex, publishIndex) {
+  if (jobLines.some((line) => line.trim() === 'continue-on-error: true')) {
+    fail('workflow_contract', 'continue-on-error is forbidden');
+  }
+  const verifierStep = findStepBlock(jobLines, verifierIndex);
+  const publishStep = findStepBlock(jobLines, publishIndex);
+  const publishCondition = publishStep
+    .map((line) => line.trim())
+    .find((line) => line.startsWith('if:'));
+  if (publishCondition === 'if: always()' || publishCondition === 'if: failure()') {
+    fail('workflow_contract', 'publish cannot run after a failed verifier');
+  }
+  const verifierText = verifierStep.join('\n');
+  if (verifierText.includes('|| true') || verifierText.includes('set +e')) {
+    fail('workflow_contract', 'verifier exit suppression is forbidden');
+  }
+  return { verifierStep, publishStep };
+}
+
+function shellTokens(lines) {
+  return lines
+    .join(' ')
+    .trim()
+    .split(/\s+/)
+    .filter(Boolean);
+}
+
+function requireExactPublishedArtifact(verifierStep, publishStep) {
+  const verifierTokens = shellTokens(verifierStep);
+  const outputIndex = verifierTokens.indexOf('--output');
+  const artifact = verifierTokens.at(outputIndex + 1);
+  if (outputIndex < 0 || !artifact) {
+    fail('workflow_contract', 'verifier output artifact is missing');
+  }
+  const publishTokens = shellTokens(publishStep);
+  const npmIndex = publishTokens.findIndex((token, index) => (
+    token === 'npm' && publishTokens.at(index + 1) === 'publish'
+  ));
+  const isExactArtifact = (
+    npmIndex >= 0
+    && publishTokens.at(npmIndex + 1) === 'publish'
+    && publishTokens.at(npmIndex + 2) === artifact
+  );
+  if (!isExactArtifact) {
+    fail('workflow_contract', 'publish must use the exact verified artifact');
+  }
+}
+
+export function assertPublishWorkflowContract(yamlText) {
+  const jobLines = findPublishJob(String(yamlText).split(/\r?\n/));
+  const { verifierIndex, publishIndex } = requireOrderedCommands(jobLines);
+  const { verifierStep, publishStep } = assertFailClosed(
+    jobLines,
+    verifierIndex,
+    publishIndex,
+  );
+  requireExactPublishedArtifact(verifierStep, publishStep);
+  return true;
+}

--- a/scripts/packed-consumer-contracts.mjs
+++ b/scripts/packed-consumer-contracts.mjs
@@ -279,7 +279,7 @@ function requireOrderedCommands(jobLines) {
 
 function assertFailClosed(jobLines, verifierIndex, publishIndex) {
   const normalizedJobLines = jobLines.map(normalizeGuardLine);
-  if (normalizedJobLines.includes('continue-on-error: true')) {
+  if (normalizedJobLines.some((line) => line.startsWith('continue-on-error:'))) {
     fail('workflow_contract', 'continue-on-error is forbidden');
   }
   const verifierStep = findStepBlock(jobLines, verifierIndex);
@@ -287,11 +287,12 @@ function assertFailClosed(jobLines, verifierIndex, publishIndex) {
   const publishCondition = publishStep
     .map(normalizeGuardLine)
     .find((line) => line.startsWith('if:'));
-  if (publishCondition === 'if: always()' || publishCondition === 'if: failure()') {
-    fail('workflow_contract', 'publish cannot run after a failed verifier');
+  if (publishCondition) {
+    fail('workflow_contract', 'publish conditions are forbidden');
   }
   const verifierText = verifierStep.join('\n');
-  if (verifierText.includes('|| true') || verifierText.includes('set +e')) {
+  const compactVerifierText = verifierText.replaceAll(/\s/g, '');
+  if (compactVerifierText.includes('||true') || compactVerifierText.includes('set+e')) {
     fail('workflow_contract', 'verifier exit suppression is forbidden');
   }
   return { verifierStep, publishStep };

--- a/scripts/packed-consumer-contracts.mjs
+++ b/scripts/packed-consumer-contracts.mjs
@@ -116,15 +116,18 @@ export function assertZeroProductionAudit(report) {
   return vulnerabilities;
 }
 
-export function assertArtifactMetadata(packReport, installedPackage) {
+function requirePackFiles(packReport) {
   if (!packReport || typeof packReport !== 'object') {
     fail('artifact_metadata', 'npm pack report is missing');
   }
   if (!Array.isArray(packReport.files)) {
     fail('artifact_metadata', 'npm pack file list is missing');
   }
-  let hasShrinkwrap = false;
-  for (const file of packReport.files) {
+  return packReport.files;
+}
+
+function assertPackFilesSafe(files) {
+  for (const file of files) {
     if (!file || typeof file !== 'object' || Array.isArray(file)) {
       fail('artifact_metadata', 'npm pack file entry is malformed');
     }
@@ -133,18 +136,23 @@ export function assertArtifactMetadata(packReport, installedPackage) {
       typeof filePath === 'string'
       && filePath.toLowerCase() === 'npm-shrinkwrap.json'
     ) {
-      hasShrinkwrap = true;
+      fail('artifact_metadata', 'npm shrinkwrap is forbidden');
     }
   }
-  if (hasShrinkwrap) {
-    fail('artifact_metadata', 'npm shrinkwrap is forbidden');
-  }
+}
+
+function assertInstalledPackageSafe(installedPackage) {
   if (!installedPackage || typeof installedPackage !== 'object') {
     fail('artifact_metadata', 'installed package manifest is missing');
   }
   if (installedPackage.dependencies?.['@hono/node-server'] !== undefined) {
     fail('artifact_metadata', 'direct @hono/node-server dependency is forbidden');
   }
+}
+
+export function assertArtifactMetadata(packReport, installedPackage) {
+  assertPackFilesSafe(requirePackFiles(packReport));
+  assertInstalledPackageSafe(installedPackage);
   return true;
 }
 
@@ -270,13 +278,14 @@ function requireOrderedCommands(jobLines) {
 }
 
 function assertFailClosed(jobLines, verifierIndex, publishIndex) {
-  if (jobLines.some((line) => line.trim() === 'continue-on-error: true')) {
+  const normalizedJobLines = jobLines.map(normalizeGuardLine);
+  if (normalizedJobLines.includes('continue-on-error: true')) {
     fail('workflow_contract', 'continue-on-error is forbidden');
   }
   const verifierStep = findStepBlock(jobLines, verifierIndex);
   const publishStep = findStepBlock(jobLines, publishIndex);
   const publishCondition = publishStep
-    .map((line) => line.trim())
+    .map(normalizeGuardLine)
     .find((line) => line.startsWith('if:'));
   if (publishCondition === 'if: always()' || publishCondition === 'if: failure()') {
     fail('workflow_contract', 'publish cannot run after a failed verifier');
@@ -286,6 +295,11 @@ function assertFailClosed(jobLines, verifierIndex, publishIndex) {
     fail('workflow_contract', 'verifier exit suppression is forbidden');
   }
   return { verifierStep, publishStep };
+}
+
+function normalizeGuardLine(line) {
+  const commentIndex = line.indexOf('#');
+  return (commentIndex < 0 ? line : line.slice(0, commentIndex)).trim();
 }
 
 function shellTokens(lines) {

--- a/scripts/verify-packed-consumer.mjs
+++ b/scripts/verify-packed-consumer.mjs
@@ -13,124 +13,22 @@ import {
 import { tmpdir } from 'node:os';
 import path from 'node:path';
 import { pathToFileURL } from 'node:url';
+import {
+  assertArtifactMetadata,
+  assertMcpSmokeResponses,
+  assertPublishWorkflowContract,
+  assertSafeDependencyTree,
+  assertZeroProductionAudit,
+  fail,
+} from './packed-consumer-contracts.mjs';
 
-const PATCHED_NODE_SERVER = Object.freeze([2, 0, 5]);
-const EXPECTED_TOOLS = Object.freeze([
-  'searxng_web_search',
-  'web_url_read',
-  'searxng_search_suggestions',
-  'searxng_instance_info',
-]);
-
-function fail(category, message) {
-  throw new Error(`${category}: ${message}`);
-}
-
-function parseStableSemver(value) {
-  if (typeof value !== 'string') {
-    fail('unsafe_dependency_tree', 'adapter version is missing');
-  }
-  const match = /^(\d+)\.(\d+)\.(\d+)(?:\+[0-9A-Za-z.-]+)?$/.exec(value);
-  if (!match) {
-    fail('unsafe_dependency_tree', `adapter version is invalid: ${value}`);
-  }
-  return match.slice(1, 4).map(Number);
-}
-
-function isAtLeastPatched(version) {
-  for (let index = 0; index < PATCHED_NODE_SERVER.length; index += 1) {
-    if (version[index] > PATCHED_NODE_SERVER[index]) return true;
-    if (version[index] < PATCHED_NODE_SERVER[index]) return false;
-  }
-  return true;
-}
-
-export function assertSafeDependencyTree(tree) {
-  if (!tree || typeof tree !== 'object' || Array.isArray(tree)) {
-    fail('unsafe_dependency_tree', 'npm ls output is not an object');
-  }
-
-  const versions = [];
-  const visit = (node) => {
-    if (!node || typeof node !== 'object' || Array.isArray(node)) {
-      fail('unsafe_dependency_tree', 'dependency node is malformed');
-    }
-    if (Array.isArray(node.problems) && node.problems.length > 0) {
-      fail('unsafe_dependency_tree', `npm problems: ${node.problems.join('; ')}`);
-    }
-    const dependencies = node.dependencies;
-    if (dependencies === undefined) return;
-    if (!dependencies || typeof dependencies !== 'object' || Array.isArray(dependencies)) {
-      fail('unsafe_dependency_tree', 'dependencies map is malformed');
-    }
-    for (const [name, dependency] of Object.entries(dependencies)) {
-      if (!dependency || typeof dependency !== 'object' || Array.isArray(dependency)) {
-        fail('unsafe_dependency_tree', `dependency ${name} is malformed`);
-      }
-      if (name === '@hono/node-server') {
-        if (dependency.invalid) {
-          fail('unsafe_dependency_tree', 'adapter is marked invalid');
-        }
-        if (dependency.extraneous) {
-          fail('unsafe_dependency_tree', 'adapter is marked extraneous');
-        }
-        const parsed = parseStableSemver(dependency.version);
-        if (!isAtLeastPatched(parsed)) {
-          fail(
-            'unsafe_dependency_tree',
-            `adapter version ${dependency.version} is below 2.0.5`,
-          );
-        }
-        versions.push(dependency.version);
-      }
-      visit(dependency);
-    }
-  };
-
-  visit(tree);
-  if (versions.length === 0) {
-    fail('unsafe_dependency_tree', 'patched adapter dependency is missing');
-  }
-  return versions.sort((left, right) => left.localeCompare(right, undefined, {
-    numeric: true,
-  }));
-}
-
-export function assertZeroProductionAudit(report) {
-  const vulnerabilities = report?.metadata?.vulnerabilities;
-  if (!vulnerabilities || typeof vulnerabilities !== 'object') {
-    fail('audit_gate', 'vulnerability metadata is missing');
-  }
-  if (typeof vulnerabilities.total !== 'number' || !Number.isFinite(vulnerabilities.total)) {
-    fail('audit_gate', 'vulnerability total must be numeric');
-  }
-  if (vulnerabilities.total !== 0) {
-    fail('audit_gate', `production audit reported ${vulnerabilities.total} vulnerabilities`);
-  }
-  return vulnerabilities;
-}
-
-export function assertArtifactMetadata(packReport, installedPackage) {
-  if (!packReport || typeof packReport !== 'object') {
-    fail('artifact_metadata', 'npm pack report is missing');
-  }
-  if (!Array.isArray(packReport.files)) {
-    fail('artifact_metadata', 'npm pack file list is missing');
-  }
-  if (packReport.files.some(({ path: filePath }) => (
-    typeof filePath === 'string'
-    && filePath.toLowerCase() === 'npm-shrinkwrap.json'
-  ))) {
-    fail('artifact_metadata', 'npm shrinkwrap is forbidden');
-  }
-  if (!installedPackage || typeof installedPackage !== 'object') {
-    fail('artifact_metadata', 'installed package manifest is missing');
-  }
-  if (installedPackage.dependencies?.['@hono/node-server'] !== undefined) {
-    fail('artifact_metadata', 'direct @hono/node-server dependency is forbidden');
-  }
-  return true;
-}
+export {
+  assertArtifactMetadata,
+  assertMcpSmokeResponses,
+  assertPublishWorkflowContract,
+  assertSafeDependencyTree,
+  assertZeroProductionAudit,
+} from './packed-consumer-contracts.mjs';
 
 export function runCheckedCommand(command, args, {
   cwd,
@@ -157,7 +55,9 @@ export function runCheckedCommand(command, args, {
     fail('infrastructure', `${command} terminated by ${result.signal}`);
   }
   if (result.status !== 0) {
-    fail('infrastructure', `${command} exited with status ${result.status}`);
+    const operation = args.at(0);
+    const commandLabel = operation ? `${command} ${operation}` : command;
+    fail('infrastructure', `${commandLabel} exited with status ${result.status}`);
   }
   return result.stdout ?? '';
 }
@@ -194,152 +94,25 @@ function runJsonCommand(command, args, {
   return { json, status: result.status };
 }
 
-export function assertMcpSmokeResponses(stdout) {
-  const responses = new Map();
-  for (const line of String(stdout).split(/\r?\n/)) {
-    if (!line.trim()) continue;
-    try {
-      const message = JSON.parse(line);
-      if (message && typeof message === 'object' && message.id !== undefined) {
-        responses.set(message.id, message);
-      }
-    } catch {
-      // Diagnostic lines are intentionally ignored; only JSON-RPC IDs are relevant.
-    }
-  }
-  const initialize = responses.get(1);
-  if (!initialize) fail('mcp_smoke', 'initialize response is missing');
-  if (initialize.error) fail('mcp_smoke', 'initialize returned an error');
-  if (!initialize.result || typeof initialize.result !== 'object') {
-    fail('mcp_smoke', 'initialize result is malformed');
-  }
-  const toolsList = responses.get(2);
-  if (!toolsList) fail('mcp_smoke', 'tools/list response is missing');
-  if (toolsList.error) fail('mcp_smoke', 'tools/list returned an error');
-  if (!Array.isArray(toolsList.result?.tools)) {
-    fail('mcp_smoke', 'tools/list tools result is malformed');
-  }
-  const toolNames = new Set(
-    toolsList.result.tools.map((tool) => tool?.name).filter(Boolean),
-  );
-  const missingTools = EXPECTED_TOOLS.filter((name) => !toolNames.has(name));
-  if (missingTools.length > 0) {
-    fail('mcp_smoke', `expected tools are missing: ${missingTools.join(', ')}`);
-  }
-  return toolsList.result.tools.length;
-}
-
-function findStepBlock(lines, commandIndex) {
-  let start = commandIndex;
-  while (start >= 0 && !/^\s{6}-\s/.test(lines[start])) start -= 1;
-  if (start < 0) fail('workflow_contract', 'command is not inside a step');
-  let end = commandIndex + 1;
-  while (end < lines.length && !/^\s{6}-\s/.test(lines[end])) end += 1;
-  return lines.slice(start, end);
-}
-
-export function assertPublishWorkflowContract(yamlText) {
-  const lines = String(yamlText).split(/\r?\n/);
-  const jobStart = lines.findIndex((line) => /^  build-and-publish:\s*$/.test(line));
-  if (jobStart < 0) fail('workflow_contract', 'build-and-publish job is missing');
-  let jobEnd = lines.length;
-  for (let index = jobStart + 1; index < lines.length; index += 1) {
-    if (/^  [A-Za-z0-9_-]+:\s*$/.test(lines[index])) {
-      jobEnd = index;
-      break;
-    }
-  }
-  const jobLines = lines.slice(jobStart, jobEnd);
-  if (jobLines.some((line) => /^\s{4}continue-on-error:\s*true\s*$/.test(line))) {
-    fail('workflow_contract', 'job-level continue-on-error is forbidden');
-  }
-
-  const testIndex = jobLines.findIndex(
-    (line) => /^\s+run:\s*.*\bnpm run test:coverage\b/.test(line),
-  );
-  const buildIndex = jobLines.findIndex(
-    (line) => /^\s+run:\s*.*\bnpm run build\b/.test(line),
-  );
-  const verifierIndex = jobLines.findIndex(
-    (line) => /^\s+run:\s*.*\bnpm run verify:packed-consumer\b/.test(line),
-  );
-  const publishIndex = jobLines.findIndex(
-    (line) => /^\s+run:\s*.*\bnpm publish\b/.test(line),
-  );
-  if (testIndex < 0 || buildIndex < 0 || verifierIndex < 0 || publishIndex < 0) {
-    fail('workflow_contract', 'tests, build, verifier, and publish must share one job');
-  }
-  if (!(
-    testIndex < buildIndex
-    && buildIndex < verifierIndex
-    && verifierIndex < publishIndex
-  )) {
-    fail(
-      'workflow_contract',
-      'tests and build must run before the verifier, which must precede publish',
-    );
-  }
-
-  const verifierStep = findStepBlock(jobLines, verifierIndex);
-  const publishStep = findStepBlock(jobLines, publishIndex);
-  for (const step of [verifierStep, publishStep]) {
-    if (step.some((line) => /^\s+continue-on-error:\s*true\s*$/.test(line))) {
-      fail('workflow_contract', 'step-level continue-on-error is forbidden');
-    }
-  }
-  if (publishStep.some((line) => /^\s+if:\s*(?:always|failure)\s*\(\s*\)/.test(line))) {
-    fail('workflow_contract', 'publish cannot run after a failed verifier');
-  }
-  if (verifierStep.some((line) => /\|\|\s*true|set\s+\+e/.test(line))) {
-    fail('workflow_contract', 'verifier exit suppression is forbidden');
-  }
-  const verifierText = verifierStep.join('\n');
-  const publishText = publishStep.join('\n');
-  const outputMatch = /--output\s+("[^"]+"|'[^']+'|\S+)/.exec(verifierText);
-  if (!outputMatch) {
-    fail('workflow_contract', 'verifier output artifact is missing');
-  }
-  const escapedArtifact = outputMatch[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
-  if (!new RegExp(`npm publish\\s+${escapedArtifact}(?:\\s|$)`).test(publishText)) {
-    fail('workflow_contract', 'publish must use the exact verified artifact');
-  }
-  return true;
-}
-
 function allowlistedProcessEnvironment() {
-  const allowedNames = [
-    'PATH',
-    'Path',
-    'SystemRoot',
-    'ComSpec',
-    'PATHEXT',
-    'TEMP',
-    'TMP',
-    'TMPDIR',
-    'HOME',
-    'USERPROFILE',
-    'CI',
-    'HTTP_PROXY',
-    'HTTPS_PROXY',
-    'NO_PROXY',
-    'http_proxy',
-    'https_proxy',
-    'no_proxy',
-    'NODE_EXTRA_CA_CERTS',
-    'SSL_CERT_FILE',
-    'SSL_CERT_DIR',
-  ];
-  return Object.fromEntries(
-    allowedNames
-      .filter((name) => process.env[name] !== undefined)
-      .map((name) => [name, process.env[name]]),
-  );
+  const {
+    PATH, Path, SystemRoot, ComSpec, PATHEXT, TEMP, TMP, TMPDIR, HOME,
+    USERPROFILE, CI, HTTP_PROXY, HTTPS_PROXY, NO_PROXY, http_proxy,
+    https_proxy, no_proxy, NODE_EXTRA_CA_CERTS, SSL_CERT_FILE, SSL_CERT_DIR,
+  } = process.env;
+  return Object.fromEntries(Object.entries({
+    PATH, Path, SystemRoot, ComSpec, PATHEXT, TEMP, TMP, TMPDIR, HOME,
+    USERPROFILE, CI, HTTP_PROXY, HTTPS_PROXY, NO_PROXY, http_proxy,
+    https_proxy, no_proxy, NODE_EXTRA_CA_CERTS, SSL_CERT_FILE, SSL_CERT_DIR,
+  }).filter(([, value]) => value !== undefined));
 }
 
 function isolatedNpmEnvironment(root) {
   const userConfig = path.join(root, 'user.npmrc');
   const globalConfig = path.join(root, 'global.npmrc');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- root is created by mkdtempSync for this verifier
   writeFileSync(userConfig, '', 'utf8');
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- root is created by mkdtempSync for this verifier
   writeFileSync(globalConfig, '', 'utf8');
   return {
     ...allowlistedProcessEnvironment(),
@@ -387,18 +160,13 @@ function npmInvocation(args) {
     'bin',
     'npm-cli.js',
   );
-  const npmCli = (
-    process.env.npm_execpath
-    && existsSync(process.env.npm_execpath)
-  )
-    ? process.env.npm_execpath
-    : bundledNpm;
-  if (!existsSync(npmCli)) {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is derived from the trusted Node executable location
+  if (!existsSync(bundledNpm)) {
     fail('infrastructure', 'npm CLI entrypoint is unavailable');
   }
   return {
     command: process.execPath,
-    args: [npmCli, ...args],
+    args: [bundledNpm, ...args],
   };
 }
 
@@ -411,7 +179,9 @@ export function verifyPackedConsumer({
   const artifactDirectory = path.join(temporaryRoot, 'artifact');
   const consumerDirectory = path.join(temporaryRoot, 'consumer');
   try {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is under the verifier-created temporary root
     mkdirSync(artifactDirectory);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is under the verifier-created temporary root
     mkdirSync(consumerDirectory);
     const npmEnvironment = isolatedNpmEnvironment(temporaryRoot);
     const packInvocation = npmInvocation([
@@ -445,10 +215,12 @@ export function verifyPackedConsumer({
       fail('infrastructure', 'npm pack did not report exactly one artifact');
     }
     const artifactPath = path.join(artifactDirectory, packedArtifacts[0].filename);
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- npm pack reports a file in the verifier-owned artifact directory
     if (!existsSync(artifactPath)) {
       fail('infrastructure', 'npm pack reported an artifact that does not exist');
     }
 
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is under the verifier-created temporary consumer
     writeFileSync(
       path.join(consumerDirectory, 'package.json'),
       `${JSON.stringify({
@@ -489,6 +261,7 @@ export function verifyPackedConsumer({
     );
     let installedPackage;
     try {
+      // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is fixed beneath the verifier-created consumer
       installedPackage = JSON.parse(readFileSync(installedManifestPath, 'utf8'));
     } catch {
       fail('artifact_metadata', 'installed package manifest is unreadable');
@@ -540,6 +313,7 @@ export function verifyPackedConsumer({
       'dist',
       'cli.js',
     );
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is fixed beneath the verifier-created consumer
     if (!existsSync(cliPath) && spawn === spawnSync) {
       fail('infrastructure', 'packed CLI is missing after installation');
     }
@@ -580,8 +354,8 @@ if (
     const args = process.argv.slice(2);
     let artifactOutput;
     for (let index = 0; index < args.length; index += 2) {
-      const option = args[index];
-      const value = args[index + 1];
+      const option = args.at(index);
+      const value = args.at(index + 1);
       if (!value) {
         fail(
           'infrastructure',

--- a/scripts/verify-packed-consumer.mjs
+++ b/scripts/verify-packed-consumer.mjs
@@ -1,0 +1,608 @@
+#!/usr/bin/env node
+
+import { spawnSync } from 'node:child_process';
+import {
+  copyFileSync,
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import path from 'node:path';
+import { pathToFileURL } from 'node:url';
+
+const PATCHED_NODE_SERVER = Object.freeze([2, 0, 5]);
+const EXPECTED_TOOLS = Object.freeze([
+  'searxng_web_search',
+  'web_url_read',
+  'searxng_search_suggestions',
+  'searxng_instance_info',
+]);
+
+function fail(category, message) {
+  throw new Error(`${category}: ${message}`);
+}
+
+function parseStableSemver(value) {
+  if (typeof value !== 'string') {
+    fail('unsafe_dependency_tree', 'adapter version is missing');
+  }
+  const match = /^(\d+)\.(\d+)\.(\d+)(?:\+[0-9A-Za-z.-]+)?$/.exec(value);
+  if (!match) {
+    fail('unsafe_dependency_tree', `adapter version is invalid: ${value}`);
+  }
+  return match.slice(1, 4).map(Number);
+}
+
+function isAtLeastPatched(version) {
+  for (let index = 0; index < PATCHED_NODE_SERVER.length; index += 1) {
+    if (version[index] > PATCHED_NODE_SERVER[index]) return true;
+    if (version[index] < PATCHED_NODE_SERVER[index]) return false;
+  }
+  return true;
+}
+
+export function assertSafeDependencyTree(tree) {
+  if (!tree || typeof tree !== 'object' || Array.isArray(tree)) {
+    fail('unsafe_dependency_tree', 'npm ls output is not an object');
+  }
+
+  const versions = [];
+  const visit = (node) => {
+    if (!node || typeof node !== 'object' || Array.isArray(node)) {
+      fail('unsafe_dependency_tree', 'dependency node is malformed');
+    }
+    if (Array.isArray(node.problems) && node.problems.length > 0) {
+      fail('unsafe_dependency_tree', `npm problems: ${node.problems.join('; ')}`);
+    }
+    const dependencies = node.dependencies;
+    if (dependencies === undefined) return;
+    if (!dependencies || typeof dependencies !== 'object' || Array.isArray(dependencies)) {
+      fail('unsafe_dependency_tree', 'dependencies map is malformed');
+    }
+    for (const [name, dependency] of Object.entries(dependencies)) {
+      if (!dependency || typeof dependency !== 'object' || Array.isArray(dependency)) {
+        fail('unsafe_dependency_tree', `dependency ${name} is malformed`);
+      }
+      if (name === '@hono/node-server') {
+        if (dependency.invalid) {
+          fail('unsafe_dependency_tree', 'adapter is marked invalid');
+        }
+        if (dependency.extraneous) {
+          fail('unsafe_dependency_tree', 'adapter is marked extraneous');
+        }
+        const parsed = parseStableSemver(dependency.version);
+        if (!isAtLeastPatched(parsed)) {
+          fail(
+            'unsafe_dependency_tree',
+            `adapter version ${dependency.version} is below 2.0.5`,
+          );
+        }
+        versions.push(dependency.version);
+      }
+      visit(dependency);
+    }
+  };
+
+  visit(tree);
+  if (versions.length === 0) {
+    fail('unsafe_dependency_tree', 'patched adapter dependency is missing');
+  }
+  return versions.sort((left, right) => left.localeCompare(right, undefined, {
+    numeric: true,
+  }));
+}
+
+export function assertZeroProductionAudit(report) {
+  const vulnerabilities = report?.metadata?.vulnerabilities;
+  if (!vulnerabilities || typeof vulnerabilities !== 'object') {
+    fail('audit_gate', 'vulnerability metadata is missing');
+  }
+  if (typeof vulnerabilities.total !== 'number' || !Number.isFinite(vulnerabilities.total)) {
+    fail('audit_gate', 'vulnerability total must be numeric');
+  }
+  if (vulnerabilities.total !== 0) {
+    fail('audit_gate', `production audit reported ${vulnerabilities.total} vulnerabilities`);
+  }
+  return vulnerabilities;
+}
+
+export function assertArtifactMetadata(packReport, installedPackage) {
+  if (!packReport || typeof packReport !== 'object') {
+    fail('artifact_metadata', 'npm pack report is missing');
+  }
+  if (!Array.isArray(packReport.files)) {
+    fail('artifact_metadata', 'npm pack file list is missing');
+  }
+  if (packReport.files.some(({ path: filePath }) => (
+    typeof filePath === 'string'
+    && filePath.toLowerCase() === 'npm-shrinkwrap.json'
+  ))) {
+    fail('artifact_metadata', 'npm shrinkwrap is forbidden');
+  }
+  if (!installedPackage || typeof installedPackage !== 'object') {
+    fail('artifact_metadata', 'installed package manifest is missing');
+  }
+  if (installedPackage.dependencies?.['@hono/node-server'] !== undefined) {
+    fail('artifact_metadata', 'direct @hono/node-server dependency is forbidden');
+  }
+  return true;
+}
+
+export function runCheckedCommand(command, args, {
+  cwd,
+  env,
+  timeoutMs,
+  input,
+  spawn = spawnSync,
+} = {}) {
+  const result = spawn(command, args, {
+    cwd,
+    env,
+    timeout: timeoutMs,
+    input,
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (result.error?.code === 'ETIMEDOUT') {
+    fail('infrastructure', `${command} timeout after ${timeoutMs}ms`);
+  }
+  if (result.error) {
+    fail('infrastructure', `${command} spawn failed: ${result.error.message}`);
+  }
+  if (result.signal) {
+    fail('infrastructure', `${command} terminated by ${result.signal}`);
+  }
+  if (result.status !== 0) {
+    fail('infrastructure', `${command} exited with status ${result.status}`);
+  }
+  return result.stdout ?? '';
+}
+
+function runJsonCommand(command, args, {
+  cwd,
+  env,
+  timeoutMs,
+  spawn,
+  label,
+}) {
+  const result = spawn(command, args, {
+    cwd,
+    env,
+    timeout: timeoutMs,
+    encoding: 'utf8',
+    windowsHide: true,
+  });
+  if (result.error?.code === 'ETIMEDOUT') {
+    fail('infrastructure', `${label} timeout after ${timeoutMs}ms`);
+  }
+  if (result.error) {
+    fail('infrastructure', `${label} spawn failed: ${result.error.message}`);
+  }
+  if (result.signal) {
+    fail('infrastructure', `${label} terminated by ${result.signal}`);
+  }
+  let json;
+  try {
+    json = JSON.parse(result.stdout ?? '');
+  } catch {
+    fail('infrastructure', `${label} returned invalid JSON`);
+  }
+  return { json, status: result.status };
+}
+
+export function assertMcpSmokeResponses(stdout) {
+  const responses = new Map();
+  for (const line of String(stdout).split(/\r?\n/)) {
+    if (!line.trim()) continue;
+    try {
+      const message = JSON.parse(line);
+      if (message && typeof message === 'object' && message.id !== undefined) {
+        responses.set(message.id, message);
+      }
+    } catch {
+      // Diagnostic lines are intentionally ignored; only JSON-RPC IDs are relevant.
+    }
+  }
+  const initialize = responses.get(1);
+  if (!initialize) fail('mcp_smoke', 'initialize response is missing');
+  if (initialize.error) fail('mcp_smoke', 'initialize returned an error');
+  if (!initialize.result || typeof initialize.result !== 'object') {
+    fail('mcp_smoke', 'initialize result is malformed');
+  }
+  const toolsList = responses.get(2);
+  if (!toolsList) fail('mcp_smoke', 'tools/list response is missing');
+  if (toolsList.error) fail('mcp_smoke', 'tools/list returned an error');
+  if (!Array.isArray(toolsList.result?.tools)) {
+    fail('mcp_smoke', 'tools/list tools result is malformed');
+  }
+  const toolNames = new Set(
+    toolsList.result.tools.map((tool) => tool?.name).filter(Boolean),
+  );
+  const missingTools = EXPECTED_TOOLS.filter((name) => !toolNames.has(name));
+  if (missingTools.length > 0) {
+    fail('mcp_smoke', `expected tools are missing: ${missingTools.join(', ')}`);
+  }
+  return toolsList.result.tools.length;
+}
+
+function findStepBlock(lines, commandIndex) {
+  let start = commandIndex;
+  while (start >= 0 && !/^\s{6}-\s/.test(lines[start])) start -= 1;
+  if (start < 0) fail('workflow_contract', 'command is not inside a step');
+  let end = commandIndex + 1;
+  while (end < lines.length && !/^\s{6}-\s/.test(lines[end])) end += 1;
+  return lines.slice(start, end);
+}
+
+export function assertPublishWorkflowContract(yamlText) {
+  const lines = String(yamlText).split(/\r?\n/);
+  const jobStart = lines.findIndex((line) => /^  build-and-publish:\s*$/.test(line));
+  if (jobStart < 0) fail('workflow_contract', 'build-and-publish job is missing');
+  let jobEnd = lines.length;
+  for (let index = jobStart + 1; index < lines.length; index += 1) {
+    if (/^  [A-Za-z0-9_-]+:\s*$/.test(lines[index])) {
+      jobEnd = index;
+      break;
+    }
+  }
+  const jobLines = lines.slice(jobStart, jobEnd);
+  if (jobLines.some((line) => /^\s{4}continue-on-error:\s*true\s*$/.test(line))) {
+    fail('workflow_contract', 'job-level continue-on-error is forbidden');
+  }
+
+  const testIndex = jobLines.findIndex(
+    (line) => /^\s+run:\s*.*\bnpm run test:coverage\b/.test(line),
+  );
+  const buildIndex = jobLines.findIndex(
+    (line) => /^\s+run:\s*.*\bnpm run build\b/.test(line),
+  );
+  const verifierIndex = jobLines.findIndex(
+    (line) => /^\s+run:\s*.*\bnpm run verify:packed-consumer\b/.test(line),
+  );
+  const publishIndex = jobLines.findIndex(
+    (line) => /^\s+run:\s*.*\bnpm publish\b/.test(line),
+  );
+  if (testIndex < 0 || buildIndex < 0 || verifierIndex < 0 || publishIndex < 0) {
+    fail('workflow_contract', 'tests, build, verifier, and publish must share one job');
+  }
+  if (!(
+    testIndex < buildIndex
+    && buildIndex < verifierIndex
+    && verifierIndex < publishIndex
+  )) {
+    fail(
+      'workflow_contract',
+      'tests and build must run before the verifier, which must precede publish',
+    );
+  }
+
+  const verifierStep = findStepBlock(jobLines, verifierIndex);
+  const publishStep = findStepBlock(jobLines, publishIndex);
+  for (const step of [verifierStep, publishStep]) {
+    if (step.some((line) => /^\s+continue-on-error:\s*true\s*$/.test(line))) {
+      fail('workflow_contract', 'step-level continue-on-error is forbidden');
+    }
+  }
+  if (publishStep.some((line) => /^\s+if:\s*(?:always|failure)\s*\(\s*\)/.test(line))) {
+    fail('workflow_contract', 'publish cannot run after a failed verifier');
+  }
+  if (verifierStep.some((line) => /\|\|\s*true|set\s+\+e/.test(line))) {
+    fail('workflow_contract', 'verifier exit suppression is forbidden');
+  }
+  const verifierText = verifierStep.join('\n');
+  const publishText = publishStep.join('\n');
+  const outputMatch = /--output\s+("[^"]+"|'[^']+'|\S+)/.exec(verifierText);
+  if (!outputMatch) {
+    fail('workflow_contract', 'verifier output artifact is missing');
+  }
+  const escapedArtifact = outputMatch[1].replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+  if (!new RegExp(`npm publish\\s+${escapedArtifact}(?:\\s|$)`).test(publishText)) {
+    fail('workflow_contract', 'publish must use the exact verified artifact');
+  }
+  return true;
+}
+
+function allowlistedProcessEnvironment() {
+  const allowedNames = [
+    'PATH',
+    'Path',
+    'SystemRoot',
+    'ComSpec',
+    'PATHEXT',
+    'TEMP',
+    'TMP',
+    'TMPDIR',
+    'HOME',
+    'USERPROFILE',
+    'CI',
+    'HTTP_PROXY',
+    'HTTPS_PROXY',
+    'NO_PROXY',
+    'http_proxy',
+    'https_proxy',
+    'no_proxy',
+    'NODE_EXTRA_CA_CERTS',
+    'SSL_CERT_FILE',
+    'SSL_CERT_DIR',
+  ];
+  return Object.fromEntries(
+    allowedNames
+      .filter((name) => process.env[name] !== undefined)
+      .map((name) => [name, process.env[name]]),
+  );
+}
+
+function isolatedNpmEnvironment(root) {
+  const userConfig = path.join(root, 'user.npmrc');
+  const globalConfig = path.join(root, 'global.npmrc');
+  writeFileSync(userConfig, '', 'utf8');
+  writeFileSync(globalConfig, '', 'utf8');
+  return {
+    ...allowlistedProcessEnvironment(),
+    NPM_CONFIG_CACHE: path.join(root, 'cache'),
+    NPM_CONFIG_USERCONFIG: userConfig,
+    NPM_CONFIG_GLOBALCONFIG: globalConfig,
+    NPM_CONFIG_REGISTRY: 'https://registry.npmjs.org/',
+  };
+}
+
+function mcpSmokeInput() {
+  return [
+    {
+      jsonrpc: '2.0',
+      id: 1,
+      method: 'initialize',
+      params: {
+        protocolVersion: '2024-11-05',
+        capabilities: {},
+        clientInfo: { name: 'packed-consumer-verifier', version: '1.0.0' },
+      },
+    },
+    {
+      jsonrpc: '2.0',
+      method: 'notifications/initialized',
+      params: {},
+    },
+    {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/list',
+      params: {},
+    },
+  ].map((message) => JSON.stringify(message)).join('\n') + '\n';
+}
+
+function npmInvocation(args) {
+  if (process.platform !== 'win32') {
+    return { command: 'npm', args };
+  }
+  const bundledNpm = path.join(
+    path.dirname(process.execPath),
+    'node_modules',
+    'npm',
+    'bin',
+    'npm-cli.js',
+  );
+  const npmCli = (
+    process.env.npm_execpath
+    && existsSync(process.env.npm_execpath)
+  )
+    ? process.env.npm_execpath
+    : bundledNpm;
+  if (!existsSync(npmCli)) {
+    fail('infrastructure', 'npm CLI entrypoint is unavailable');
+  }
+  return {
+    command: process.execPath,
+    args: [npmCli, ...args],
+  };
+}
+
+export function verifyPackedConsumer({
+  projectRoot = process.cwd(),
+  artifactOutput,
+  spawn = spawnSync,
+} = {}) {
+  const temporaryRoot = mkdtempSync(path.join(tmpdir(), 'mcp-searxng-packed-consumer-'));
+  const artifactDirectory = path.join(temporaryRoot, 'artifact');
+  const consumerDirectory = path.join(temporaryRoot, 'consumer');
+  try {
+    mkdirSync(artifactDirectory);
+    mkdirSync(consumerDirectory);
+    const npmEnvironment = isolatedNpmEnvironment(temporaryRoot);
+    const packInvocation = npmInvocation([
+        'pack',
+        '--json',
+        '--ignore-scripts',
+        '--pack-destination',
+        artifactDirectory,
+    ]);
+    const packOutput = runCheckedCommand(
+      packInvocation.command,
+      packInvocation.args,
+      {
+        cwd: projectRoot,
+        env: npmEnvironment,
+        timeoutMs: 300_000,
+        spawn,
+      },
+    );
+    let packedArtifacts;
+    try {
+      packedArtifacts = JSON.parse(packOutput);
+    } catch {
+      fail('infrastructure', 'npm pack returned invalid JSON');
+    }
+    if (
+      !Array.isArray(packedArtifacts)
+      || packedArtifacts.length !== 1
+      || typeof packedArtifacts[0]?.filename !== 'string'
+    ) {
+      fail('infrastructure', 'npm pack did not report exactly one artifact');
+    }
+    const artifactPath = path.join(artifactDirectory, packedArtifacts[0].filename);
+    if (!existsSync(artifactPath)) {
+      fail('infrastructure', 'npm pack reported an artifact that does not exist');
+    }
+
+    writeFileSync(
+      path.join(consumerDirectory, 'package.json'),
+      `${JSON.stringify({
+        name: 'mcp-searxng-packed-consumer-verifier',
+        version: '1.0.0',
+        private: true,
+        dependencies: {
+          'mcp-searxng': pathToFileURL(artifactPath).href,
+        },
+      }, null, 2)}\n`,
+      'utf8',
+    );
+
+    const installInvocation = npmInvocation([
+        'install',
+        '--ignore-scripts',
+        '--no-audit',
+        '--no-fund',
+        '--fetch-retries=2',
+        '--fetch-timeout=60000',
+    ]);
+    runCheckedCommand(
+      installInvocation.command,
+      installInvocation.args,
+      {
+        cwd: consumerDirectory,
+        env: npmEnvironment,
+        timeoutMs: 300_000,
+        spawn,
+      },
+    );
+
+    const installedManifestPath = path.join(
+      consumerDirectory,
+      'node_modules',
+      'mcp-searxng',
+      'package.json',
+    );
+    let installedPackage;
+    try {
+      installedPackage = JSON.parse(readFileSync(installedManifestPath, 'utf8'));
+    } catch {
+      fail('artifact_metadata', 'installed package manifest is unreadable');
+    }
+    assertArtifactMetadata(packedArtifacts[0], installedPackage);
+
+    const treeInvocation = npmInvocation(
+      ['ls', '--all', '--json'],
+    );
+    const treeResult = runJsonCommand(
+      treeInvocation.command,
+      treeInvocation.args,
+      {
+        cwd: consumerDirectory,
+        env: npmEnvironment,
+        timeoutMs: 300_000,
+        spawn,
+        label: 'npm ls',
+      },
+    );
+    const adapterVersions = assertSafeDependencyTree(treeResult.json);
+    if (treeResult.status !== 0) {
+      fail('infrastructure', `npm ls exited with status ${treeResult.status}`);
+    }
+
+    const auditInvocation = npmInvocation(
+      ['audit', '--omit=dev', '--json'],
+    );
+    const auditResult = runJsonCommand(
+      auditInvocation.command,
+      auditInvocation.args,
+      {
+        cwd: consumerDirectory,
+        env: npmEnvironment,
+        timeoutMs: 300_000,
+        spawn,
+        label: 'npm audit',
+      },
+    );
+    const audit = assertZeroProductionAudit(auditResult.json);
+    if (auditResult.status !== 0) {
+      fail('infrastructure', `npm audit exited with status ${auditResult.status}`);
+    }
+
+    const cliPath = path.join(
+      consumerDirectory,
+      'node_modules',
+      'mcp-searxng',
+      'dist',
+      'cli.js',
+    );
+    if (!existsSync(cliPath) && spawn === spawnSync) {
+      fail('infrastructure', 'packed CLI is missing after installation');
+    }
+    const smokeOutput = runCheckedCommand(
+      process.execPath,
+      [path.join('node_modules', 'mcp-searxng', 'dist', 'cli.js')],
+      {
+        cwd: consumerDirectory,
+        env: {
+          ...allowlistedProcessEnvironment(),
+          SEARXNG_URL: 'https://packed-consumer.invalid',
+        },
+        timeoutMs: 30_000,
+        input: mcpSmokeInput(),
+        spawn,
+      },
+    );
+    const toolCount = assertMcpSmokeResponses(smokeOutput);
+    if (artifactOutput) {
+      copyFileSync(artifactPath, path.resolve(artifactOutput));
+    }
+
+    return {
+      adapterVersions,
+      auditTotal: audit.total,
+      toolCount,
+    };
+  } finally {
+    rmSync(temporaryRoot, { recursive: true, force: true });
+  }
+}
+
+if (
+  process.argv[1]
+  && import.meta.url === pathToFileURL(process.argv[1]).href
+) {
+  try {
+    const args = process.argv.slice(2);
+    let artifactOutput;
+    for (let index = 0; index < args.length; index += 2) {
+      const option = args[index];
+      const value = args[index + 1];
+      if (!value) {
+        fail(
+          'infrastructure',
+          'usage: verify-packed-consumer.mjs [--output artifact.tgz]',
+        );
+      }
+      if (option === '--output' && artifactOutput === undefined) {
+        artifactOutput = value;
+      } else {
+        fail(
+          'infrastructure',
+          'usage: verify-packed-consumer.mjs [--output artifact.tgz]',
+        );
+      }
+    }
+    const outcome = verifyPackedConsumer({ artifactOutput });
+    process.stdout.write(
+      `packed-consumer verification passed: adapters=${outcome.adapterVersions.join(',')} audit=${outcome.auditTotal} tools=${outcome.toolCount}\n`,
+    );
+  } catch (error) {
+    process.stderr.write(`${error instanceof Error ? error.message : String(error)}\n`);
+    process.exitCode = 1;
+  }
+}

--- a/scripts/verify-packed-consumer.mjs
+++ b/scripts/verify-packed-consumer.mjs
@@ -148,6 +148,17 @@ function mcpSmokeInput() {
   ].map((message) => JSON.stringify(message)).join('\n') + '\n';
 }
 
+function copyVerifiedArtifact(artifactPath, artifactOutput) {
+  try {
+    copyFileSync(artifactPath, path.resolve(artifactOutput));
+  } catch (error) {
+    const code = error && typeof error === 'object' && 'code' in error
+      ? error.code
+      : 'copy failed';
+    fail('infrastructure', `verified artifact output failed: ${code}`);
+  }
+}
+
 function npmInvocation(args) {
   if (process.platform !== 'win32') {
     return { command: 'npm', args };
@@ -332,7 +343,7 @@ export function verifyPackedConsumer({
     );
     const toolCount = assertMcpSmokeResponses(smokeOutput);
     if (artifactOutput) {
-      copyFileSync(artifactPath, path.resolve(artifactOutput));
+      copyVerifiedArtifact(artifactPath, artifactOutput);
     }
 
     return {

--- a/scripts/verify-packed-consumer.mjs
+++ b/scripts/verify-packed-consumer.mjs
@@ -16,7 +16,6 @@ import { pathToFileURL } from 'node:url';
 import {
   assertArtifactMetadata,
   assertMcpSmokeResponses,
-  assertPublishWorkflowContract,
   assertSafeDependencyTree,
   assertZeroProductionAudit,
   fail,


### PR DESCRIPTION
## Summary
- upgrade the MCP SDK so clean consumers can resolve the patched Hono Node server line
- verify the exact packed tarball in an isolated consumer before publishing it
- fail closed on unsafe dependency trees, production advisories, malformed npm output, and an incomplete MCP tool surface
- document the verified installation boundary for downstream consumers

## Verification
- Node 24.18.0: coverage, lint, build, E2E, packed-consumer verification, production audit
- Node 20.20.2: coverage, lint, build, E2E, packed-consumer verification, production audit
- packed consumer: @hono/node-server 2.0.12, zero production audit findings, four expected MCP tools
- git diff --check