### PR TITLE
fix(search): avoid caching empty results

### DIFF
--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -766,6 +766,80 @@ async function runTests() {
     searchCache.clear();
   }, results);
 
+  await testFunction('Zero-result text searches are fetched again instead of cached', async () => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://empty-cache-text.example.com');
+    const mockServer = createMockServer();
+    let fetchCount = 0;
+    fetchMocker.mock(async (url, options) => {
+      fetchCount++;
+      return createMockFetch({ json: { results: [] } })(url, options);
+    });
+
+    try {
+      const first = await performWebSearch(mockServer as any, 'empty text cache');
+      const second = await performWebSearch(mockServer as any, 'empty text cache');
+
+      assert.equal(fetchCount, 2);
+      assert.ok(first.includes('No results found'));
+      assert.ok(second.includes('No results found'));
+      assert.ok(!second.includes('_Cached result_'), second);
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+    }
+  }, results);
+
+  await testFunction('Zero-result JSON searches are fetched again instead of cached', async () => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://empty-cache-json.example.com');
+    const mockServer = createMockServer();
+    let fetchCount = 0;
+    fetchMocker.mock(async (url, options) => {
+      fetchCount++;
+      return createMockFetch({ json: { query: 'empty json cache', results: [] } })(url, options);
+    });
+
+    try {
+      const first = JSON.parse(await performWebSearch(
+        mockServer as any,
+        'empty json cache',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'json',
+      ));
+      const second = JSON.parse(await performWebSearch(
+        mockServer as any,
+        'empty json cache',
+        1,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'json',
+      ));
+
+      assert.equal(fetchCount, 2);
+      assert.deepEqual(first.results, []);
+      assert.deepEqual(second.results, []);
+      assert.equal(second.cached, undefined);
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+    }
+  }, results);
+
   await testFunction('Cached text search includes _Cached result_ suffix', async () => {
     searchCache.clear();
     envManager.set('SEARXNG_URL', 'https://cache-marker.example.com');

--- a/src/search.ts
+++ b/src/search.ts
@@ -793,7 +793,9 @@ export async function performWebSearch(
       ...(filters.validationWarning ? { warnings: [filters.validationWarning] } : {}),
       ...(includeProvenance ? { servedBy: redactedServedBy } : {}),
     }, null, 2);
-    searchCache.set("searxng_web_search", cacheArgs, result);
+    if (slicedResults.length > 0) {
+      searchCache.set("searxng_web_search", cacheArgs, result);
+    }
     return result;
   }
 
@@ -816,7 +818,6 @@ export async function performWebSearch(
     logMessage(mcpServer, "info", `No results found for query: "${query}"${filterNote}`);
     const noResultsMessage = createNoResultsMessage(query);
     const result = leadingSections ? `${leadingSections}\n\n---\n\n${noResultsMessage}` : noResultsMessage;
-    searchCache.set("searxng_web_search", cacheArgs, result);
     return result;
   }
 


### PR DESCRIPTION
## Summary
- skip search-cache writes for zero-result text responses
- skip search-cache writes for zero-result JSON responses
- verify identical empty searches fetch upstream again while positive caching stays unchanged

## Verification
- focused search suite (106/106)
- npm run test:coverage (581/581; 96.42% lines, 93.01% branches)
- build, lint, and test:e2e (11/11)
- audit (0 vulnerabilities)
- packed-consumer verification (adapter 2.0.12, audit 0, tools 4)
- git diff --check