### PR TITLE
Add MCP client configuration cookbook

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,9 @@ Add to your MCP client configuration (e.g. `claude_desktop_config.json`):
 
 Replace `YOUR_SEARXNG_INSTANCE_URL` with the URL of your SearXNG instance (e.g. `https://searxng.example.com`). You can also provide interchangeable replicas as a semicolon-separated list, e.g. `https://one.example.com;https://two.example.com`.
 
-For verified Claude, Codex, Cursor, VS Code, Windsurf, Cline, and OpenCode
-recipes, see the [MCP client configuration cookbook](docs/client-configurations.md).
+For verified Claude Desktop, Claude Code, Codex CLI, Cursor, VS Code, Windsurf,
+Cline, and OpenCode recipes, see the
+[MCP client configuration cookbook](docs/client-configurations.md).
 
 ## Features
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,9 @@ Add to your MCP client configuration (e.g. `claude_desktop_config.json`):
 
 Replace `YOUR_SEARXNG_INSTANCE_URL` with the URL of your SearXNG instance (e.g. `https://searxng.example.com`). You can also provide interchangeable replicas as a semicolon-separated list, e.g. `https://one.example.com;https://two.example.com`.
 
+For verified Claude, Codex, Cursor, VS Code, Windsurf, Cline, and OpenCode
+recipes, see the [MCP client configuration cookbook](docs/client-configurations.md).
+
 ## Features
 
 - **Web Search**: General, news, and article queries with pagination, time-range/language/safe-search filters, relevance filtering (`min_score`), and formatted-text or raw-JSON output (`response_format`).

--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -30,6 +30,7 @@ import { runTests as runHttpServerUnitTests } from './unit/http-server.test.js';
 import { runTests as runVersionTests } from './unit/version.test.js';
 import { runTests as runHttpSecurityTests } from './unit/http-security.test.js';
 import { runTests as runPackedConsumerTests } from './unit/packed-consumer.test.js';
+import { runTests as runDocumentationTests } from './unit/documentation.test.js';
 import { runTests as runFuzzTests } from './fuzz/search-params.fuzz.js';
 import { runTests as runHttpServerTests } from './integration/http-server.test.js';
 import { runTests as runIndexTests } from './integration/index.test.js';
