### PR TITLE
fix(config): reject malformed integer settings

### DIFF
--- a/__tests__/integration/cli.test.ts
+++ b/__tests__/integration/cli.test.ts
@@ -53,6 +53,29 @@ async function runTests() {
     );
   }, results);
 
+  await testFunction('MCP_HTTP_PORT rejects a numeric prefix with a suffix', () => {
+    const result = spawnSync(
+      process.execPath,
+      ['--import', 'tsx', 'src/cli.ts'],
+      {
+        cwd: process.cwd(),
+        env: {
+          ...process.env,
+          MCP_HTTP_PORT: '3000x',
+          SEARXNG_URL: 'https://test-searx.example.com',
+        },
+        encoding: 'utf8',
+        timeout: 2000,
+      }
+    );
+
+    assert.equal(result.status, 1, `expected exit code 1, got ${result.status}; stderr:\n${result.stderr}`);
+    assert.ok(
+      result.stderr.includes('Invalid HTTP port: 3000x'),
+      `expected invalid-port diagnostic in stderr, got:\n${result.stderr}`
+    );
+  }, results);
+
   printTestSummary(results, 'CLI');
   return results;
 }

--- a/__tests__/integration/cli.test.ts
+++ b/__tests__/integration/cli.test.ts
@@ -65,7 +65,7 @@ async function runTests() {
           SEARXNG_URL: 'https://test-searx.example.com',
         },
         encoding: 'utf8',
-        timeout: 2000,
+        timeout: 8000,
       }
     );
 

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -612,6 +612,64 @@ async function runTests() {
     await client.close();
   }, results);
 
+  await testFunction('tools/call web_url_read rejects a numeric prefix with a suffix in URL_READ_MAX_CHARS', async () => {
+    const originalValue = process.env.URL_READ_MAX_CHARS;
+    process.env.URL_READ_MAX_CHARS = '10x';
+    const { client } = await connect();
+
+    try {
+      await withPrivateUrlReadsAllowed(async () => {
+        await withLocalHtmlServer(LONG_HTML_RESPONSE, async (url) => {
+          const result = await client.callTool({
+            name: 'web_url_read',
+            arguments: { url },
+          });
+
+          const text = (result.content[0] as { type: string; text: string }).text;
+          assert.ok(text.includes('abcdefghijklmnopqrstuvwxyz'), text);
+        });
+      });
+    } finally {
+      await client.close();
+      if (originalValue === undefined) {
+        delete process.env.URL_READ_MAX_CHARS;
+      } else {
+        process.env.URL_READ_MAX_CHARS = originalValue;
+      }
+    }
+  }, results);
+
+  await testFunction('tools/call web_url_read rejects FETCH_TIMEOUT_MS with a unit suffix', async () => {
+    const originalValue = process.env.FETCH_TIMEOUT_MS;
+    process.env.FETCH_TIMEOUT_MS = '10s';
+    const { client, logs } = await connectWithLogs();
+
+    try {
+      await withPrivateUrlReadsAllowed(async () => {
+        await withLocalHtmlServer(HTML_RESPONSE, async (url) => {
+          const result = await client.callTool({
+            name: 'web_url_read',
+            arguments: { url },
+          });
+          assert.equal(result.content[0].type, 'text');
+        });
+      });
+      await new Promise(resolve => setTimeout(resolve, 10));
+      assert.ok(
+        logs.some((entry: any) => entry.params?.level === 'warning'
+          && entry.params?.data?.message?.includes('Ignoring invalid FETCH_TIMEOUT_MS="10s"')),
+        JSON.stringify(logs),
+      );
+    } finally {
+      await client.close();
+      if (originalValue === undefined) {
+        delete process.env.FETCH_TIMEOUT_MS;
+      } else {
+        process.env.FETCH_TIMEOUT_MS = originalValue;
+      }
+    }
+  }, results);
+
   await testFunction('tools/call web_url_read FETCH_TIMEOUT_MS=100 times out against hanging server', async () => {
     process.env.FETCH_TIMEOUT_MS = '100';
     process.env.MCP_HTTP_ALLOW_PRIVATE_URLS = 'true';

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -654,12 +654,15 @@ async function runTests() {
           assert.equal(result.content[0].type, 'text');
         });
       });
