### PR TITLE
docs: remove unsupported test watch command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -35,7 +35,6 @@ npm run build   # One-off build
 ```bash
 npm test                  # Run all tests
 npm run test:coverage     # Generate coverage report
-npm run test:watch        # Watch mode
 ```
 
 ## Submitting a PR

--- a/__tests__/README.md
+++ b/__tests__/README.md
@@ -9,7 +9,6 @@ Production-ready test suite for MCP SearXNG Server. Tests are organized into uni
 ```bash
 npm test                    # Run all tests
 npm run test:coverage       # Run with coverage report
-npm run test:watch          # Watch mode (auto-rerun)
 npx tsx __tests__/unit/logging.test.ts  # Run single test file
 ```
 


### PR DESCRIPTION
## Summary
- remove the nonexistent npm run test:watch command from CONTRIBUTING.md
- leave the supported test commands unchanged

## Verification
- every remaining documented npm run command exists in package.json
- stale test:watch reference is absent
- git diff --check