### PR TITLE
fix(logging): isolate MCP session thresholds

### DIFF
--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -795,6 +795,41 @@ async function runTests() {
     await client.close();
   }, results);
 
+  await testFunction('logging/setLevel and config resources stay isolated per server', async () => {
+    const first = await connectWithLogs();
+    const second = await connectWithLogs();
+
+    try {
+      await first.client.setLoggingLevel('debug');
+      await second.client.setLoggingLevel('error');
+      first.logs.length = 0;
+      second.logs.length = 0;
+
+      await first.client.listTools();
+      await second.client.listTools();
+
+      assert.ok(
+        first.logs.some((entry) => JSON.stringify(entry).includes('Handling list_tools request')),
+        JSON.stringify(first.logs),
+      );
+      assert.ok(
+        !second.logs.some((entry) => JSON.stringify(entry).includes('Handling list_tools request')),
+        JSON.stringify(second.logs),
+      );
+
+      const firstConfig = await first.client.readResource({ uri: 'config://server-config' });
+      const secondConfig = await second.client.readResource({ uri: 'config://server-config' });
+      const firstPayload = JSON.parse((firstConfig.contents[0] as { text: string }).text);
+      const secondPayload = JSON.parse((secondConfig.contents[0] as { text: string }).text);
+
+      assert.equal(firstPayload.environment.currentLogLevel, 'debug');
+      assert.equal(secondPayload.environment.currentLogLevel, 'error');
+    } finally {
+      await first.client.close();
+      await second.client.close();
+    }
+  }, results);
+
   // ── resources/list ───────────────────────────────────────────────────────────
 
   await testFunction('resources/list returns config and help resources', async () => {

--- a/__tests__/unit/logging.test.ts
+++ b/__tests__/unit/logging.test.ts
@@ -9,6 +9,7 @@
 import { strict as assert } from 'node:assert';
 import { fileURLToPath } from 'node:url';
 import { 
+  DEFAULT_LOG_LEVEL,
   logMessage, 
   shouldLog, 
   setLogLevel, 
@@ -22,26 +23,50 @@ import {
 } from '../../src/diagnostic-sanitizer.js';
 
 const results = createTestResults();
+const testServer = createMockServerWithTracking().server as any;
 
 async function runTests() {
   console.log('🧪 Testing: logging.ts\n');
 
+  await testFunction('Default log level is explicit and deterministic', () => {
+    const freshServer = createMockServerWithTracking().server;
+    assert.equal(DEFAULT_LOG_LEVEL, 'info');
+    assert.equal(getCurrentLogLevel(freshServer as any), DEFAULT_LOG_LEVEL);
+    assert.equal(getCurrentLogLevel(), DEFAULT_LOG_LEVEL);
+  }, results);
+
   await testFunction('Log level filtering', () => {
-    setLogLevel('error');
-    assert.equal(shouldLog('error'), true);
-    assert.equal(shouldLog('info'), false);
+    setLogLevel(testServer, 'error');
+    assert.equal(shouldLog(testServer, 'error'), true);
+    assert.equal(shouldLog(testServer, 'info'), false);
     
-    setLogLevel('debug');  
-    assert.equal(shouldLog('error'), true);
-    assert.equal(shouldLog('debug'), true);
+    setLogLevel(testServer, 'debug');
+    assert.equal(shouldLog(testServer, 'error'), true);
+    assert.equal(shouldLog(testServer, 'debug'), true);
   }, results);
 
   await testFunction('Get and set current log level', () => {
-    setLogLevel('warning');
-    assert.equal(getCurrentLogLevel(), 'warning');
+    setLogLevel(testServer, 'warning');
+    assert.equal(getCurrentLogLevel(testServer), 'warning');
     
-    setLogLevel('info');
-    assert.equal(getCurrentLogLevel(), 'info');
+    setLogLevel(testServer, 'info');
+    assert.equal(getCurrentLogLevel(testServer), 'info');
+  }, results);
+
+  await testFunction('Log levels are isolated by MCP server identity', () => {
+    const first = createMockServerWithTracking().server;
+    const second = createMockServerWithTracking().server;
+
+    assert.equal(getCurrentLogLevel(first as any), 'info');
+    assert.equal(getCurrentLogLevel(second as any), 'info');
+
+    setLogLevel(first as any, 'debug');
+    setLogLevel(second as any, 'error');
+
+    assert.equal(getCurrentLogLevel(first as any), 'debug');
+    assert.equal(getCurrentLogLevel(second as any), 'error');
+    assert.equal(shouldLog(first as any, 'debug'), true);
+    assert.equal(shouldLog(second as any, 'debug'), false);
   }, results);
 
   await testFunction('All log levels work correctly', () => {
@@ -57,9 +82,9 @@ async function runTests() {
     ] as const;
     
     for (const level of levels) {
-      setLogLevel(level);
+      setLogLevel(testServer, level);
       for (const testLevel of levels) {
-        const result = shouldLog(testLevel);
+        const result = shouldLog(testServer, testLevel);
         assert.equal(typeof result, 'boolean');
       }
     }
@@ -67,16 +92,16 @@ async function runTests() {
 
   await testFunction('RFC 5424 thresholds filter lower-severity messages', () => {
     try {
-      setLogLevel('notice');
-      assert.equal(shouldLog('info'), false);
-      assert.equal(shouldLog('notice'), true);
-      assert.equal(shouldLog('warning'), true);
+      setLogLevel(testServer, 'notice');
+      assert.equal(shouldLog(testServer, 'info'), false);
+      assert.equal(shouldLog(testServer, 'notice'), true);
+      assert.equal(shouldLog(testServer, 'warning'), true);
 
-      setLogLevel('emergency');
-      assert.equal(shouldLog('error'), false);
-      assert.equal(shouldLog('emergency'), true);
+      setLogLevel(testServer, 'emergency');
+      assert.equal(shouldLog(testServer, 'error'), false);
+      assert.equal(shouldLog(testServer, 'emergency'), true);
     } finally {
-      setLogLevel('info');
+      setLogLevel(testServer, 'info');
     }
   }, results);
 
@@ -84,7 +109,7 @@ async function runTests() {
     const { server, getLoggingCalls } = createMockServerWithTracking();
 
     // Test different log levels
-    setLogLevel('debug'); // Allow all messages
+    setLogLevel(server as any, 'debug'); // Allow all messages
     
     logMessage(server as any, 'info', 'Test info message');
     logMessage(server as any, 'warning', 'Test warning message');
@@ -102,7 +127,7 @@ async function runTests() {
       AUTH_PASSWORD: 'log-secret',
     });
     const { server, getLoggingCalls } = createMockServerWithTracking();
-    setLogLevel('debug');
+    setLogLevel(server as any, 'debug');
 
     logMessage(
       server as any,
@@ -119,7 +144,7 @@ async function runTests() {
     assert.ok(!serialized.includes('log-secret'), serialized);
     assert.ok(serialized.includes('[redacted]'), serialized);
     resetDiagnosticSanitizerForTests();
-    setLogLevel('info');
+    setLogLevel(server as any, 'info');
   }, results);
 
   await testFunction('logging-send failures sanitize errors before stderr output', async () => {
@@ -132,17 +157,18 @@ async function runTests() {
     const originalError = console.error;
     console.error = (...args: unknown[]) => calls.push(args);
     try {
-      setLogLevel('debug');
-      logMessage({
+      const server = {
         sendLoggingMessage: async () => {
           throw new Error('send failed for send-user:send-secret');
         },
-      } as any, 'error', 'safe');
+      } as any;
+      setLogLevel(server, 'debug');
+      logMessage(server, 'error', 'safe');
       await new Promise(resolve => setTimeout(resolve, 10));
     } finally {
       console.error = originalError;
       resetDiagnosticSanitizerForTests();
-      setLogLevel('info');
+      setLogLevel(testServer, 'info');
     }
 
     const output = calls.flat().map((value) => (
@@ -154,29 +180,29 @@ async function runTests() {
 
   await testFunction('shouldLog edge cases', () => {
     // Test with all combinations of log levels
-    setLogLevel('error');
-    assert.equal(shouldLog('error'), true);
-    assert.equal(shouldLog('warning'), false);
-    assert.equal(shouldLog('info'), false);
-    assert.equal(shouldLog('debug'), false);
+    setLogLevel(testServer, 'error');
+    assert.equal(shouldLog(testServer, 'error'), true);
+    assert.equal(shouldLog(testServer, 'warning'), false);
+    assert.equal(shouldLog(testServer, 'info'), false);
+    assert.equal(shouldLog(testServer, 'debug'), false);
     
-    setLogLevel('warning');
-    assert.equal(shouldLog('error'), true);
-    assert.equal(shouldLog('warning'), true);
-    assert.equal(shouldLog('info'), false);
-    assert.equal(shouldLog('debug'), false);
+    setLogLevel(testServer, 'warning');
+    assert.equal(shouldLog(testServer, 'error'), true);
+    assert.equal(shouldLog(testServer, 'warning'), true);
+    assert.equal(shouldLog(testServer, 'info'), false);
+    assert.equal(shouldLog(testServer, 'debug'), false);
     
-    setLogLevel('info');
-    assert.equal(shouldLog('error'), true);
-    assert.equal(shouldLog('warning'), true);
-    assert.equal(shouldLog('info'), true);
-    assert.equal(shouldLog('debug'), false);
+    setLogLevel(testServer, 'info');
+    assert.equal(shouldLog(testServer, 'error'), true);
+    assert.equal(shouldLog(testServer, 'warning'), true);
+    assert.equal(shouldLog(testServer, 'info'), true);
+    assert.equal(shouldLog(testServer, 'debug'), false);
     
-    setLogLevel('debug');
-    assert.equal(shouldLog('error'), true);
-    assert.equal(shouldLog('warning'), true);
-    assert.equal(shouldLog('info'), true);
-    assert.equal(shouldLog('debug'), true);
+    setLogLevel(testServer, 'debug');
+    assert.equal(shouldLog(testServer, 'error'), true);
+    assert.equal(shouldLog(testServer, 'warning'), true);
+    assert.equal(shouldLog(testServer, 'info'), true);
+    assert.equal(shouldLog(testServer, 'debug'), true);
   }, results);
 
   await testFunction('logMessage silently ignores async "Not connected" errors', async () => {
@@ -186,12 +212,12 @@ async function runTests() {
       }
     };
 
-    setLogLevel('debug');
+    setLogLevel(server as any, 'debug');
     // Should not throw
     logMessage(server as any, 'info', 'test message');
     // Wait for the async rejection to be handled
     await new Promise(resolve => setTimeout(resolve, 10));
-    setLogLevel('info');
+    setLogLevel(server as any, 'info');
   }, results);
 
   await testFunction('logMessage silently ignores sync "Not connected" errors', () => {
@@ -201,10 +227,10 @@ async function runTests() {
       }
     };
 
-    setLogLevel('debug');
+    setLogLevel(server as any, 'debug');
     // Should not throw
     logMessage(server as any, 'info', 'test message');
-    setLogLevel('info');
+    setLogLevel(server as any, 'info');
   }, results);
 
   await testFunction('logMessage logs non-"Not connected" async errors to console.error', async () => {
@@ -218,12 +244,12 @@ async function runTests() {
       }
     };
 
-    setLogLevel('debug');
+    setLogLevel(server as any, 'debug');
     logMessage(server as any, 'info', 'test message');
     await new Promise(resolve => setTimeout(resolve, 10));
 
     console.error = originalError;
-    setLogLevel('info');
+    setLogLevel(server as any, 'info');
     assert.ok(consoleErrors.length > 0, 'Expected console.error to be called');
   }, results);
 
@@ -238,11 +264,11 @@ async function runTests() {
       }
     };
 
-    setLogLevel('debug');
+    setLogLevel(server as any, 'debug');
     logMessage(server as any, 'info', 'test message');
 
     console.error = originalError;
-    setLogLevel('info');
+    setLogLevel(server as any, 'info');
     assert.ok(consoleErrors.length > 0, 'Expected console.error to be called');
   }, results);
 

--- a/__tests__/unit/resources.test.ts
+++ b/__tests__/unit/resources.test.ts
@@ -36,7 +36,7 @@ async function runTests() {
     // Check that config includes environment information
     assert.ok(parsed.environment);
     assert.ok(parsed.environment.searxngUrl || parsed.environment.hasOwnProperty('searxngUrl'));
-    assert.ok(parsed.environment.currentLogLevel || parsed.environment.hasOwnProperty('currentLogLevel'));
+    assert.equal(parsed.environment.currentLogLevel, 'info');
   }, results);
 
   await testFunction('createHelpResource returns markdown string', () => {

--- a/src/index.ts
+++ b/src/index.ts
@@ -275,7 +275,7 @@ export function createMcpServer(): McpServer {
   server.setRequestHandler(SetLevelRequestSchema, async (request) => {
     const { level } = request.params;
     logMessage(mcpServer, "info", `Setting log level to: ${level}`);
-    setLogLevel(level);
+    setLogLevel(mcpServer, level);
     return {};
   });
 
@@ -319,7 +319,7 @@ export function createMcpServer(): McpServer {
             {
               uri: uri,
               mimeType: "application/json",
-              text: createConfigResource()
+              text: createConfigResource(mcpServer)
             }
           ]
         };
@@ -401,7 +401,7 @@ export async function main() {
     
     // Log after connection is established
     logMessage(mcpServer, "info", `MCP SearXNG Server v${packageVersion} connected via STDIO`);
-    logMessage(mcpServer, "info", `Log level: ${getCurrentLogLevel()}`);
+    logMessage(mcpServer, "info", `Log level: ${getCurrentLogLevel(mcpServer)}`);
     logMessage(mcpServer, "info", `Environment: ${process.env.NODE_ENV || 'development'}`);
     const searxngInstances = getSearxngInstances();
     logMessage(

--- a/src/logging.ts
+++ b/src/logging.ts
@@ -7,8 +7,8 @@ import {
 } from "./diagnostic-sanitizer.js";
 import { writeDiagnostic } from "./diagnostic-output.js";
 
-// Logging state
-let currentLogLevel: LoggingLevel = "info";
+export const DEFAULT_LOG_LEVEL: LoggingLevel = "info";
+const logLevelsByServer = new WeakMap<McpServer, LoggingLevel>();
 
 const LOG_LEVELS: LoggingLevel[] = [
   "debug",
@@ -30,7 +30,7 @@ function handleSendError(error: unknown): void {
 
 // Logging helper function
 export function logMessage(mcpServer: McpServer, level: LoggingLevel, message: string, data?: unknown): void {
-  if (shouldLog(level)) {
+  if (shouldLog(mcpServer, level)) {
     try {
       const notificationData = data !== undefined
         ? (typeof data === 'object' && data !== null ? { message, ...data } : { message, data })
@@ -49,14 +49,16 @@ export function logMessage(mcpServer: McpServer, level: LoggingLevel, message: s
   }
 }
 
-export function shouldLog(level: LoggingLevel): boolean {
-  return LOG_LEVELS.indexOf(level) >= LOG_LEVELS.indexOf(currentLogLevel);
+export function shouldLog(mcpServer: McpServer, level: LoggingLevel): boolean {
+  return LOG_LEVELS.indexOf(level) >= LOG_LEVELS.indexOf(getCurrentLogLevel(mcpServer));
 }
 
-export function setLogLevel(level: LoggingLevel): void {
-  currentLogLevel = level;
+export function setLogLevel(mcpServer: McpServer, level: LoggingLevel): void {
+  logLevelsByServer.set(mcpServer, level);
 }
 
-export function getCurrentLogLevel(): LoggingLevel {
-  return currentLogLevel;
+export function getCurrentLogLevel(mcpServer?: McpServer): LoggingLevel {
+  return mcpServer === undefined
+    ? DEFAULT_LOG_LEVEL
+    : (logLevelsByServer.get(mcpServer) ?? DEFAULT_LOG_LEVEL);
 }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -1,3 +1,4 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { getCurrentLogLevel } from "./logging.js";
 import { packageVersion } from "./version.js";
 import { getHttpSecurityConfig } from "./http-security.js";
@@ -58,7 +59,7 @@ function hasConfiguredAuth(): boolean {
   });
 }
 
-export function createConfigResource() {
+export function createConfigResource(mcpServer?: McpServer) {
   const security = getHttpSecurityConfig();
   const showFullConfig = !security.harden || security.exposeFullConfig;
 
@@ -76,7 +77,7 @@ export function createConfigResource() {
       hasProxy: !!(process.env.HTTP_PROXY || process.env.HTTPS_PROXY || process.env.http_proxy || process.env.https_proxy),
       hasNoProxy: !!(process.env.NO_PROXY || process.env.no_proxy),
       nodeVersion: process.version,
-      currentLogLevel: getCurrentLogLevel()
+      currentLogLevel: getCurrentLogLevel(mcpServer)
     },
     capabilities: {
       tools: [


### PR DESCRIPTION
## Summary
- store logging thresholds per MCP server instead of in module-global state
- keep the explicit default at info while reporting each server's effective level
- verify independent clients cannot change each other's log filtering or config resource

## Verification
- focused logging, resources, MCP-handler, and HTTP-server suites
- npm run test:coverage (579/579; 96.42% lines, 93.01% branches)
- npm run build
- npm run lint
- npm run test:e2e (11/11)
- npm audit --audit-level=moderate (0 vulnerabilities)
- npm run verify:packed-consumer (adapter 2.0.12, audit 0, tools 4)
- git diff --check