@@ -66,6 +67,7 @@ const testSuites: TestSuite[] = [
   { name: 'Version', category: 'unit', run: runVersionTests },
   { name: 'HTTP Security', category: 'unit', run: runHttpSecurityTests },
   { name: 'Packed Consumer Verification', category: 'unit', run: runPackedConsumerTests },
+  { name: 'Documentation', category: 'unit', run: runDocumentationTests },
   { name: 'Fuzz Properties', category: 'unit', run: runFuzzTests },
 
   // Integration Tests

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -1,0 +1,193 @@
+#!/usr/bin/env tsx
+
+/**
+ * Unit Tests: client configuration cookbook
+ *
+ * Keeps copyable client examples aligned with the current server contract.
+ */
+
+import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
+import { createTestResults, printTestSummary, TestResult, testFunction } from '../helpers/test-utils.js';
+
+const results = createTestResults();
+const guideUrl = new URL('../../docs/client-configurations.md', import.meta.url);
+
+const expectedMatrixRows = [
+  '| Claude Desktop | Yes | Yes | No |',
+  '| Claude Code | Yes | Yes | Yes |',
+  '| Codex CLI | Yes | Yes | Yes |',
+  '| Cursor | Yes | Yes | No |',
+  '| VS Code | Yes | Yes | Yes |',
+  '| Windsurf | Yes | Yes | Yes |',
+  '| Cline | Yes | Yes | Yes |',
+  '| OpenCode | Yes | Yes | Yes |',
+];
+
+const expectedTools = [
+  'searxng_web_search',
+  'searxng_search_suggestions',
+  'searxng_instance_info',
+  'web_url_read',
+];
+
+function readText(url: URL): string {
+  // eslint-disable-next-line security/detect-non-literal-fs-filename -- all callers pass compile-time repository URLs
+  return readFileSync(url, 'utf-8');
+}
+
+function extractFences(markdown: string, language: string): string[] {
+  const blocks: string[] = [];
+  let active: string[] | null = null;
+
+  for (const line of markdown.split(/\r?\n/u)) {
+    if (active === null && line.trim() === `\`\`\`${language}`) {
+      active = [];
+    } else if (active !== null && line.trim() === '```') {
+      blocks.push(active.join('\n'));
+      active = null;
+    } else if (active !== null) {
+      active.push(line);
+    }
+  }
+
+  assert.equal(active, null, `unclosed ${language} fence`);
+  return blocks;
+}
+
+function parseTomlSubset(source: string): void {
+  let hasSection = false;
+  const allowedNameCharacters = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789_.-';
+
+  for (const rawLine of source.split(/\r?\n/u)) {
+    const line = rawLine.trim();
+    if (line === '' || line.startsWith('#')) continue;
+
+    if (line.startsWith('[') && line.endsWith(']')) {
+      const name = line.slice(1, -1);
+      assert.ok(name.length > 0);
+      assert.ok([...name].every((character) => allowedNameCharacters.includes(character)));
+      hasSection = true;
+      continue;
+    }
+
+    const separator = line.indexOf('=');
+    assert.ok(separator > 0, `missing TOML assignment: ${line}`);
+    const key = line.slice(0, separator).trim();
+    const value = line.slice(separator + 1).trim();
+    assert.ok([...key].every((character) => allowedNameCharacters.includes(character)));
+    const parsed = JSON.parse(value);
+    assert.ok(typeof parsed === 'string' || (
+      Array.isArray(parsed) && parsed.every((entry) => typeof entry === 'string')
+    ), `unsupported TOML value: ${value}`);
+  }
+
+  assert.ok(hasSection, 'each TOML example must contain a table');
+}
+
+function collectJsonServers(config: Record<string, unknown>): Record<string, unknown>[] {
+  const roots = [
+    config.mcpServers,
+    config.servers,
+    (config.mcp as Record<string, unknown> | undefined)?.servers,
+  ];
+
+  return roots.flatMap((root) => (
+    root && typeof root === 'object'
+      ? Object.values(root as Record<string, unknown>)
+          .filter((entry): entry is Record<string, unknown> => Boolean(entry) && typeof entry === 'object')
+      : []
+  ));
+}
+
+export async function runTests(): Promise<TestResult> {
+  console.log('Testing: client configuration cookbook\n');
+
+  await testFunction('cookbook exists and README links to it', () => {
+    const guide = readText(guideUrl);
+    const readme = readText(new URL('../../README.md', import.meta.url));
+    assert.ok(guide.startsWith('# MCP Client Configuration Cookbook'));
+    assert.ok(readme.includes('(docs/client-configurations.md)'));
+  }, results);
+
+  await testFunction('support matrix contains only verified client and transport combinations', () => {
+    const guide = readText(guideUrl);
+    for (const row of expectedMatrixRows) {
+      assert.ok(guide.includes(row), `missing matrix row: ${row}`);
+    }
+    assert.equal((guide.match(/^\| (?:Claude Desktop|Claude Code|Codex CLI|Cursor|VS Code|Windsurf|Cline|OpenCode) \|/gmu) ?? []).length, 8);
+  }, results);
+
+  await testFunction('every JSON and TOML configuration snippet parses', () => {
+    const guide = readText(guideUrl);
+    const jsonBlocks = extractFences(guide, 'json');
+    const tomlBlocks = extractFences(guide, 'toml');
+    assert.ok(jsonBlocks.length >= 6, 'expected client JSON examples');
+    assert.ok(tomlBlocks.length >= 2, 'expected Codex TOML examples');
+    for (const block of jsonBlocks) JSON.parse(block);
+    for (const block of tomlBlocks) parseTomlSubset(block);
+  }, results);
+
+  await testFunction('local examples use current NPX and Docker launch contracts', () => {
+    const guide = readText(guideUrl);
+    const servers = extractFences(guide, 'json')
+      .flatMap((block) => collectJsonServers(JSON.parse(block) as Record<string, unknown>));
+
+    const localServers = servers.filter((server) => (
+      typeof server.command === 'string' || Array.isArray(server.command)
+    ));
+    assert.ok(localServers.some((server) => server.command === 'npx'));
+    assert.ok(localServers.some((server) => server.command === 'docker'));
+    assert.ok(localServers.some((server) => Array.isArray(server.command) && server.command[0] === 'npx'));
+    assert.ok(localServers.some((server) => Array.isArray(server.command) && server.command[0] === 'docker'));
+
+    for (const server of localServers) {
+      const command = Array.isArray(server.command)
+        ? server.command
+        : [server.command, ...(server.args as unknown[])];
+      if (command[0] === 'npx') {
+        assert.deepEqual(command, ['npx', '-y', 'mcp-searxng']);
+      } else if (command[0] === 'docker') {
+        assert.deepEqual(command, [
+          'docker',
+          'run', '-i', '--rm',
+          '-e', 'SEARXNG_URL',
+          'isokoliuk/mcp-searxng:latest',
+        ]);
+      }
+    }
+
+    assert.ok(guide.includes('SEARXNG_URL'));
+  }, results);
+
+  await testFunction('remote examples use the current endpoint and bearer header contract', () => {
+    const guide = readText(guideUrl);
+    const servers = extractFences(guide, 'json')
+      .flatMap((block) => collectJsonServers(JSON.parse(block) as Record<string, unknown>));
+    const remoteServers = servers.filter((server) => typeof server.url === 'string' || typeof server.serverUrl === 'string');
+    assert.ok(remoteServers.length >= 4, 'expected verified HTTP client examples');
+    for (const server of remoteServers) {
+      const url = String(server.url ?? server.serverUrl);
+      assert.ok(url.endsWith('/mcp'), `remote MCP URL must end in /mcp: ${url}`);
+      const headers = server.headers as Record<string, unknown> | undefined;
+      assert.ok(headers?.Authorization, 'authenticated remote examples must show Authorization handling');
+    }
+    assert.ok(guide.includes('MCP_HTTP_AUTH_TOKEN'));
+    assert.ok(guide.includes('MCP_HTTP_ALLOWED_ORIGINS'));
+    assert.ok(guide.includes('MCP_HTTP_ALLOWED_HOSTS'));
+  }, results);
+
+  await testFunction('verification checklist names all current tools', () => {
+    const guide = readText(guideUrl);
+    const types = readText(new URL('../../src/types.ts', import.meta.url));
+    for (const tool of expectedTools) {
+      assert.ok(guide.includes(`\`${tool}\``), `guide must name ${tool}`);
+      assert.ok(types.includes(`name: "${tool}"`), `source must still expose ${tool}`);
+    }
+  }, results);
+
+  printTestSummary(results, 'Client Configuration Cookbook');
+  return results;
+}
+
+runTests();

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -193,5 +193,7 @@ export async function runTests(): Promise<TestResult> {
 }
 
 if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
-  runTests();
+  runTests().then((testResults) => {
+    process.exit(testResults.failed > 0 ? 1 : 0);
+  }).catch(console.error);
 }

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -8,10 +8,12 @@
 
 import { strict as assert } from 'node:assert';
 import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
 import { createTestResults, printTestSummary, TestResult, testFunction } from '../helpers/test-utils.js';
 
 const results = createTestResults();
 const guideUrl = new URL('../../docs/client-configurations.md', import.meta.url);
