### PR TITLE
Reject fractional search page numbers

### DIFF
--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -36,6 +36,7 @@ async function runTests() {
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', language: 'en' }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test search' }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', pageno: 1, time_range: 'day' }), true);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', pageno: 2 }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', pageno: 1, time_range: 'week', safesearch: 2 }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: 0 }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', safesearch: 1 }), true);
@@ -61,6 +62,7 @@ async function runTests() {
   await testFunction('isSearXNGWebSearchArgs type guard - invalid optional parameters', () => {
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', pageno: 0 }), false);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', pageno: -1 }), false);
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test', pageno: 1.5 }), false);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', pageno: '1' }), false);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', time_range: 'last week' }), false);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', language: 123 }), false);
@@ -89,6 +91,8 @@ async function runTests() {
     assert.equal(properties.min_score.type, 'number');
     assert.equal(properties.min_score.minimum, 0);
     assert.equal(properties.min_score.maximum, 1);
+    assert.equal(properties.pageno.type, 'integer');
+    assert.equal(properties.pageno.minimum, 1);
     assert.equal(properties.num_results.type, 'number');
     assert.equal(properties.num_results.minimum, 1);
     assert.equal(properties.num_results.maximum, 20);

--- a/src/types.ts
+++ b/src/types.ts
@@ -68,7 +68,10 @@ export function isSearXNGWebSearchArgs(args: unknown): args is {
     response_format?: unknown;
   };
 
-  if (searchArgs.pageno !== undefined && (typeof searchArgs.pageno !== "number" || searchArgs.pageno < 1)) {
+  if (
+    searchArgs.pageno !== undefined &&
+    (typeof searchArgs.pageno !== "number" || !Number.isInteger(searchArgs.pageno) || searchArgs.pageno < 1)
+  ) {
     return false;
   }
   if (
@@ -196,8 +199,9 @@ export const WEB_SEARCH_TOOL: Tool = {
           "The search query string. This is the required parameter name — use exactly `query`, not `prompt` or `q`.",
       },
       pageno: {
-        type: "number",
+        type: "integer",
         description: "Search page number (starts at 1)",
+        minimum: 1,
         default: 1,
       },
       time_range: {


### PR DESCRIPTION
## Summary
- reject non-integer pageno values in the search argument guard
- retain valid positive integer page numbers

## Verification
- regression failed before the fix and passes after it
- 581 tests passed with coverage
- build, lint, audit, packed-consumer verification, and 11 live E2E scenarios passed
- git diff --check