### PR TITLE
Restore environment after every test case

### DIFF
--- a/__tests__/helpers/env-utils.ts
+++ b/__tests__/helpers/env-utils.ts
@@ -8,6 +8,36 @@ export interface EnvSnapshot {
   [key: string]: string | undefined;
 }
 
+export type ProcessEnvSnapshot = Record<string, string>;
+
+/**
+ * Snapshot the complete process environment for per-test isolation.
+ */
+export function snapshotProcessEnv(): ProcessEnvSnapshot {
+  const snapshot = Object.create(null) as ProcessEnvSnapshot;
+  for (const [key, value] of Object.entries(process.env)) {
+    if (value !== undefined) {
+      snapshot[key] = value;
+    }
+  }
+  return snapshot;
+}
+
+/**
+ * Restore the complete process environment, removing keys added after the snapshot.
+ */
+export function restoreProcessEnv(snapshot: ProcessEnvSnapshot): void {
+  for (const key of Object.keys(process.env)) {
+    if (!Object.hasOwn(snapshot, key)) {
+      delete process.env[key];
+    }
+  }
+
+  for (const [key, value] of Object.entries(snapshot)) {
+    process.env[key] = value;
+  }
+}
+
 /**
  * Save current environment variables
  */

--- a/__tests__/helpers/test-utils.ts
+++ b/__tests__/helpers/test-utils.ts
@@ -4,6 +4,8 @@
  * Shared utility functions for test suite
  */
 
+import { restoreProcessEnv, snapshotProcessEnv } from './env-utils.js';
+
 export interface TestResult {
   passed: number;
   failed: number;
@@ -25,6 +27,7 @@ export async function testFunction(
   results: TestResult
 ): Promise<void> {
   console.log(`Testing ${name}...`);
+  const environmentSnapshot = snapshotProcessEnv();
   try {
     const result = fn();
     if (result instanceof Promise) {
@@ -37,6 +40,8 @@ export async function testFunction(
     const errorMsg = `❌ ${name} failed: ${error.message}`;
     results.errors.push(errorMsg);
     console.log(errorMsg);
+  } finally {
+    restoreProcessEnv(environmentSnapshot);
   }
 }
 

--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -10,6 +10,7 @@ import { TestResult } from './helpers/test-utils.js';
 
 // Import all test suites
 import { runTests as runLoggingTests } from './unit/logging.test.js';
+import { runTests as runTestUtilsTests } from './unit/test-utils.test.js';
 import { runTests as runDiagnosticSanitizerTests } from './unit/diagnostic-sanitizer.test.js';
 import { runTests as runDiagnosticOutputTests } from './unit/diagnostic-output.test.js';
 import { runTests as runTypesTests } from './unit/types.test.js';
@@ -45,6 +46,7 @@ interface TestSuite {
 const testSuites: TestSuite[] = [
   // Unit Tests
   { name: 'Logging', category: 'unit', run: runLoggingTests },
+  { name: 'Test Utilities', category: 'unit', run: runTestUtilsTests },
   { name: 'Diagnostic Sanitizer', category: 'unit', run: runDiagnosticSanitizerTests },
   { name: 'Diagnostic Output', category: 'unit', run: runDiagnosticOutputTests },
   { name: 'Types', category: 'unit', run: runTypesTests },

--- a/__tests__/unit/test-utils.test.ts
+++ b/__tests__/unit/test-utils.test.ts
@@ -1,0 +1,82 @@
+#!/usr/bin/env tsx
+
+import { strict as assert } from 'node:assert';
+import { fileURLToPath } from 'node:url';
+import {
+  createTestResults,
+  printTestSummary,
+  testFunction,
+} from '../helpers/test-utils.js';
+import { snapshotProcessEnv } from '../helpers/env-utils.js';
+
+const results = createTestResults();
+const isolationKey = 'MCP_SEARXNG_TEST_ENV_ISOLATION';
+
+async function runTests() {
+  console.log('🧪 Testing: test-utils.ts\n');
+
+  await testFunction('testFunction restores process.env after callbacks pass or fail', async () => {
+    const originalValue = process.env[isolationKey];
+    const originalLog = console.log;
+    const nestedResults = createTestResults();
+
+    try {
+      delete process.env[isolationKey];
+      console.log = () => {};
+
+      await testFunction('intentional failure', () => {
+        process.env[isolationKey] = 'failed-test-value';
+        throw new Error('intentional harness failure');
+      }, nestedResults);
+
+      assert.equal(nestedResults.failed, 1);
+      assert.equal(process.env[isolationKey], undefined);
+
+      process.env[isolationKey] = 'baseline-value';
+      await testFunction('intentional success', () => {
+        process.env[isolationKey] = 'successful-test-value';
+      }, nestedResults);
+
+      assert.equal(nestedResults.passed, 1);
+      assert.equal(process.env[isolationKey], 'baseline-value');
+    } finally {
+      console.log = originalLog;
+      if (originalValue === undefined) {
+        delete process.env[isolationKey];
+      } else {
+        process.env[isolationKey] = originalValue;
+      }
+    }
+  }, results);
+
+  await testFunction('snapshotProcessEnv preserves prototype-like environment keys', () => {
+    const key = '__proto__';
+    const originalValue = process.env[key];
+
+    try {
+      process.env[key] = 'prototype-key-value';
+      const snapshot = snapshotProcessEnv();
+
+      assert.equal(Object.getPrototypeOf(snapshot), null);
+      assert.equal(Object.hasOwn(snapshot, key), true);
+      assert.equal(snapshot[key], 'prototype-key-value');
+    } finally {
+      if (originalValue === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = originalValue;
+      }
+    }
+  }, results);
+
+  printTestSummary(results, 'Test Utilities');
+  return results;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runTests().then((testResults) => {
+    process.exit(testResults.failed > 0 ? 1 : 0);
+  }).catch(console.error);
+}
+
+export { runTests };


### PR DESCRIPTION
## Summary
- snapshot process.env before every test callback
- restore changed and added variables in a finally block after success or failure
- add a regression covering deliberate failure and successful mutation without mass-editing existing tests

## Verification
- regression failed before the fix and passes after it
- 582 tests passed with coverage
- build, lint, audit, packed-consumer verification, and 11 live E2E scenarios passed
- git diff --check