+const markdownFence = String.fromCharCode(96).repeat(3);
 
 const expectedMatrixRows = [
   '| Claude Desktop | Yes | Yes | No |',
@@ -41,9 +43,9 @@ function extractFences(markdown: string, language: string): string[] {
   let active: string[] | null = null;
 
   for (const line of markdown.split(/\r?\n/u)) {
-    if (active === null && line.trim() === `\`\`\`${language}`) {
+    if (active === null && line.trim() === markdownFence + language) {
       active = [];
-    } else if (active !== null && line.trim() === '```') {
+    } else if (active !== null && line.trim() === markdownFence) {
       blocks.push(active.join('\n'));
       active = null;
     } else if (active !== null) {
@@ -190,4 +192,6 @@ export async function runTests(): Promise<TestResult> {
   return results;
 }
 
-runTests();
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runTests();
+}

--- a/docs/client-configurations.md
+++ b/docs/client-configurations.md
@@ -31,7 +31,7 @@ that the client can never support it.
 | Cline | Yes | Yes | Yes |
 | OpenCode | Yes | Yes | Yes |
 
-Claude Desktop remote connectors accept authless or OAuth servers, but a
+Claude Desktop remote connectors accept unauthenticated or OAuth servers, but a
 network-exposed `mcp-searxng` server uses its own static bearer-token hardening.
 Cursor's current remote MCP documentation likewise specifies OAuth. Because
 `mcp-searxng` does not implement MCP OAuth, this cookbook keeps both clients on

--- a/docs/client-configurations.md
+++ b/docs/client-configurations.md
@@ -299,8 +299,9 @@ The empty `autoApprove` list keeps tool calls subject to normal approval.
 
 ## OpenCode
 
-OpenCode V2 stores servers under `mcp.servers` in `opencode.json`. Keep one
-local entry.
+OpenCode V2 stores servers under `mcp.servers` in `opencode.json`. Keep either
+the `searxng` NPX entry or the `searxng-docker` entry and remove the one you do
+not use.
 
 ```json
 {

--- a/docs/client-configurations.md
+++ b/docs/client-configurations.md
@@ -1,0 +1,401 @@
+# MCP Client Configuration Cookbook
+
+This guide connects supported MCP clients to an already selected SearXNG
+endpoint through `mcp-searxng`. It does not discover or install SearXNG, bundle
+SearXNG with this server, or install `mcp-searxng` as a client plugin.
+
+Choose one connection mode:
+
+- **NPX/STDIO:** the client starts the npm package locally. Requires Node.js 20
+  or newer.
+- **Docker/STDIO:** the client starts the published container locally. Requires
+  Docker.
+- **HTTP:** the client connects to an independently running Streamable HTTP
+  server. The server operator, not the client configuration, sets
+  `SEARXNG_URL`.
+
+## Verified support matrix
+
+The matrix reflects the current authoritative client schemas linked below. A
+`No` means this cookbook deliberately omits that combination; it does not claim
+that the client can never support it.
+
+| Client | NPX/STDIO | Docker/STDIO | HTTP |
+| --- | --- | --- | --- |
+| Claude Desktop | Yes | Yes | No |
+| Claude Code | Yes | Yes | Yes |
+| Codex CLI | Yes | Yes | Yes |
+| Cursor | Yes | Yes | No |
+| VS Code | Yes | Yes | Yes |
+| Windsurf | Yes | Yes | Yes |
+| Cline | Yes | Yes | Yes |
+| OpenCode | Yes | Yes | Yes |
+
+Claude Desktop remote connectors accept authless or OAuth servers, but a
+network-exposed `mcp-searxng` server uses its own static bearer-token hardening.
+Cursor's current remote MCP documentation likewise specifies OAuth. Because
+`mcp-searxng` does not implement MCP OAuth, this cookbook keeps both clients on
+local STDIO instead of recommending a weaker remote deployment.
+
+## Values used below
+
+Replace these placeholders:
+
+- `https://search.example.com` — your SearXNG base URL. For local STDIO
+  examples, the MCP client passes it as `SEARXNG_URL`.
+- `https://mcp.example.com/mcp` — the complete MCP HTTP endpoint, including
+  `/mcp`.
+- `MCP_SEARXNG_TOKEN` — a client-side environment variable containing the same
+  secret that the HTTP server uses as `MCP_HTTP_AUTH_TOKEN`.
+
+For multiple interchangeable SearXNG replicas, set `SEARXNG_URL` to a
+semicolon-separated list. See [Configuration](../CONFIGURATION.md) before
+adding authentication, fan-out, proxies, or TLS settings.
+
+## Shared local JSON configuration
+
+The local server objects below work in Claude Desktop, Cursor, Windsurf, and
+Cline because all four use a top-level `mcpServers` object. Keep either the NPX
+entry or the Docker entry.
+
+```json
+{
+  "mcpServers": {
+    "searxng": {
+      "command": "npx",
+      "args": ["-y", "mcp-searxng"],
+      "env": {
+        "SEARXNG_URL": "https://search.example.com"
+      }
+    },
+    "searxng-docker": {
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "SEARXNG_URL",
+        "isokoliuk/mcp-searxng:latest"
+      ],
+      "env": {
+        "SEARXNG_URL": "https://search.example.com"
+      }
+    }
+  }
+}
+```
+
+Do not add Docker's detached (`-d`) or TTY (`-t`) flags. The MCP client needs
+the container's raw standard input and output.
+
+### Claude Desktop
+
+Open **Settings → Developer → Edit Config**, add one shared local entry, save,
+and restart Claude Desktop. Remote servers are added through Claude's
+Connectors UI rather than `claude_desktop_config.json`; no compatible hardened
+HTTP recipe is claimed here. See Anthropic's
+[local MCP](https://support.anthropic.com/en/articles/10949351-getting-started-with-local-mcp-servers-on-claude-desktop)
+and [remote connector](https://support.anthropic.com/en/articles/11503834-building-custom-connectors-via-remote-mcp-servers)
+documentation.
+
+### Cursor
+
+Put one shared local entry in `.cursor/mcp.json` for a project or
+`~/.cursor/mcp.json` for all projects. Cursor documents STDIO plus remote
+OAuth; this guide uses STDIO because the server's hardened HTTP mode is static
+bearer authentication. See the
+[Cursor MCP documentation](https://docs.cursor.com/context/model-context-protocol).
+
+### Windsurf
+
+Put one shared local entry in `~/.codeium/windsurf/mcp_config.json`. For HTTP,
+use the separate Windsurf recipe below. See the
+[Windsurf MCP documentation](https://docs.windsurf.com/windsurf/cascade/mcp).
+
+### Cline
+
+For Cline CLI, put one shared local entry in `~/.cline/mcp.json`. In the IDE,
+open **MCP Servers → Configure → Configure MCP Servers** and add it to the
+opened `mcpServers` object. See the
+[Cline MCP documentation](https://docs.cline.bot/mcp/mcp-overview).
+
+## Claude Code
+
+Claude Code supports STDIO commands and Streamable HTTP through `claude mcp`.
+These commands use user scope; change it if you want project-local
+configuration.
+
+NPX/STDIO:
+
+```bash
+claude mcp add --scope user --env SEARXNG_URL=https://search.example.com --transport stdio searxng -- npx -y mcp-searxng
+```
+
+Docker/STDIO:
+
+```bash
+claude mcp add --scope user --env SEARXNG_URL=https://search.example.com --transport stdio searxng-docker -- docker run -i --rm -e SEARXNG_URL isokoliuk/mcp-searxng:latest
+```
+
+HTTP on POSIX shells:
+
+```bash
+claude mcp add --scope user --transport http searxng-http https://mcp.example.com/mcp --header "Authorization: Bearer ${MCP_SEARXNG_TOKEN}"
+```
+
+HTTP in PowerShell:
+
+```powershell
+claude mcp add --scope user --transport http searxng-http https://mcp.example.com/mcp --header "Authorization: Bearer $env:MCP_SEARXNG_TOKEN"
+```
+
+The shell expands the token before Claude Code stores the configuration.
+Protect the resulting user configuration file. Run `claude mcp get searxng`
+or `claude mcp get searxng-http`, then `/mcp` inside Claude Code to check the
+connection. See the
+[Claude Code MCP documentation](https://code.claude.com/docs/en/mcp).
+
+## Codex CLI
+
+Add one local table or the HTTP table to `~/.codex/config.toml` (on Windows,
+`%USERPROFILE%\.codex\config.toml`). The TOML shape is the same on every
+platform.
+
+NPX/STDIO:
+
+```toml
+[mcp_servers.searxng]
+command = "npx"
+args = ["-y", "mcp-searxng"]
+
+[mcp_servers.searxng.env]
+SEARXNG_URL = "https://search.example.com"
+```
+
+Docker/STDIO:
+
+```toml
+[mcp_servers.searxng_docker]
+command = "docker"
+args = ["run", "-i", "--rm", "-e", "SEARXNG_URL", "isokoliuk/mcp-searxng:latest"]
+
+[mcp_servers.searxng_docker.env]
+SEARXNG_URL = "https://search.example.com"
+```
+
+HTTP:
+
+```toml
+[mcp_servers.searxng_http]
+url = "https://mcp.example.com/mcp"
+bearer_token_env_var = "MCP_SEARXNG_TOKEN"
+```
+
+Codex reads the bearer token from the named environment variable instead of
+the TOML file. Run `codex mcp list` to inspect the configured servers. See the
+[Codex MCP documentation](https://developers.openai.com/codex/mcp).
+
+## VS Code
+
+Put the configuration in `.vscode/mcp.json` for a workspace, or run
+**MCP: Open User Configuration** for a user-level file. Keep either local
+entry.
+
+```json
+{
+  "servers": {
+    "searxng": {
+      "type": "stdio",
+      "command": "npx",
+      "args": ["-y", "mcp-searxng"],
+      "env": {
+        "SEARXNG_URL": "https://search.example.com"
+      }
+    },
+    "searxng-docker": {
+      "type": "stdio",
+      "command": "docker",
+      "args": [
+        "run", "-i", "--rm",
+        "-e", "SEARXNG_URL",
+        "isokoliuk/mcp-searxng:latest"
+      ],
+      "env": {
+        "SEARXNG_URL": "https://search.example.com"
+      }
+    }
+  }
+}
+```
+
+For hardened HTTP, use a password input so the token is not committed:
+
+```json
+{
+  "inputs": [
+    {
+      "id": "searxng-token",
+      "type": "promptString",
+      "description": "mcp-searxng bearer token",
+      "password": true
+    }
+  ],
+  "servers": {
+    "searxng-http": {
+      "type": "http",
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${input:searxng-token}"
+      }
+    }
+  }
+}
+```
+
+Run **MCP: List Servers** to start or inspect the server. See the
+[VS Code MCP configuration reference](https://code.visualstudio.com/docs/agents/reference/mcp-configuration).
+
+## Windsurf HTTP
+
+Windsurf interpolates environment variables in `serverUrl` and `headers`.
+Export `MCP_SEARXNG_TOKEN` before launching Windsurf:
+
+```json
+{
+  "mcpServers": {
+    "searxng-http": {
+      "serverUrl": "https://mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer ${env:MCP_SEARXNG_TOKEN}"
+      }
+    }
+  }
+}
+```
+
+Open Cascade's MCP settings to reload the server and inspect its tools.
+
+## Cline HTTP
+
+Cline supports Streamable HTTP through `type: "streamableHttp"`. Its current
+manual example uses a literal header value, so replace the placeholder locally
+and protect the configuration file; do not commit it.
+
+```json
+{
+  "mcpServers": {
+    "searxng-http": {
+      "type": "streamableHttp",
+      "url": "https://mcp.example.com/mcp",
+      "headers": {
+        "Authorization": "Bearer REPLACE_WITH_TOKEN"
+      },
+      "disabled": false,
+      "autoApprove": []
+    }
+  }
+}
+```
+
+The empty `autoApprove` list keeps tool calls subject to normal approval.
+
+## OpenCode
+
+OpenCode V2 stores servers under `mcp.servers` in `opencode.json`. Keep one
+local entry.
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "servers": {
+      "searxng": {
+        "type": "local",
+        "command": ["npx", "-y", "mcp-searxng"],
+        "environment": {
+          "SEARXNG_URL": "https://search.example.com"
+        }
+      },
+      "searxng-docker": {
+        "type": "local",
+        "command": [
+          "docker",
+          "run", "-i", "--rm",
+          "-e", "SEARXNG_URL",
+          "isokoliuk/mcp-searxng:latest"
+        ],
+        "environment": {
+          "SEARXNG_URL": "https://search.example.com"
+        }
+      }
+    }
+  }
+}
+```
+
+For hardened HTTP, disable OAuth and read the static token from the environment:
+
+```json
+{
+  "$schema": "https://opencode.ai/config.json",
+  "mcp": {
+    "servers": {
+      "searxng-http": {
+        "type": "remote",
+        "url": "https://mcp.example.com/mcp",
+        "oauth": false,
+        "headers": {
+          "Authorization": "Bearer {env:MCP_SEARXNG_TOKEN}"
+        }
+      }
+    }
+  }
+}
+```
+
+Run `opencode2 mcp list` for the V2 CLI. See the
+[OpenCode V2 MCP documentation](https://opencode.ai/v2/docs/mcp-servers).
+
+## Start an HTTP server first
+
+HTTP client entries do not start `mcp-searxng`. Deploy it separately and use
+TLS before connecting across a network. A Docker example is:
+
+```bash
+docker run --rm -p 3000:3000 \
+  -e MCP_HTTP_PORT=3000 \
+  -e MCP_HTTP_HOST=0.0.0.0 \
+  -e MCP_HTTP_HARDEN=true \
+  -e MCP_HTTP_AUTH_TOKEN \
+  -e MCP_HTTP_ALLOWED_ORIGINS=https://client.example.com \
+  -e MCP_HTTP_ALLOWED_HOSTS=mcp.example.com \
+  -e SEARXNG_URL \
+  isokoliuk/mcp-searxng:latest
+```
+
+Set `MCP_HTTP_AUTH_TOKEN`, `MCP_SEARXNG_TOKEN`, and `SEARXNG_URL` in the
+operator environment before starting the container. Replace
+`https://client.example.com` with any browser client origin you intentionally
+allow and `mcp.example.com` with the exact `Host` header forwarded by the
+reverse proxy. Native clients that omit `Origin` are not granted browser CORS
+access by this list. For reverse proxies, allowed hosts, origins, and rate-limit
+behavior, follow
+[Hardened HTTP Mode](../CONFIGURATION.md#hardened-http-mode) and the
+[security deployment recommendations](../SECURITY.md#deployment-recommendations).
+
+## Verify the connection
+
+After saving the client configuration:
+
+1. Restart or reload the MCP server in the client.
+2. Confirm exactly these four tools are visible:
+   - `searxng_web_search`
+   - `searxng_search_suggestions`
+   - `searxng_instance_info`
+   - `web_url_read`
+3. Call `searxng_instance_info` to confirm the selected SearXNG endpoint is
+   reachable.
+4. Call `searxng_web_search` with `{"query":"SearXNG"}`.
+
+If the server does not appear, inspect the client's MCP log first. For STDIO,
+the most common causes are a missing executable, a Docker TTY/detached flag, or
+an absent `SEARXNG_URL`. For HTTP, verify the full `/mcp` URL, TLS, and that the
+client token matches `MCP_HTTP_AUTH_TOKEN`.

--- a/docs/client-configurations.md
+++ b/docs/client-configurations.md
@@ -372,8 +372,9 @@ docker run --rm -p 3000:3000 \
   isokoliuk/mcp-searxng:latest
 ```
 
-Set `MCP_HTTP_AUTH_TOKEN`, `MCP_SEARXNG_TOKEN`, and `SEARXNG_URL` in the
-operator environment before starting the container. Replace
+Set `MCP_HTTP_AUTH_TOKEN` and `SEARXNG_URL` in the operator environment before
+starting the container. In each client environment, set `MCP_SEARXNG_TOKEN` to
+the same value as `MCP_HTTP_AUTH_TOKEN`. Replace
 `https://client.example.com` with any browser client origin you intentionally
 allow and `mcp.example.com` with the exact `Host` header forwarded by the
 reverse proxy. Native clients that omit `Origin` are not granted browser CORS


### PR DESCRIPTION
## Summary

- add a verified support matrix and copyable NPX, Docker, and HTTP recipes for eight MCP clients
- document each client's configuration location and bearer-token handling without claiming unsupported combinations
- add a documentation contract test that parses all JSON/TOML examples and keeps launch arguments, transport settings, tool names, and README navigation current

## Validation

- `npm run lint` (Docker)
- `npm run test:coverage` (Docker): 595/595 passed; 96.41% lines, 92.95% branches
- `npm run test:e2e` (Docker): 2/2 local scenarios passed

Live SearXNG tests were not required because this change documents client configuration schemas and existing transport wiring; it does not change or claim live search behavior.