### PR TITLE
fix(cli): handle help and version flags

### DIFF
--- a/__tests__/integration/cli.test.ts
+++ b/__tests__/integration/cli.test.ts
@@ -60,6 +60,7 @@ async function runTests() {
       assert.ok(result.stdout.includes('STDIO is the default transport'));
       assert.ok(result.stdout.includes('MCP_HTTP_PORT enables HTTP transport'));
       assert.ok(result.stdout.includes('CONFIGURATION.md'));
+      assert.ok(!result.stdout.endsWith('\n\n'), 'help output should end with one newline');
     }
   }, results);
 
@@ -101,6 +102,7 @@ async function runTests() {
       assert.ok(result.stdout.includes('--version, -v'));
       assert.ok(result.stdout.includes('SEARXNG_URL is the only required environment variable'));
       assert.ok(result.stdout.includes('CONFIGURATION.md'));
+      assert.ok(!result.stdout.endsWith('\n\n'), 'help output should end with one newline');
     }
   }, results);
 

--- a/__tests__/integration/cli.test.ts
+++ b/__tests__/integration/cli.test.ts
@@ -60,6 +60,7 @@ async function runTests() {
       assert.ok(result.stdout.includes('STDIO is the default transport'));
       assert.ok(result.stdout.includes('MCP_HTTP_PORT enables HTTP transport'));
       assert.ok(result.stdout.includes('CONFIGURATION.md'));
+      assert.ok(result.stdout.endsWith('\n'), 'help output should end with a newline');
       assert.ok(!result.stdout.endsWith('\n\n'), 'help output should end with one newline');
     }
   }, results);
@@ -102,6 +103,7 @@ async function runTests() {
       assert.ok(result.stdout.includes('--version, -v'));
       assert.ok(result.stdout.includes('SEARXNG_URL is the only required environment variable'));
       assert.ok(result.stdout.includes('CONFIGURATION.md'));
+      assert.ok(result.stdout.endsWith('\n'), 'help output should end with a newline');
       assert.ok(!result.stdout.endsWith('\n\n'), 'help output should end with one newline');
     }
   }, results);

--- a/__tests__/integration/cli.test.ts
+++ b/__tests__/integration/cli.test.ts
@@ -15,11 +15,94 @@ import { strict as assert } from 'node:assert';
 import { spawnSync } from 'node:child_process';
 import { fileURLToPath } from 'node:url';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