-      await new Promise(resolve => setTimeout(resolve, 10));
-      assert.ok(
-        logs.some((entry: any) => entry.params?.level === 'warning'
-          && entry.params?.data?.message?.includes('Ignoring invalid FETCH_TIMEOUT_MS="10s"')),
-        JSON.stringify(logs),
+      const hasExpectedWarning = () => logs.some((entry: any) =>
+        entry.params?.level === 'warning'
+        && entry.params?.data?.message?.includes('Ignoring invalid FETCH_TIMEOUT_MS="10s"')
       );
+      const deadline = Date.now() + 1000;
+      while (!hasExpectedWarning() && Date.now() < deadline) {
+        await new Promise(resolve => setTimeout(resolve, 10));
+      }
+      assert.ok(hasExpectedWarning(), JSON.stringify(logs));
     } finally {
       await client.close();
       if (originalValue === undefined) {

--- a/__tests__/unit/cache.test.ts
+++ b/__tests__/unit/cache.test.ts
@@ -163,6 +163,28 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('Cache rejects non-decimal and unsafe integer spellings in CACHE_TTL_MS', () => {
+    const previousTtl = process.env.CACHE_TTL_MS;
+
+    try {
+      for (const value of ['5.0', '1e3', '0x10', '9007199254740993']) {
+        process.env.CACHE_TTL_MS = value;
+        const testCache = new SimpleCache();
+        try {
+          assert.equal((testCache as any).ttlMs, 86400000, value);
+        } finally {
+          testCache.destroy();
+        }
+      }
+    } finally {
+      if (previousTtl === undefined) {
+        delete process.env.CACHE_TTL_MS;
+      } else {
+        process.env.CACHE_TTL_MS = previousTtl;
+      }
+    }
+  }, results);
+
   await testFunction('Cache clear functionality', () => {
     const testCache = new SimpleCache(1000);
 

--- a/__tests__/unit/cache.test.ts
+++ b/__tests__/unit/cache.test.ts
@@ -146,6 +146,23 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('Cache rejects a numeric prefix with a suffix in CACHE_TTL_MS', () => {
+    const previousTtl = process.env.CACHE_TTL_MS;
+    process.env.CACHE_TTL_MS = '500x';
+    const testCache = new SimpleCache();
+
+    try {
+      assert.equal((testCache as any).ttlMs, 86400000);
+    } finally {
+      testCache.destroy();
+      if (previousTtl === undefined) {
+        delete process.env.CACHE_TTL_MS;
+      } else {
+        process.env.CACHE_TTL_MS = previousTtl;
+      }
+    }
+  }, results);
+
   await testFunction('Cache clear functionality', () => {
     const testCache = new SimpleCache(1000);
 

--- a/__tests__/unit/search-cache.test.ts
+++ b/__tests__/unit/search-cache.test.ts
@@ -149,6 +149,22 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('SearchCache rejects a numeric prefix with a suffix in SEARCH_CACHE_TTL_MS', () => {
+    const previousTtl = process.env.SEARCH_CACHE_TTL_MS;
+    process.env.SEARCH_CACHE_TTL_MS = '500x';
+    const testCache = new SearchCache();
+
+    try {
+      assert.equal((testCache as any).ttlMs, 86400000);
+    } finally {
+      if (previousTtl === undefined) {
+        delete process.env.SEARCH_CACHE_TTL_MS;
+      } else {
+        process.env.SEARCH_CACHE_TTL_MS = previousTtl;
+      }
+    }
+  }, results);
+
   await testFunction('Global search cache instance', () => {
     searchCache.clear();
 

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -1055,11 +1055,13 @@ async function runTests() {
     const mockServer = createMockServer();
     fetchMocker.mock(createMockFetch({ json: { results: makeMockSearchResults(6) } }));
 
-    const result = await performWebSearch(mockServer as any, 'suffix max results');
-    assert.ok(result.includes('Result 6'));
-
-    fetchMocker.restore();
-    envManager.restore();
+    try {
+      const result = await performWebSearch(mockServer as any, 'suffix max results');
+      assert.ok(result.includes('Result 6'));
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+    }
   }, results);
 
   await testFunction('Omitted num_results and unset SEARXNG_MAX_RESULTS preserves all results', async () => {
@@ -1175,11 +1177,13 @@ async function runTests() {
       },
     }));
 
-    const result = await performWebSearch(mockServer as any, 'suffix max chars');
-    assert.ok(result.includes('Description: abcdefghijklmnopqrstuvwxyz'));
-
-    fetchMocker.restore();
-    envManager.restore();
+    try {
+      const result = await performWebSearch(mockServer as any, 'suffix max chars');
+      assert.ok(result.includes('Description: abcdefghijklmnopqrstuvwxyz'));
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+    }
   }, results);
 
   // A NaN/non-positive timeout makes setTimeout(abort, ms) fire on the next tick,
@@ -2051,16 +2055,18 @@ async function runTests() {
     });
 
     try {
-      await performWebSearch(mockServer as any, 'suffix safe search');
-    } catch {
-      // expected
+      try {
+        await performWebSearch(mockServer as any, 'suffix safe search');
+      } catch {
+        // expected
+      }
+
+      const url = new URL(getCapturedUrl());
+      assert.equal(url.searchParams.get('safesearch'), null);
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
     }
-
-    const url = new URL(getCapturedUrl());
-    assert.equal(url.searchParams.get('safesearch'), null);
-
-    fetchMocker.restore();
-    envManager.restore();
   }, results);
 
   await testFunction('text output prepends answers before result list', async () => {

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -1048,6 +1048,20 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('SEARXNG_MAX_RESULTS rejects a numeric prefix with a suffix', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARXNG_MAX_RESULTS', '5s');
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(createMockFetch({ json: { results: makeMockSearchResults(6) } }));
+
+    const result = await performWebSearch(mockServer as any, 'suffix max results');
+    assert.ok(result.includes('Result 6'));
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
   await testFunction('Omitted num_results and unset SEARXNG_MAX_RESULTS preserves all results', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
     envManager.delete('SEARXNG_MAX_RESULTS');
@@ -1139,6 +1153,29 @@ async function runTests() {
     fetchMocker.mock(mockFetch);
 
     const result = await performWebSearch(mockServer as any, 'test query');
+    assert.ok(result.includes('Description: abcdefghijklmnopqrstuvwxyz'));
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('SEARXNG_MAX_RESULT_CHARS rejects a numeric prefix with a suffix', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARXNG_MAX_RESULT_CHARS', '5x');
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(createMockFetch({
+      json: {
+        results: [{
+          title: 'Untruncated suffix result',
+          content: 'abcdefghijklmnopqrstuvwxyz',
+          url: 'https://example.com/untruncated-suffix',
+          score: 1,
+        }],
+      },
+    }));
+
+    const result = await performWebSearch(mockServer as any, 'suffix max chars');
     assert.ok(result.includes('Description: abcdefghijklmnopqrstuvwxyz'));
 
     fetchMocker.restore();
@@ -1996,6 +2033,31 @@ async function runTests() {
 
     const url = new URL(getCapturedUrl());
     assert.equal(url.searchParams.get('safesearch'), null, 'Invalid SEARXNG_DEFAULT_SAFESEARCH should not set URL param');
+
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('SEARXNG_DEFAULT_SAFESEARCH rejects a numeric prefix with a suffix', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARXNG_DEFAULT_SAFESEARCH', '1x');
+
+    const mockServer = createMockServer();
+    const { mockFetch, getCapturedUrl } = createCapturingMockFetch();
+
+    fetchMocker.mock(async (url, options) => {
+      await mockFetch(url, options);
+      throw new Error('MOCK_STOP');
+    });
+
+    try {
+      await performWebSearch(mockServer as any, 'suffix safe search');
+    } catch {
+      // expected
+    }
+
+    const url = new URL(getCapturedUrl());
+    assert.equal(url.searchParams.get('safesearch'), null);
 
     fetchMocker.restore();
     envManager.restore();

--- a/src/env-int.ts
+++ b/src/env-int.ts
@@ -5,8 +5,13 @@
  */
 
 export function parseStrictInteger(value: string): number | undefined {
-  const parsed = Number(value.trim());
-  return Number.isInteger(parsed) ? parsed : undefined;
+  const trimmed = value.trim();
+  if (!/^[+-]?\d+$/.test(trimmed)) {
+    return undefined;
+  }
+
+  const parsed = Number(trimmed);
+  return Number.isSafeInteger(parsed) ? parsed : undefined;
 }
 
 export function parsePositiveInteger(value: string | undefined, fallback: number): number {

--- a/src/env-int.ts
+++ b/src/env-int.ts
@@ -1,7 +1,6 @@
 /**
- * Shared positive-integer parsing/normalization for environment-configured
- * numeric settings. Used by both the URL cache (`cache.ts`) and the search
- * cache (`search-cache.ts`) so their env-parsing behavior stays identical.
+ * Shared strict-integer parsing and positive-integer normalization for
+ * environment-configured numeric settings.
  */
 
 export function parseStrictInteger(value: string): number | undefined {

--- a/src/env-int.ts
+++ b/src/env-int.ts
@@ -4,13 +4,18 @@
  * cache (`search-cache.ts`) so their env-parsing behavior stays identical.
  */
 
+export function parseStrictInteger(value: string): number | undefined {
+  const parsed = Number(value.trim());
+  return Number.isInteger(parsed) ? parsed : undefined;
+}
+
 export function parsePositiveInteger(value: string | undefined, fallback: number): number {
   if (value === undefined || value.trim() === "") {
     return fallback;
   }
 
-  const parsed = parseInt(value, 10);
-  return Number.isNaN(parsed) || parsed <= 0 ? fallback : parsed;
+  const parsed = parseStrictInteger(value);
+  return parsed === undefined || parsed <= 0 ? fallback : parsed;
 }
 
 export function normalizePositiveInteger(value: number, fallback: number): number {

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ import {
   sanitizeErrorForTransport,
 } from "./diagnostic-sanitizer.js";
 import { writeDiagnostic } from "./diagnostic-output.js";
+import { parseStrictInteger } from "./env-int.js";
 
 import { packageVersion } from "./version.js";
 
@@ -92,8 +93,8 @@ function getFetchTimeoutMs(mcpServer: McpServer): number {
     return 10000;
   }
 
-  const parsed = parseInt(rawValue, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
+  const parsed = parseStrictInteger(rawValue);
+  if (parsed === undefined || parsed <= 0) {
     logMessage(
       mcpServer,
       "warning",
@@ -111,8 +112,8 @@ function getDefaultUrlReadMaxChars(mcpServer: McpServer): number | undefined {
     return undefined;
   }
 
-  const parsed = parseInt(rawValue, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
+  const parsed = parseStrictInteger(rawValue);
+  if (parsed === undefined || parsed <= 0) {
     logMessage(
       mcpServer,
       "warning",
@@ -348,8 +349,8 @@ export async function main() {
   // Check for HTTP transport mode
   const httpPort = process.env.MCP_HTTP_PORT;
   if (httpPort) {
-    const port = parseInt(httpPort, 10);
-    if (isNaN(port) || port < 1 || port > 65535) {
+    const port = parseStrictInteger(httpPort);
+    if (port === undefined || port < 1 || port > 65535) {
       writeDiagnostic("error", `Invalid HTTP port: ${httpPort}. Must be between 1-65535.`);
       process.exit(1);
     }

--- a/src/search.ts
+++ b/src/search.ts
@@ -5,6 +5,7 @@ import { getKnownCategories, getKnownEngines } from "./instance-info.js";
 import { applySearchRequestConfig } from "./proxy.js";
 import { logMessage } from "./logging.js";
 import { searchCache } from "./search-cache.js";
+import { parseStrictInteger } from "./env-int.js";
 import {
   getHealthySearxngInstances,
   getSearxngInstances,
@@ -31,8 +32,8 @@ function getOperatorMaxResults(mcpServer: McpServer): number | undefined {
     return undefined;
   }
 
-  const parsed = parseInt(rawValue, 10);
-  if (Number.isNaN(parsed) || parsed <= 0 || parsed > 20) {
+  const parsed = parseStrictInteger(rawValue);
+  if (parsed === undefined || parsed <= 0 || parsed > 20) {
     logMessage(
       mcpServer,
       "warning",
@@ -50,8 +51,8 @@ function getMaxResultChars(mcpServer: McpServer): number | undefined {
     return undefined;
   }
 
-  const parsed = parseInt(rawValue, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
+  const parsed = parseStrictInteger(rawValue);
+  if (parsed === undefined || parsed <= 0) {
     logMessage(
       mcpServer,
       "warning",
@@ -398,8 +399,8 @@ function getDefaultSafesearch(mcpServer: McpServer): number | undefined {
     return undefined;
   }
 
-  const parsed = parseInt(rawValue, 10);
-  if (Number.isNaN(parsed) || ![0, 1, 2].includes(parsed)) {
+  const parsed = parseStrictInteger(rawValue);
+  if (parsed === undefined || ![0, 1, 2].includes(parsed)) {
     logMessage(
       mcpServer,
       "warning",


### PR DESCRIPTION
## Summary
- reject malformed whole-string values for selected cache, URL output/fetch-timeout, HTTP-port, and search integer settings
- preserve existing defaults, bounds, blank handling, and warnings through one shared strict parser
- add regression coverage for suffix-bearing values such as `10s`, `500x`, and `3000x`

## Verification
- `npm run test:coverage` (571/571; 96.38% lines, 93.05% branches)
- `npm run build`
- `npm run lint`
- `npm run test:e2e` (11/11, including live SearXNG)
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm run verify:packed-consumer` (adapter 2.0.12, audit 0, tools 4)
- `git diff --check`