### PR TITLE
Clarify HTML fallback error behavior

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ If you must use a public instance you don't control and it rejects `format=json`
 A search that gets a `403`/`404` or a non-JSON response is then retried automatically **without** `format=json` and parsed from the regular HTML results page.
 
 - **On success:** you get normal results (title, URL, snippet). They are marked `sourceFormat: "html"` in JSON mode, and text mode adds the line *"Note: Results parsed from SearXNG HTML fallback; metadata is limited."* Relevance scores and engine names are not available from HTML.
-- **On failure:** parsing is best-effort and varies by the instance's theme/version, so some results may be missed or sparse. If the HTML page itself also fails — still blocked, rate-limited (`429`), auth (`401`), or `5xx` — the **original error is surfaced unchanged**. The fallback only triggers on `403`/`404`/non-JSON, never on auth or network errors.
+- **On failure:** parsing is best-effort and varies by the instance's theme/version, so some results may be missed or sparse. If the HTML page itself also fails — still blocked, rate-limited (`429`), auth (`401`), or `5xx` — the **fallback attempt's error is surfaced**, so the search never silently returns empty results. The fallback only triggers on `403`/`404`/non-JSON, never on auth or network errors.
 
 Enabling JSON on an instance you control (above) remains the recommended setup — the fallback is a compatibility aid, not a replacement.
 


### PR DESCRIPTION
## Summary
- describe failures using the HTML fallback attempt's error
- retain the guarantee that searches do not silently return empty results

## Verification
- confirmed the stale original-error claim is absent
- confirmed fallback trigger wording remains unchanged
- ran git diff --check