+import { packageVersion } from '../../src/version.js';
 
 const results = createTestResults();
 
 async function runTests() {
   console.log('🧪 Integration Testing: cli.ts\n');
+
+  await testFunction('source CLI version flags print the package version without starting MCP', () => {
+    for (const flag of ['--version', '-v']) {
+      const env = { ...process.env };
+      delete env.SEARXNG_URL;
+      delete env.MCP_HTTP_PORT;
+      const result = spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', flag], {
+        cwd: process.cwd(),
+        env,
+        encoding: 'utf8',
+        timeout: 8000,
+      });
+
+      assert.equal(result.status, 0, `${flag} failed: ${result.stderr}`);
+      assert.equal(result.stdout, `${packageVersion}\n`);
+      assert.equal(result.stderr, '');
+    }
+  }, results);
+
+  await testFunction('source CLI help flags print shared configuration guidance without starting MCP', () => {
+    for (const flag of ['--help', '-h']) {
+      const env = { ...process.env };
+      delete env.SEARXNG_URL;
+      delete env.MCP_HTTP_PORT;
+      const result = spawnSync(process.execPath, ['--import', 'tsx', 'src/cli.ts', flag], {
+        cwd: process.cwd(),
+        env,
+        encoding: 'utf8',
+        timeout: 8000,
+      });
+
+      assert.equal(result.status, 0, `${flag} failed: ${result.stderr}`);
+      assert.equal(result.stderr, '');
+      assert.ok(result.stdout.includes('--help, -h'));
+      assert.ok(result.stdout.includes('--version, -v'));
+      assert.ok(result.stdout.includes('SEARXNG_URL is the only required environment variable'));
+      assert.ok(result.stdout.includes('STDIO is the default transport'));
+      assert.ok(result.stdout.includes('MCP_HTTP_PORT enables HTTP transport'));
+      assert.ok(result.stdout.includes('CONFIGURATION.md'));
+    }
+  }, results);
+
+  await testFunction('built npm CLI target handles all metadata flags without starting MCP', () => {
+    const build = spawnSync(process.execPath, ['node_modules/typescript/bin/tsc'], {
+      cwd: process.cwd(),
+      env: process.env,
+      encoding: 'utf8',
+      timeout: 30000,
+    });
+    assert.equal(build.status, 0, `build failed:\n${build.stdout}\n${build.stderr}`);
+
+    const env = { ...process.env };
+    delete env.SEARXNG_URL;
+    delete env.MCP_HTTP_PORT;
+
+    for (const flag of ['--version', '-v']) {
+      const result = spawnSync(process.execPath, ['dist/cli.js', flag], {
+        cwd: process.cwd(),
+        env,
+        encoding: 'utf8',
+        timeout: 8000,
+      });
+      assert.equal(result.status, 0, `${flag} failed: ${result.stderr}`);
+      assert.equal(result.stdout, `${packageVersion}\n`);
+      assert.equal(result.stderr, '');
+    }
+
+    for (const flag of ['--help', '-h']) {
+      const result = spawnSync(process.execPath, ['dist/cli.js', flag], {
+        cwd: process.cwd(),
+        env,
+        encoding: 'utf8',
+        timeout: 8000,
+      });
+      assert.equal(result.status, 0, `${flag} failed: ${result.stderr}`);
+      assert.equal(result.stderr, '');
+      assert.ok(result.stdout.includes('--help, -h'));
+      assert.ok(result.stdout.includes('--version, -v'));
+      assert.ok(result.stdout.includes('SEARXNG_URL is the only required environment variable'));
+      assert.ok(result.stdout.includes('CONFIGURATION.md'));
+    }
+  }, results);
 
   await testFunction('main().catch logs error and exits 1 when server creation fails', () => {
     // MCP_HTTP_HARDEN=true without MCP_HTTP_AUTH_TOKEN causes validateHttpSecurityConfig

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,5 @@
 #!/usr/bin/env node
 
-import { main } from "./index.js";
 import { handleUncaughtException, handleUnhandledRejection } from "./error-handler.js";
 import {
   initializeDiagnosticSanitizer,
@@ -20,8 +19,10 @@ if (args.length === 1 && (args[0] === "--version" || args[0] === "-v")) {
 } else if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
   writeDiagnostic("log", createCliHelpText());
 } else {
-  main().catch((error) => {
-    writeDiagnostic("error", "Failed to start server:", sanitizeErrorForTransport(error));
-    process.exit(1);
-  });
+  void import("./index.js")
+    .then(({ main }) => main())
+    .catch((error) => {
+      writeDiagnostic("error", "Failed to start server:", sanitizeErrorForTransport(error));
+      process.exit(1);
+    });
 }

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,7 +7,6 @@ import {
 } from "./diagnostic-sanitizer.js";
 import { writeDiagnostic } from "./diagnostic-output.js";
 import { packageVersion } from "./version.js";
-import { createCliHelpText } from "./resources.js";
 
 initializeDiagnosticSanitizer();
 process.on('uncaughtException', handleUncaughtException);
@@ -17,6 +16,7 @@ const args = process.argv.slice(2);
 if (args.length === 1 && (args[0] === "--version" || args[0] === "-v")) {
   writeDiagnostic("log", packageVersion);
 } else if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
+  const { createCliHelpText } = await import("./resources.js");
   writeDiagnostic("log", createCliHelpText());
 } else {
   void import("./index.js")

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -7,12 +7,21 @@ import {
   sanitizeErrorForTransport,
 } from "./diagnostic-sanitizer.js";
 import { writeDiagnostic } from "./diagnostic-output.js";
+import { packageVersion } from "./version.js";
+import { createCliHelpText } from "./resources.js";
 
 initializeDiagnosticSanitizer();
 process.on('uncaughtException', handleUncaughtException);
 process.on('unhandledRejection', handleUnhandledRejection);
 
-main().catch((error) => {
-  writeDiagnostic("error", "Failed to start server:", sanitizeErrorForTransport(error));
-  process.exit(1);
-});
+const args = process.argv.slice(2);
+if (args.length === 1 && (args[0] === "--version" || args[0] === "-v")) {
+  writeDiagnostic("log", packageVersion);
+} else if (args.length === 1 && (args[0] === "--help" || args[0] === "-h")) {
+  writeDiagnostic("log", createCliHelpText());
+} else {
+  main().catch((error) => {
+    writeDiagnostic("error", "Failed to start server:", sanitizeErrorForTransport(error));
+    process.exit(1);
+  });
+}

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -3,6 +3,28 @@ import { packageVersion } from "./version.js";
 import { getHttpSecurityConfig } from "./http-security.js";
 import { parseSearxngUrls, redactSearxngInstanceUrl } from "./searxng-instances.js";
 
+export const REQUIRED_CONFIGURATION_GUIDANCE =
+  "SEARXNG_URL is the only required environment variable.";
+export const OPTIONAL_CONFIGURATION_GUIDANCE =
+  "All other environment variables are optional; see CONFIGURATION.md for the complete reference.";
+
+export function createCliHelpText(): string {
+  return `Usage: mcp-searxng [options]
+
+Options:
+  --help, -h       Show this help and exit
+  --version, -v    Print the package version and exit
+
+Configuration:
+  ${REQUIRED_CONFIGURATION_GUIDANCE}
+  ${OPTIONAL_CONFIGURATION_GUIDANCE}
+
+Transport:
+  STDIO is the default transport.
+  MCP_HTTP_PORT enables HTTP transport.
+`;
+}
+
 // SEARXNG_URL may embed Basic Auth credentials in its userinfo (the recommended
 // auth path) and may be a semicolon-separated multi-instance list. Redact the
 // userinfo from each entry before exposing it in the config resource so the host
@@ -127,10 +149,12 @@ Reads and converts web page content to Markdown format.
 ## Configuration
 
 ### Required Environment Variables
+${REQUIRED_CONFIGURATION_GUIDANCE}
 - \`SEARXNG_URL\`: URL of your SearXNG instance (e.g., http://localhost:8080). For Basic Auth, embed credentials in the URL (e.g., https://user:password@search.example.com); percent-encode special characters in the username or password (e.g. \`@\` as \`%40\`). Multi-instance lists can use different credentials per semicolon-separated URL.
 
 ### Optional Environment Variables
-Common ones are listed below. This is not exhaustive — see CONFIGURATION.md in the project repository for the full reference (failover/fan-out, caching, timeouts, result limits, per-tool proxies, TLS, HTTP transport, and hardening).
+${OPTIONAL_CONFIGURATION_GUIDANCE}
+Common ones are listed below (failover/fan-out, caching, timeouts, result limits, per-tool proxies, TLS, HTTP transport, and hardening).
 - \`AUTH_USERNAME\` & \`AUTH_PASSWORD\`: Legacy global Basic Auth fallback when \`SEARXNG_URL\` has no userinfo
 - \`HTTP_PROXY\` / \`HTTPS_PROXY\`: Proxy server configuration
 - \`NO_PROXY\` / \`no_proxy\`: Comma-separated list of hosts to bypass proxy

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -22,7 +22,7 @@ Configuration:
 Transport:
   STDIO is the default transport.
   MCP_HTTP_PORT enables HTTP transport.
-`;
+`.trimEnd();
 }
 
 // SEARXNG_URL may embed Basic Auth credentials in its userinfo (the recommended


### PR DESCRIPTION
## Summary
- handle `--help`/`-h` and `--version`/`-v` before MCP transport startup
- share required and optional configuration guidance with the MCP help resource
- verify all four flags against both the TypeScript source entry point and compiled npm bin target

## Verification
- focused CLI/resources/diagnostic suites (25/25)
- `npm run test:coverage` (576/576; 96.42% lines, 93.11% branches)
- `npm run build`
- `npm run lint`
- `npm run test:e2e` (11/11)
- `npm audit --audit-level=moderate` (0 vulnerabilities)
- `npm run verify:packed-consumer` (adapter 2.0.12, audit 0, tools 4)
- `git diff --check`