### PR TITLE
docs: add measured MCP deployment profiles

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -15,6 +15,8 @@ With `SEARXNG_FANOUT=true`, all healthy instances are queried in parallel. Resul
 
 For SearXNG setup, direct verification, and replica troubleshooting, see
 [Operating Self-Hosted SearXNG with mcp-searxng](docs/self-hosted-searxng.md).
+For MCP-process capacity planning and optional Docker limits, see the
+[measured deployment profiles](docs/deployment-profiles.md).
 
 ## Authentication
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ For a bounded, client-neutral method to search, inspect sources, cross-check
 claims, and cite evidence, see the
 [evidence-focused research workflow](docs/research-workflow.md).
 
+For measured MCP-process CPU and memory starting points, see
+[measured deployment profiles](docs/deployment-profiles.md).
+
 ## Features
 
 - **Web Search**: General, news, and article queries with pagination, time-range/language/safe-search filters, relevance filtering (`min_score`), and formatted-text or raw-JSON output (`response_format`).

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -14,6 +14,8 @@ import { createTestResults, printTestSummary, TestResult, testFunction } from '.
 const results = createTestResults();
 const guideUrl = new URL('../../docs/client-configurations.md', import.meta.url);
 const researchGuideUrl = new URL('../../docs/research-workflow.md', import.meta.url);
+const deploymentGuideUrl = new URL('../../docs/deployment-profiles.md', import.meta.url);
+const resourceOverlayUrl = new URL('../../docker-compose.resources.yml', import.meta.url);
 const markdownFence = String.fromCharCode(96).repeat(3);
 
 const expectedMatrixRows = [
@@ -242,6 +244,64 @@ export async function runTests(): Promise<TestResult> {
     ]) {
       assert.ok(!guide.includes(unsupportedPromise), `workflow must not promise: ${unsupportedPromise}`);
     }
+  }, results);
+
+  await testFunction('deployment profiles exist and public navigation links to them', () => {
+    const guide = readText(deploymentGuideUrl);
+    const readme = readText(new URL('../../README.md', import.meta.url));
+    const configuration = readText(new URL('../../CONFIGURATION.md', import.meta.url));
+    const compose = readText(new URL('../../docker-compose.yml', import.meta.url));
+    assert.ok(guide.startsWith('# Measured MCP Deployment Profiles'));
+    assert.ok(readme.includes('(docs/deployment-profiles.md)'));
+    assert.ok(configuration.includes('(docs/deployment-profiles.md)'));
+    assert.ok(compose.includes('docs/deployment-profiles.md'));
+  }, results);
+
+  await testFunction('deployment measurements are traceable and recommendations remain bounded', () => {
+    const guide = readText(deploymentGuideUrl);
+    const normalizedGuide = guide.replace(/\s+/gu, ' ');
+    for (const evidence of [
+      '2026-07-29',
+      'Node 24.18.0',
+      'Docker Engine 29.6.2',
+      'linux/amd64',
+      'ecd0b7c99941d8e204d633676873058b2a07fffe',
+      '| Small | 1 | 160 | 6.03 s | 52.39-110.60 MiB | 8.72% | 11.39% |',
+      '| Balanced | 4 | 480 | 6.06 s | 53.43-139.30 MiB | 20.39% | 31.84% |',
+      '| Research-heavy | 8 | 960 | 6.06 s | 53.63-254.40 MiB | 40.80% | 65.32% |',
+      'starting range, not a universal requirement',
+      'does not size SearXNG',
+    ]) {
+      assert.ok(normalizedGuide.includes(evidence), `missing deployment evidence: ${evidence}`);
+    }
+  }, results);
+
+  await testFunction('deployment profiles use current configuration and valid MCP-only Compose fields', () => {
+    const guide = readText(deploymentGuideUrl);
+    const configuration = readText(new URL('../../CONFIGURATION.md', import.meta.url));
+    const overlay = readText(resourceOverlayUrl);
+    const variables = [
+      'SEARXNG_MAX_RESULTS',
+      'FETCH_TIMEOUT_MS',
+      'SEARCH_CACHE_TTL_MS',
+      'SEARCH_CACHE_MAX_ENTRIES',
+      'URL_READ_MAX_CHARS',
+      'URL_READ_MAX_CONTENT_LENGTH_BYTES',
+      'CACHE_TTL_MS',
+      'CACHE_MAX_ENTRIES',
+      'SEARXNG_FANOUT',
+      'MCP_RATE_WINDOW_MS',
+      'MCP_RATE_INIT_MAX',
+      'MCP_RATE_SESSION_MAX',
+    ];
+    for (const variable of variables) {
+      assert.ok(guide.includes(`\`${variable}\``), `guide must name ${variable}`);
+      assert.ok(configuration.includes(`\`${variable}\``), `configuration must still define ${variable}`);
+    }
+    assert.ok(overlay.includes('cpus: ${MCP_SEARXNG_CPUS:-0.50}'));
+    assert.ok(overlay.includes('mem_limit: ${MCP_SEARXNG_MEMORY_LIMIT:-256m}'));
+    assert.ok(overlay.includes('mem_reservation: ${MCP_SEARXNG_MEMORY_RESERVATION:-192m}'));
+    assert.ok(!overlay.includes('\n  searxng:'), 'resource overlay must not add or size SearXNG');
   }, results);
 
   printTestSummary(results, 'Public Documentation Guides');

