### PR TITLE
fix(search): align fetch and dispatcher clients

### DIFF
--- a/__tests__/helpers/mock-fetch.ts
+++ b/__tests__/helpers/mock-fetch.ts
@@ -5,6 +5,7 @@
  */
 
 import { searchCache } from '../../src/search-cache.js';
+import { setSearxngFetchForTesting } from '../../src/proxy.js';
 
 export type FetchMockOptions = {
   status?: number;
@@ -113,21 +114,15 @@ export function createAbortableMockFetch(delayMs: number = 50) {
 }
 
 /**
- * Save and restore global fetch
+ * Replace and restore the shared SearXNG fetch implementation
  */
 export class FetchMocker {
-  private originalFetch: typeof global.fetch;
-
-  constructor() {
-    this.originalFetch = global.fetch;
-  }
-
   mock(mockFetch: typeof global.fetch): void {
-    global.fetch = mockFetch;
+    setSearxngFetchForTesting(mockFetch);
   }
 
   restore(): void {
-    global.fetch = this.originalFetch;
+    setSearxngFetchForTesting();
     searchCache.clear();
   }
 }

--- a/__tests__/unit/proxy.test.ts
+++ b/__tests__/unit/proxy.test.ts
@@ -8,7 +8,14 @@
 
 import { strict as assert } from 'node:assert';
 import { fileURLToPath } from 'node:url';
-import { createProxyAgent, createDefaultAgent, applySearchRequestConfig, ProxyType } from '../../src/proxy.js';
+import {
+  createProxyAgent,
+  createDefaultAgent,
+  applySearchRequestConfig,
+  fetchSearxng,
+  setSearxngFetchForTesting,
+  ProxyType,
+} from '../../src/proxy.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 import { EnvManager } from '../helpers/env-utils.js';
 
@@ -502,6 +509,32 @@ async function runTests() {
     assert.equal(headers['user-agent'], 'MyBot/1.0', 'User-Agent should be set');
 
     envManager.restore();
+  }, results);
+
+  await testFunction('fetchSearxng forwards requests through the configured implementation', async () => {
+    const expectedResponse = { ok: true, status: 200 } as Response;
+    let capturedInput: string | URL | Request | undefined;
+    let capturedOptions: RequestInit | undefined;
+
+    setSearxngFetchForTesting(async (input, options) => {
+      capturedInput = input;
+      capturedOptions = options;
+      return expectedResponse;
+    });
+
+    try {
+      const options: RequestInit = {
+        method: 'POST',
+        headers: { 'X-Test': 'forwarded' },
+      };
+      const response = await fetchSearxng('https://searx.example.com/search', options);
+
+      assert.equal(response, expectedResponse);
+      assert.equal(capturedInput, 'https://searx.example.com/search');
+      assert.equal(capturedOptions, options);
+    } finally {
+      setSearxngFetchForTesting();
+    }
   }, results);
 
   printTestSummary(results, 'Proxy Module');

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logMessage } from "./logging.js";
-import { applySearchRequestConfig } from "./proxy.js";
+import { applySearchRequestConfig, fetchSearxng } from "./proxy.js";
 import { getSearxngInstances, redactSearxngInstanceUrl, stripSearxngInstanceUrlUserinfo } from "./searxng-instances.js";
 
 type SearXNGConfig = Record<string, any>;
@@ -269,7 +269,7 @@ async function requestInstanceConfig(mcpServer: McpServer, base: string): Promis
     };
     applySearchRequestConfig(requestOptions, url.toString());
 
-    const response = await fetch(requestUrl.toString(), requestOptions);
+    const response = await fetchSearxng(requestUrl.toString(), requestOptions);
     if (!response.ok) {
       const message = `SearXNG /config is unavailable: HTTP ${response.status} ${response.statusText}`;
       return {

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -1,5 +1,5 @@
 import * as dns from "node:dns";
-import { Agent, ProxyAgent } from "undici";
+import { Agent, ProxyAgent, fetch as undiciFetch } from "undici";
 import { getHttpSecurityConfig } from "./http-security.js";
 import { getConnectOptions } from "./tls-config.js";
 import { createUrlSecurityPolicyDnsError, isPrivateAddress } from "./url-security.js";
@@ -10,6 +10,23 @@ type LookupCallback = (
   address: string | dns.LookupAddress[],
   family?: number,
 ) => void;
+
+type SearxngFetch = typeof globalThis.fetch;
+const defaultSearxngFetch = undiciFetch as unknown as SearxngFetch;
+let searxngFetch = defaultSearxngFetch;
+
+export function fetchSearxng(
+  input: string | URL | Request,
+  options?: RequestInit,
+): Promise<Response> {
+  return searxngFetch(input, options);
+}
+
+export function setSearxngFetchForTesting(
+  implementation: SearxngFetch = defaultSearxngFetch,
+): void {
+  searxngFetch = implementation;
+}
 
 export function createUrlReaderLookup() {
   return (hostname: string, options: dns.LookupOptions, callback: LookupCallback): void => {

--- a/src/search.ts
+++ b/src/search.ts
@@ -2,7 +2,7 @@ import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { parse } from "node-html-parser";
 import { SearXNGWeb } from "./types.js";
 import { getKnownCategories, getKnownEngines } from "./instance-info.js";
-import { applySearchRequestConfig } from "./proxy.js";
+import { applySearchRequestConfig, fetchSearxng } from "./proxy.js";
 import { logMessage } from "./logging.js";
 import { searchCache } from "./search-cache.js";
 import { parseStrictInteger } from "./env-int.js";
@@ -172,7 +172,7 @@ async function fetchWithSearchTimeout(
 
   try {
     logMessage(mcpServer, "info", `Making request to: ${redactedUrl}`);
-    return await fetch(rawUrl, {
+    return await fetchSearxng(rawUrl, {
       ...requestOptions,
       signal: controller.signal,
     });

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -1,6 +1,6 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logMessage } from "./logging.js";
-import { applySearchRequestConfig } from "./proxy.js";
+import { applySearchRequestConfig, fetchSearxng } from "./proxy.js";
 import { getPrimarySearxngInstance, stripSearxngInstanceUrlUserinfo } from "./searxng-instances.js";
 
 export async function performSearchSuggestions(
@@ -27,7 +27,7 @@ export async function performSearchSuggestions(
     };
     applySearchRequestConfig(requestOptions, url.toString());
 
-    const response = await fetch(requestUrl.toString(), requestOptions);
+    const response = await fetchSearxng(requestUrl.toString(), requestOptions);
     if (!response.ok) {
       return [];
     }


### PR DESCRIPTION
## Summary
- use npm-undici fetch for SearXNG search, instance-config, and suggestion requests
- keep fetch and Agent/ProxyAgent dispatchers on the same undici implementation
- move the deterministic fetch test helper to the shared SearXNG request seam so global-fetch holdouts fail coverage

## Verification
- focused proxy/search/instance/suggestions/MCP suites (214/214)
- `npm run test:coverage` (573/573; 96.39% lines, 93.06% branches)
- `npm run build`
- `npm run lint`
- `npm run test:e2e` (11/11, including live search, suggestions, and instance info)
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm run verify:packed-consumer` (adapter 2.0.12, audit 0, tools 4)
- `git diff --check`