### PR TITLE
fix(url-reader): reject malformed content limits

### DIFF
--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -20,7 +20,7 @@ import { checkContentLength, fetchAndConvertToMarkdown } from '../../src/url-rea
 import { createUrlReaderLookup } from '../../src/proxy.js';
 import { urlCache } from '../../src/cache.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
-import { createMockServer } from '../helpers/mock-server.js';
+import { createMockServer, createMockServerWithTracking } from '../helpers/mock-server.js';
 import { EnvManager } from '../helpers/env-utils.js';
 
 const results = createTestResults();
@@ -653,6 +653,42 @@ async function runTests() {
       const result = await fetchAndConvertToMarkdown(mockServer as any, url);
       assert.ok(result.includes('Content too large'));
       assert.deepEqual(seenMethods, ['HEAD']);
+    } finally {
+      await close();
+      envManager.restore();
+      urlCache.clear();
+    }
+  }, results);
+
+  await testFunction('URL_READ_MAX_CONTENT_LENGTH_BYTES rejects a numeric prefix with a suffix', async () => {
+    const { server: mockServer, getLoggingCalls } = createMockServerWithTracking();
+    urlCache.clear();
+    envManager.set('URL_READ_MAX_CONTENT_LENGTH_BYTES', '5MB');
+
+    const seenMethods: string[] = [];
+    const { url, close } = await startHttpServer((req, res) => {
+      seenMethods.push(req.method || 'UNKNOWN');
+      if (req.method === 'HEAD') {
+        res.writeHead(200, { 'content-length': '6' });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end('<html><body><h1>Readable Content</h1></body></html>');
+    });
+
+    try {
+      const result = await fetchAndConvertToMarkdown(mockServer as any, url);
+      assert.ok(result.includes('Readable Content'), `Expected default limit to allow the read, got: ${result}`);
+      assert.deepEqual(seenMethods, ['HEAD', 'GET']);
+      assert.ok(
+        getLoggingCalls().some((entry: any) =>
+          entry.level === 'warning'
+          && entry.data?.message?.includes(
+            'Ignoring invalid URL_READ_MAX_CONTENT_LENGTH_BYTES="5MB"',
+          )),
+        `Expected invalid-value warning, got: ${JSON.stringify(getLoggingCalls())}`,
+      );
     } finally {
       await close();
       envManager.restore();

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -5,6 +5,7 @@ import { createProxyAgent, createUrlReaderAgent, ProxyType } from "./proxy.js";
 import { logMessage } from "./logging.js";
 import { urlCache } from "./cache.js";
 import { assertUrlAllowed, isUrlSecurityPolicyDnsError } from "./url-security.js";
+import { parseStrictInteger } from "./env-int.js";
 import {
   createURLFormatError,
   createURLSecurityPolicyError,
@@ -249,8 +250,8 @@ function getMaxContentLengthBytes(mcpServer: McpServer): number {
     return DEFAULT_MAX_CONTENT_LENGTH_BYTES;
   }
 
-  const parsed = parseInt(rawValue, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
+  const parsed = parseStrictInteger(rawValue);
+  if (parsed === undefined || parsed <= 0) {
     logMessage(
       mcpServer,
       "warning",


### PR DESCRIPTION
## Summary
- reject malformed whole-string values for `URL_READ_MAX_CONTENT_LENGTH_BYTES`
- preserve the 5 MiB default, positive bound, blank handling, and existing warning
- add a local-server regression proving `5MB` falls back instead of becoming a five-byte cap

## Verification
- `node --import tsx __tests__/unit/url-reader.test.ts` (68/68)
- `npm run test:coverage` (572/572; 96.38% lines, 93.05% branches)
- `npm run build`
- `npm run lint`
- `npm run test:e2e` (11/11, including live SearXNG)
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm run verify:packed-consumer` (adapter 2.0.12, audit 0, tools 4)
- `git diff --check`