--- a/docker-compose.resources.yml
+++ b/docker-compose.resources.yml
@@ -1,0 +1,6 @@
+services:
+  mcp-searxng:
+    cpus: ${MCP_SEARXNG_CPUS:-0.50}
+    mem_limit: ${MCP_SEARXNG_MEMORY_LIMIT:-256m}
+    mem_reservation: ${MCP_SEARXNG_MEMORY_RESERVATION:-192m}
+

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,7 @@
 services:
   mcp-searxng:
+    # Optional measured MCP-only limits: docs/deployment-profiles.md
+    # Apply them with: -f docker-compose.yml -f docker-compose.resources.yml
     image: isokoliuk/mcp-searxng:latest
     stdin_open: true
     environment:

--- a/docs/deployment-profiles.md
+++ b/docs/deployment-profiles.md
@@ -1,0 +1,173 @@
+# Measured MCP Deployment Profiles
+
+These profiles are starting points for the **mcp-searxng process only**. They
+do not size SearXNG, Redis, a reverse proxy, or any upstream search engine.
+Measure your own workload before enforcing a production limit.
+
+## Measurement snapshot
+
+The baseline below was captured on 2026-07-29 from source commit
+`ecd0b7c99941d8e204d633676873058b2a07fffe`:
+
+- locally built mcp-searxng 1.12.1 production image;
+- Node 24.18.0 on `linux/amd64`;
+- Docker Engine 29.6.2 under Docker Desktop;
+- 24 virtual CPUs and 15.18 GiB assigned to the Docker VM;
+- one or two deterministic mock SearXNG replicas with 75 ms response latency;
+- 20-result search responses and approximately 48 KiB HTML pages;
+- Docker CPU and memory sampled with `docker stats --no-stream`.
+
+Each client opened its own Streamable HTTP session. Every cycle called
+`searxng_web_search`, `web_url_read`, `searxng_search_suggestions`, and
+`searxng_instance_info`. Queries rotated across four cache keys, search pages
+alternated between `pageno` 1 and 2, URL reads used a 12,000-character window,
+and the first capability call refreshed `/config`.
+
+| Profile | Concurrent sessions | Tool calls | Measured duration | Observed memory | Average CPU | Peak CPU |
+| --- | ---: | ---: | ---: | ---: | ---: | ---: |
+| Small | 1 | 160 | 6.03 s | 52.39-110.60 MiB | 8.72% | 11.39% |
+| Balanced | 4 | 480 | 6.06 s | 53.43-139.30 MiB | 20.39% | 31.84% |
+| Research-heavy | 8 | 960 | 6.06 s | 53.63-254.40 MiB | 40.80% | 65.32% |
+
+Docker CPU percentages use one logical CPU as approximately 100%. The balanced
+run configured two replicas in default failover mode. The research-heavy run
+queried two replicas with `SEARXNG_FANOUT=true`. The small, balanced, and
+research-heavy cache caps were 100, 500, and 2,000 entries respectively.
+
+This is a short, deterministic MCP overhead sample, not a soak test or an SLA.
+Real pages, response sizes, TLS, proxies, logging, cache cardinality, Node
+versions, and client behavior can move both CPU and memory. The ranges below
+add headroom to this sample; each is a starting range, not a universal
+requirement.
+
+## Starting profiles
+
+| Profile | Intended MCP workload | CPU starting range | Memory starting range |
+| --- | --- | ---: | ---: |
+| Small | 1-2 mostly sequential clients, one SearXNG URL, modest caches | 0.25-0.50 CPU | 192-256 MiB |
+| Balanced | About 4 concurrent clients, replicas in failover mode, default-sized caches | 0.50-1.00 CPU | 256-384 MiB |
+| Research-heavy | About 8 concurrent sessions, fan-out or large caches, frequent 12 KiB page reads | 1.00-2.00 CPU | 512-768 MiB |
+
+Start at the lower end only when the measured workload resembles the baseline.
+Use the upper end when pages are larger, cache keys are less reusable, TLS or
+proxy work is significant, or concurrency arrives in bursts. Treat an
+out-of-memory kill or sustained CPU throttling as evidence that the enforced
+limit is too low, not as an application retry condition.
+
+## Apply a profile
+
+### NPX and STDIO
+
+NPX does not impose CPU or memory limits. Set the profile's mcp-searxng
+environment variables in the MCP client, observe the Node process with the
+operating system's process monitor, and use an operating-system or service
+manager limit only after measuring that client workload.
+
+One STDIO process normally serves one client connection. Multiple clients that
+launch separate NPX processes need the profile allowance **per process**.
+
+### Docker and STDIO
+
+Docker's `--cpus` and `--memory` flags place ceilings on the MCP container. For
+the balanced starting point:
+
+```bash
+docker run -i --rm \
+  --cpus 0.50 \
+  --memory 256m \
+  -e SEARXNG_URL \
+  isokoliuk/mcp-searxng:latest
+```
+
+For STDIO, keep `-i`; do not publish an HTTP port. Replace the two resource
+values with the selected profile and watch for throttling or OOM termination.
+
+### Standalone HTTP with Compose
+
+The optional `docker-compose.resources.yml` overlay applies balanced defaults
+without changing the base Compose service:
+
+```bash
+SEARXNG_URL=https://searxng.example.com \
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.resources.yml \
+  up -d
+```
+
+Choose another point in the measured ranges through Compose interpolation:
+
+```bash
+MCP_SEARXNG_CPUS=1.50 \
+MCP_SEARXNG_MEMORY_LIMIT=768m \
+MCP_SEARXNG_MEMORY_RESERVATION=512m \
+SEARXNG_URL=https://searxng.example.com \
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.resources.yml \
+  up -d
+```
+
+`MCP_SEARXNG_CPUS`, `MCP_SEARXNG_MEMORY_LIMIT`, and
+`MCP_SEARXNG_MEMORY_RESERVATION` are Compose interpolation variables, not
+mcp-searxng application settings. Compose `cpus` is a CPU ceiling,
+`mem_limit` is the memory ceiling, and `mem_reservation` is the requested
+reservation. See Docker's current
+[Compose service reference](https://docs.docker.com/reference/compose-file/services/)
+and [container resource guidance](https://docs.docker.com/engine/containers/resource_constraints/).
+
+HTTP deployments also need the transport and security settings in
+[Hardened HTTP Mode](../CONFIGURATION.md#hardened-http-mode). Resource limits
+do not replace authentication, host/origin validation, TLS, or rate limiting.
+
+## Map workload to current controls
+
+| Concern | Current control | Capacity effect |
+| --- | --- | --- |
+| Results per call | `SEARXNG_MAX_RESULTS` | A lower 1-20 ceiling reduces response processing and agent context. |
+| URL timeout | `FETCH_TIMEOUT_MS` | Bounds how long a page read can occupy an in-flight request. |
+| Search cache | `SEARCH_CACHE_TTL_MS`, `SEARCH_CACHE_MAX_ENTRIES` | Larger or longer-lived caches trade memory for fewer upstream searches. |
+| URL output | `URL_READ_MAX_CHARS` | Sets the default returned window when the caller omits `maxLength`. |
+| URL body cap | `URL_READ_MAX_CONTENT_LENGTH_BYTES` | Bounds decompressed bytes read before conversion; the default is 5 MiB. |
+| URL cache | `CACHE_TTL_MS`, `CACHE_MAX_ENTRIES` | Larger or longer-lived caches trade memory for fewer page fetches. |
+| Replica mode | `SEARXNG_FANOUT` | Fan-out increases simultaneous upstream work; default failover is cheaper. |
+| HTTP window | `MCP_RATE_WINDOW_MS` | Defines the rate-limit accounting window. |
+| New sessions | `MCP_RATE_INIT_MAX` | Bounds initialization and invalid-session POST traffic per client IP. |
+| Live sessions | `MCP_RATE_SESSION_MAX` | Bounds established-session HTTP traffic per client IP. |
+
+Do not raise cache caps and concurrency together without observing memory.
+Do not use a short `FETCH_TIMEOUT_MS` to compensate for insufficient CPU.
+Pagination and larger result counts increase total work even when each call
+stays within its individual bound.
+
+## Observe and adjust
+
+For Docker or Compose, sample the MCP container during representative traffic:
+
+```bash
+docker stats --no-stream mcp-searxng
+docker inspect mcp-searxng --format '{{.State.OOMKilled}} {{.RestartCount}}'
+```
+
+Record the Node version, image digest, architecture, active environment,
+concurrent sessions, call mix, page sizes, cache hit rate, sample duration, CPU
+average/peak, memory low/peak, errors, and restarts. Repeat after material
+changes to the workload or runtime.
+
+Increase memory when normal peaks approach the ceiling or the container is
+OOM-killed. Increase CPU when latency rises with sustained throttling. Reduce
+cache caps or page/result limits when retained content is the cause. Scale out
+to separate MCP instances when clients need different security policies,
+SearXNG endpoints, cache lifecycles, failure domains, or when one process cannot
+meet the measured concurrency target with acceptable headroom.
+
+## SearXNG is a separate capacity plan
+
+These measurements cover only the MCP adapter process. They exclude SearXNG
+engine fan-out, Redis, result rendering, bot detection, and upstream network
+behavior. Use the [self-hosted operator guide](self-hosted-searxng.md) for the
+integration boundary and the
+[SearXNG installation documentation](https://docs.searxng.org/admin/installation.html)
+for the search service itself. This project does not bundle SearXNG, and this
+guide does not size SearXNG.
+

--- a/docs/deployment-profiles.md
+++ b/docs/deployment-profiles.md
@@ -75,7 +75,7 @@ the balanced starting point:
 docker run -i --rm \
   --cpus 0.50 \
   --memory 256m \
-  -e SEARXNG_URL \
+  -e SEARXNG_URL=https://searxng.example.com \
   isokoliuk/mcp-searxng:latest
 ```
 
@@ -170,4 +170,3 @@ integration boundary and the
 [SearXNG installation documentation](https://docs.searxng.org/admin/installation.html)
 for the search service itself. This project does not bundle SearXNG, and this
 guide does not size SearXNG.
-


### PR DESCRIPTION
## Summary

- publish measured small, balanced, and research-heavy starting profiles for the MCP process
- record the exact Docker/Node platform, workload, duration, observed CPU/memory, and limitations
- map capacity tradeoffs to current server configuration
- add an optional Compose resource overlay without changing the base service limits
- keep SearXNG sizing explicitly separate

## Validation

- Docker lint
- focused documentation suite: 12/12 passed
- `docker compose -f docker-compose.yml -f docker-compose.resources.yml config --quiet`

No runtime behavior, dependency, API, release, or default resource-enforcement change.