### PR TITLE
fix(docs): align deployment and security contracts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@
 All notable changes to mcp-searxng are documented here.
 Versions follow [Semantic Versioning](https://semver.org/).
 
+## [Unreleased]
+
+### Fixed
+
+- **HTTP rate-limit settings now honor the strict integer-validation contract:** `MCP_RATE_WINDOW_MS`, `MCP_RATE_INIT_MAX`, and `MCP_RATE_SESSION_MAX` reject fractional, unit-suffixed, exponent, non-decimal, non-positive, and unsafe values instead of accepting numeric prefixes. Invalid values fall back with a raw-value-free warning. Because previously accepted numeric prefixes may have produced a different effective limit, the documented default may be looser or stricter until the operator corrects the setting.
+
 ## [1.12.1] - 2026-07-28
 
 ### Fixed

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -112,7 +112,7 @@ Interface-specific proxies take priority over global proxies for their respectiv
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `HTTP_PROXY` / `HTTPS_PROXY` | No | — | Global proxy for all traffic. Format: `http://[user:pass@]host:port` |
-| `SEARCH_HTTP_PROXY` / `SEARCH_HTTPS_PROXY` | No | — | Proxy for `searxng_web_search` only |
+| `SEARCH_HTTP_PROXY` / `SEARCH_HTTPS_PROXY` | No | — | Proxy for all SearXNG-bound traffic: search, suggestions, and capability discovery |
 | `URL_READER_HTTP_PROXY` / `URL_READER_HTTPS_PROXY` | No | — | Proxy for `web_url_read` only |
 | `NO_PROXY` | No | — | Comma-separated bypass list (e.g. `localhost,.internal,example.com`) |
 
@@ -169,7 +169,11 @@ HTTP sessions are stored in memory per process. A stale or unknown `mcp-session-
 
 ## Rate Limiting (HTTP mode)
 
-Rate limiting is always active in HTTP mode to prevent resource exhaustion. Before the MCP handler runs, each request is counted by resolved client IP against exactly one limit: POST requests with a currently live session use the session limit, other POST requests use the initialization limit, and GET/DELETE requests always use the session limit. A non-numeric or non-positive value for any `MCP_RATE_*` variable is ignored with a startup warning and the documented default is used, so a typo cannot silently disable rate limiting. (A blank or unset variable uses the default silently.)
+Rate limiting is always active in HTTP mode to prevent resource exhaustion. Before the MCP handler runs, each request is counted by resolved client IP against exactly one limit: POST requests with a currently live session use the session limit, other POST requests use the initialization limit, and GET/DELETE requests always use the session limit.
+
+Each `MCP_RATE_*` value must be a positive decimal safe integer after JavaScript whitespace trimming. A leading `+` and leading zeros are accepted; fractions, suffixes, exponents, hexadecimal forms, non-positive values, and integers above `Number.MAX_SAFE_INTEGER` are rejected. An invalid value uses the documented default and emits one startup warning per variable without copying the raw value into diagnostics. Blank or unset variables use the default silently.
+
+Before this correction, spellings such as `20requests`, `12.5`, or `1e3` could be accepted as numeric prefixes. They now fall back to the documented default, which may be looser or stricter than the value an older process effectively used. Check startup warnings and correct the environment value rather than relying on the fallback.
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
@@ -213,9 +217,9 @@ When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTP
 Set `MCP_HTTP_ALLOW_PRIVATE_URLS=true` only when internal URL reads are intentional for your deployment. This also allows hostnames that DNS-resolve to private/internal addresses.
 
 
-## Full Example (All Options)
+## Combined Example (Representative Options)
 
-Complete MCP client configuration with every variable. Mix and match as needed — all optional variables can be used independently or together.
+This combined MCP client configuration shows the supported option groups in one place. Remove settings you do not need. Some options have dependencies: `MCP_HTTP_HARDEN=true`, `MCP_HTTP_AUTH_TOKEN`, and `MCP_HTTP_ALLOWED_ORIGINS` must be configured together; `MCP_HTTP_ALLOWED_HOSTS` and `MCP_HTTP_TRUST_PROXY` depend on the exact network and proxy topology. The representative `MCP_HTTP_TRUST_PROXY=1` value assumes exactly one trusted proxy hop. Without that trusted proxy boundary, clients can spoof `X-Forwarded-For` and influence IP-based rate limiting and logs.
 
 ```json
 {
@@ -224,7 +228,9 @@ Complete MCP client configuration with every variable. Mix and match as needed �
       "command": "npx",
       "args": ["-y", "mcp-searxng"],
       "env": {
-        "SEARXNG_URL": "https://your_username:your_password@searxng.example.com",
+        "SEARXNG_URL": "https://searxng.example.com",
+        "AUTH_USERNAME": "legacy-fallback-user",
+        "AUTH_PASSWORD": "legacy-fallback-password",
         "SEARXNG_FANOUT": "false",
         "SEARXNG_TIMEOUT_MS": "10000",
         "FETCH_TIMEOUT_MS": "10000",
@@ -253,6 +259,9 @@ Complete MCP client configuration with every variable. Mix and match as needed �
         "MCP_HTTP_PORT": "3000",
         "MCP_HTTP_HOST": "0.0.0.0",
         "MCP_HTTP_TRUST_PROXY": "1",
+        "MCP_RATE_WINDOW_MS": "60000",
+        "MCP_RATE_INIT_MAX": "20",
+        "MCP_RATE_SESSION_MAX": "300",
         "MCP_HTTP_HARDEN": "true",
         "MCP_HTTP_AUTH_TOKEN": "replace-me",
         "MCP_HTTP_ALLOWED_ORIGINS": "https://app.example.com",

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # 🔍 SearXNG MCP Server
 
-**Private web search for AI assistants — connect any SearXNG instance to Claude, Cursor, and more.**
+**Privacy-respecting web search for AI assistants — use an operator-controlled or trusted SearXNG instance with Claude, Cursor, and more.**
 
 [![GitHub Stars](https://img.shields.io/github/stars/ihor-sokoliuk/mcp-searxng?style=flat-square&logo=github&label=stars)](https://github.com/ihor-sokoliuk/mcp-searxng/stargazers)
 [![npm version](https://img.shields.io/npm/v/mcp-searxng?style=flat-square&logo=npm)](https://www.npmjs.com/package/mcp-searxng)
@@ -68,14 +68,27 @@ For measured MCP-process CPU and memory starting points, see
 
 ## Why mcp-searxng?
 
+As of 2026-07-29, the capability comparison below reflects the official
+[Brave MCP](https://github.com/brave/brave-search-mcp-server),
+[Exa MCP](https://github.com/exa-labs/exa-mcp-server), and
+[Firecrawl MCP](https://github.com/mendableai/firecrawl-mcp-server) projects.
+“Pagination” means an exposed page or offset control. “Self-hosted” means the
+search service can run under your control. “Free / No API key” means this MCP
+server does not require a paid search-vendor API key; you still operate or
+select the underlying SearXNG instance.
+
 | | Brave MCP | Exa MCP | Firecrawl MCP | **mcp-searxng** |
 |--|:---------:|:-------:|:-------------:|:---------------:|
 | Web Search | ✓ | ✓ | ✓ | ✓ |
 | Read URL | ✗ | ✓ | ✓ | ✓ |
-| Pagination | ✗ | ✗ | ✓ | ✓ |
+| Pagination | ✓ | ✗ | ✓ | ✓ |
 | Self-hosted | ✗ | ✗ | Partial | ✓ |
-| Privacy | ✗ | ✗ | ✗ | ✓ |
 | Free / No API key | ✗ | ✗ | ✗ | ✓ |
+
+Privacy depends on the SearXNG deployment. An operator-controlled instance can
+avoid trusting a third-party search operator, while a public instance receives
+the query and may log it. SearXNG and this MCP integration do not by themselves
+provide anonymity.
 
 ## How It Works
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -66,13 +66,21 @@ MCP_HTTP_AUTH_TOKEN=<strong-random-token>
 MCP_HTTP_ALLOWED_ORIGINS=https://your-app.example.com
 ```
 
-Hardened mode enforces:
+Hardened mode protects the MCP protocol endpoint (`/mcp`) with:
 
-- **Bearer token authentication** on every request (`Authorization: Bearer <token>`)
-- **CORS origin allowlist** — requests from unlisted origins are rejected
+- **Bearer token authentication** on every `/mcp` request (`Authorization: Bearer <token>`)
+- **Origin allowlist** — `/mcp` requests from unlisted browser origins are rejected
 - **DNS rebinding protection** — the `Host` header is validated against `MCP_HTTP_ALLOWED_HOSTS`. The default allows loopback access on the configured port (`127.0.0.1`, `localhost`, `[::1]` and their `:PORT` forms). A custom list is matched exactly against `Host`: an entry matches only when it carries the same port the client or proxy sends (e.g. `app.example.com:8443`).
 
 `MCP_HTTP_HARDEN=true` will fail to start if `MCP_HTTP_AUTH_TOKEN` or `MCP_HTTP_ALLOWED_ORIGINS` are missing.
+
+`GET /health` intentionally remains unauthenticated so container orchestrators
+and load balancers can perform liveness checks. It is independently limited to
+60 requests per minute and returns only `status`, `server`, `version`, and
+`transport`; it does not return the SearXNG URL or server configuration. Public
+version metadata permits version fingerprinting, which is the accepted trade-off
+for this unauthenticated operational endpoint. Restrict the network path to the
+health endpoint when your threat model does not accept that disclosure.
 
 ### Transport Security
 

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -137,6 +137,32 @@ async function runTests() {
     assert.ok(res.headers['access-control-allow-origin']);
   }, results);
 
+  await testFunction('hardened mode keeps GET /health unauthenticated with fixed metadata', async () => {
+    envManager.set('MCP_HTTP_HARDEN', 'true');
+    envManager.set('MCP_HTTP_AUTH_TOKEN', 'secret-token');
+    envManager.set('MCP_HTTP_ALLOWED_ORIGINS', 'https://app.example.com');
+
+    try {
+      const app = await createHttpServer(() => createTestMcpServer(), 3000);
+      const res = await request(app)
+        .get('/health')
+        .set('Origin', 'https://unlisted.example.com')
+        .set('Host', 'unlisted.example.com');
+
+      assert.equal(res.status, 200);
+      assert.deepEqual(
+        Object.keys(res.body).sort(),
+        ['server', 'status', 'transport', 'version'],
+      );
+      assert.equal(res.body.status, 'healthy');
+      assert.equal(res.body.server, 'ihor-sokoliuk/mcp-searxng');
+      assert.equal(res.body.transport, 'http');
+      assert.equal(typeof res.body.version, 'string');
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
   await testFunction('CORS allows expected headers', async () => {
     const app = await createHttpServer(() => createTestMcpServer());
     const res = await request(app)
@@ -536,6 +562,27 @@ async function runTests() {
 
   // --- Rate Limiting ---
 
+  await testFunction('Rate limiting: production construction parses each configured variable once', async () => {
+    envManager.set('MCP_RATE_WINDOW_MS', '50ms');
+    envManager.set('MCP_RATE_INIT_MAX', '1e3');
+    envManager.set('MCP_RATE_SESSION_MAX', '0x10');
+
+    try {
+      const output = await captureConsoleOutput(async () => {
+        await createHttpServer(() => createTestMcpServer());
+      });
+      const warnings = output.filter(line => line.includes('Ignoring invalid MCP_RATE_'));
+
+      assert.deepEqual(warnings, [
+        '⚠️  Ignoring invalid MCP_RATE_WINDOW_MS. Expected a positive integer. Using default 60000.',
+        '⚠️  Ignoring invalid MCP_RATE_INIT_MAX. Expected a positive integer. Using default 20.',
+        '⚠️  Ignoring invalid MCP_RATE_SESSION_MAX. Expected a positive integer. Using default 300.',
+      ]);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
   await testFunction('Rate limiting: established-session POSTs use only the session limiter', async () => {
     envManager.set('MCP_RATE_INIT_MAX', '2');
     envManager.set('MCP_RATE_SESSION_MAX', '3');
@@ -765,19 +812,22 @@ async function runTests() {
     );
   }, results);
 
-  await testFunction('Rate limiting: RateLimit-* headers present on /health response', async () => {
-    const app = await createHttpServer(() => createTestMcpServer());
+  await testFunction('Rate limiting: /health keeps its independent fixed limit of 60', async () => {
+    envManager.set('MCP_RATE_WINDOW_MS', '120000');
+    envManager.set('MCP_RATE_INIT_MAX', '2');
+    envManager.set('MCP_RATE_SESSION_MAX', '3');
 
-    const res = await request(app).get('/health');
+    try {
+      const app = await createHttpServer(() => createTestMcpServer());
+      const res = await request(app).get('/health');
+      const limit = res.headers['ratelimit-limit'] || res.headers['x-ratelimit-limit'];
+      const remaining = res.headers['ratelimit-remaining'] || res.headers['x-ratelimit-remaining'];
 
-    assert.ok(
-      res.headers['ratelimit-limit'] || res.headers['x-ratelimit-limit'],
-      'RateLimit-Limit header should be present on /health'
-    );
-    assert.ok(
-      res.headers['ratelimit-remaining'] || res.headers['x-ratelimit-remaining'],
-      'RateLimit-Remaining header should be present on /health'
-    );
+      assert.equal(limit, '60', 'health limit must remain fixed at 60 per minute');
+      assert.ok(remaining, 'RateLimit-Remaining header should be present on /health');
+    } finally {
+      envManager.restore();
+    }
   }, results);
 
   await testFunction('Rate limiting: trust proxy suppresses X-Forwarded-For validation warning', async () => {

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -15,7 +15,9 @@ const results = createTestResults();
 const guideUrl = new URL('../../docs/client-configurations.md', import.meta.url);
 const researchGuideUrl = new URL('../../docs/research-workflow.md', import.meta.url);
 const deploymentGuideUrl = new URL('../../docs/deployment-profiles.md', import.meta.url);
+const baseComposeUrl = new URL('../../docker-compose.yml', import.meta.url);
 const resourceOverlayUrl = new URL('../../docker-compose.resources.yml', import.meta.url);
+const httpOverlayUrl = new URL('../../docker-compose.http.yml', import.meta.url);
 const markdownFence = String.fromCharCode(96).repeat(3);
 
 const expectedMatrixRows = [
@@ -279,6 +281,7 @@ export async function runTests(): Promise<TestResult> {
   await testFunction('deployment profiles use current configuration and valid MCP-only Compose fields', () => {
     const guide = readText(deploymentGuideUrl);
     const configuration = readText(new URL('../../CONFIGURATION.md', import.meta.url));
+    const baseCompose = readText(baseComposeUrl);
     const overlay = readText(resourceOverlayUrl);
     const variables = [
       'SEARXNG_MAX_RESULTS',
@@ -302,6 +305,94 @@ export async function runTests(): Promise<TestResult> {
     assert.ok(overlay.includes('mem_limit: ${MCP_SEARXNG_MEMORY_LIMIT:-256m}'));
     assert.ok(overlay.includes('mem_reservation: ${MCP_SEARXNG_MEMORY_RESERVATION:-192m}'));
     assert.ok(!overlay.includes('\n  searxng:'), 'resource overlay must not add or size SearXNG');
+    assert.ok(!baseCompose.includes('ports:'), 'base Compose file must remain STDIO-only');
+    assert.ok(!baseCompose.includes('MCP_HTTP_'), 'base Compose file must not select HTTP transport');
+  }, results);
+
+  await testFunction('deployment HTTP Compose profile is fail-closed and service-aware', () => {
+    const guide = readText(deploymentGuideUrl);
+    const normalizedGuide = guide.replace(/\s+/gu, ' ');
+    const overlay = readText(httpOverlayUrl);
+    for (const contract of [
+      'MCP_HTTP_PORT=${MCP_HTTP_PORT:-3000}',
+      'MCP_HTTP_HOST=0.0.0.0',
+      'MCP_HTTP_HARDEN=true',
+      'MCP_HTTP_AUTH_TOKEN=${MCP_HTTP_AUTH_TOKEN:?',
+      'MCP_HTTP_ALLOWED_ORIGINS=${MCP_HTTP_ALLOWED_ORIGINS:?',
+      'MCP_HTTP_ALLOWED_HOSTS',
+      'MCP_HTTP_TRUST_PROXY',
+      '${MCP_SEARXNG_HTTP_BIND_ADDRESS:-127.0.0.1}',
+      '${MCP_SEARXNG_HTTP_PUBLISHED_PORT:-3000}',
+    ]) {
+      assert.ok(overlay.includes(contract), `HTTP overlay must include ${contract}`);
+    }
+    for (const composeFile of [
+      'docker-compose.yml',
+      'docker-compose.http.yml',
+      'docker-compose.resources.yml',
+    ]) {
+      assert.ok(guide.includes(composeFile), `guide must compose ${composeFile}`);
+    }
+    assert.match(guide, /docker compose[\s\S]+stats --no-stream mcp-searxng/u);
+    assert.match(guide, /docker compose[\s\S]+ps -q mcp-searxng/u);
+    assert.ok(guide.includes('--name mcp-searxng-profile'));
+    assert.ok(guide.includes('docker stats --no-stream mcp-searxng-profile'));
+    assert.ok(guide.includes('disposable placeholder'));
+    assert.ok(normalizedGuide.includes('passes no value for an optional variable'));
+    assert.ok(normalizedGuide.includes('replaces those defaults'));
+    assert.ok(normalizedGuide.includes('clients can spoof `X-Forwarded-For`'));
+    assert.ok(normalizedGuide.includes('prints expanded environment values'));
+    assert.ok(normalizedGuide.includes('differs from `MCP_HTTP_PORT`'));
+    assert.ok(normalizedGuide.includes('published port in `MCP_HTTP_ALLOWED_HOSTS`'));
+  }, results);
+
+  await testFunction('public documentation states current security, privacy, and configuration contracts', () => {
+    const readme = readText(new URL('../../README.md', import.meta.url));
+    const configuration = readText(new URL('../../CONFIGURATION.md', import.meta.url));
+    const security = readText(new URL('../../SECURITY.md', import.meta.url));
+    const normalizedSecurity = security.replace(/\s+/gu, ' ');
+    const changelog = readText(new URL('../../CHANGELOG.md', import.meta.url));
+    const index = readText(new URL('../../docs/index.md', import.meta.url));
+
+    assert.ok(readme.includes('operator-controlled or trusted SearXNG instance'));
+    assert.ok(readme.includes('As of 2026-07-29'));
+    assert.ok(readme.includes('| Pagination | ✓ | ✗ | ✓ | ✓ |'));
+    assert.ok(!readme.includes('| Privacy |'));
+
+    assert.ok(configuration.includes('all SearXNG-bound traffic'));
+    assert.ok(configuration.includes('## Combined Example (Representative Options)'));
+    for (const variable of [
+      '"AUTH_USERNAME"',
+      '"AUTH_PASSWORD"',
+      '"MCP_RATE_WINDOW_MS"',
+      '"MCP_RATE_INIT_MAX"',
+      '"MCP_RATE_SESSION_MAX"',
+    ]) {
+      assert.ok(configuration.includes(variable), `representative example must include ${variable}`);
+    }
+    assert.ok(configuration.includes('must be configured together'));
+    assert.ok(configuration.includes('may be looser or stricter'));
+    assert.ok(configuration.includes('clients can spoof `X-Forwarded-For`'));
+
+    assert.ok(security.includes('Hardened mode protects the MCP protocol endpoint (`/mcp`)'));
+    assert.ok(security.includes('`GET /health` intentionally remains unauthenticated'));
+    assert.ok(security.includes('60 requests per minute'));
+    assert.ok(normalizedSecurity.includes('`status`, `server`, `version`, and `transport`'));
+    assert.ok(normalizedSecurity.includes('does not return the SearXNG URL or server configuration'));
+    assert.ok(security.includes('version fingerprinting'));
+
+    assert.ok(changelog.startsWith('# Changelog'));
+    assert.ok(changelog.includes('## [Unreleased]'));
+    assert.ok(changelog.includes('previously accepted numeric prefixes'));
+    assert.ok(changelog.includes('may be looser or stricter'));
+
+    for (const guide of [
+      'client-configurations.md',
+      'research-workflow.md',
+      'deployment-profiles.md',
+    ]) {
+      assert.ok(index.includes(guide), `documentation index must link ${guide}`);
+    }
   }, results);
 
   printTestSummary(results, 'Public Documentation Guides');

--- a/__tests__/unit/http-security.test.ts
+++ b/__tests__/unit/http-security.test.ts
@@ -127,6 +127,24 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('blank optional host and trust-proxy values preserve safe defaults', () => {
+    envManager.set('MCP_HTTP_ALLOWED_HOSTS', '');
+    envManager.set('MCP_HTTP_TRUST_PROXY', '');
+
+    const config = getHttpSecurityConfig(3000);
+    assert.deepEqual(config.allowedHosts, [
+      '127.0.0.1',
+      'localhost',
+      '[::1]',
+      '127.0.0.1:3000',
+      'localhost:3000',
+      '[::1]:3000',
+    ]);
+    assert.equal(config.trustProxy, false);
+
+    envManager.restore();
+  }, results);
+
   await testFunction('explicit MCP_HTTP_ALLOWED_HOSTS overrides the port-aware default exactly', () => {
     envManager.set('MCP_HTTP_ALLOWED_HOSTS', 'app.example.com:8443, other.example.com');
 

--- a/__tests__/unit/http-server.test.ts
+++ b/__tests__/unit/http-server.test.ts
@@ -103,29 +103,30 @@ export async function runTests(): Promise<TestResult> {
     assert.equal(warnings.length, 0, 'blank value must not warn');
   }, results);
 
-  await testFunction('parseRateLimitEnv: non-numeric → fallback AND warns', () => {
-    envManager.set('MCP_RATE_TEST', 'abc'); // no leading digit → parseInt yields NaN (the fail-open case)
-    let result = 0;
-    const warnings = captureWarnings(() => { result = parseRateLimitEnv('MCP_RATE_TEST', 20); });
-    envManager.restore();
-    assert.equal(result, 20);
-    assert.equal(warnings.length, 1, 'invalid value must warn once');
-    assert.ok(warnings[0].includes('MCP_RATE_TEST'), 'warning names the variable');
-    assert.ok(warnings[0].includes('20'), 'warning names the default used');
-  }, results);
-
-  await testFunction('parseRateLimitEnv: zero and negative → fallback AND warns', () => {
-    for (const bad of ['0', '-5']) {
+  await testFunction('parseRateLimitEnv: malformed or unsafe values → fallback AND one raw-value-free warning', () => {
+    const expectedWarning =
+      '⚠️  Ignoring invalid MCP_RATE_TEST. Expected a positive integer. Using default 300.';
+    for (const bad of [
+      '12.5',
+      '50ms',
+      '1e3',
+      '0x10',
+      'abc',
+      '9007199254740992',
+      '0',
+      '-5',
+    ]) {
       envManager.set('MCP_RATE_TEST', bad);
       let result = 0;
       const warnings = captureWarnings(() => { result = parseRateLimitEnv('MCP_RATE_TEST', 300); });
       envManager.restore();
       assert.equal(result, 300, `${bad} → fallback`);
       assert.equal(warnings.length, 1, `${bad} must warn`);
+      assert.equal(warnings[0], expectedWarning, `${bad} must not be copied into diagnostics`);
     }
   }, results);
 
-  await testFunction('parseRateLimitEnv warnings redact configured passwords', () => {
+  await testFunction('parseRateLimitEnv warnings never emit configured invalid values', () => {
     envManager.set('MCP_RATE_TEST', 'rate-secret');
     envManager.set('AUTH_USERNAME', 'rate-user');
     envManager.set('AUTH_PASSWORD', 'rate-secret');
@@ -140,18 +141,28 @@ export async function runTests(): Promise<TestResult> {
     assert.equal(result, 20);
     assert.equal(warnings.length, 1);
     assert.ok(!warnings[0].includes('rate-secret'), warnings[0]);
-    assert.ok(warnings[0].includes('[redacted]'), warnings[0]);
+    assert.equal(
+      warnings[0],
+      '⚠️  Ignoring invalid MCP_RATE_TEST. Expected a positive integer. Using default 20.',
+    );
     resetDiagnosticSanitizerForTests();
     envManager.restore();
   }, results);
 
-  await testFunction('parseRateLimitEnv: valid positive integer is honored, no warning', () => {
-    envManager.set('MCP_RATE_TEST', '50');
-    let result = 0;
-    const warnings = captureWarnings(() => { result = parseRateLimitEnv('MCP_RATE_TEST', 20); });
-    envManager.restore();
-    assert.equal(result, 50);
-    assert.equal(warnings.length, 0, 'valid value must not warn');
+  await testFunction('parseRateLimitEnv: strict positive integer forms are honored without warnings', () => {
+    for (const [raw, expected] of [
+      ['50', 50],
+      ['+5', 5],
+      ['005', 5],
+      ['\u00a05\u00a0', 5],
+    ] as const) {
+      envManager.set('MCP_RATE_TEST', raw);
+      let result = 0;
+      const warnings = captureWarnings(() => { result = parseRateLimitEnv('MCP_RATE_TEST', 20); });
+      envManager.restore();
+      assert.equal(result, expected, `${JSON.stringify(raw)} parses strictly`);
+      assert.equal(warnings.length, 0, `${JSON.stringify(raw)} must not warn`);
+    }
   }, results);
 
   printTestSummary(results, 'HTTP Server');

--- a/__tests__/unit/resources.test.ts
+++ b/__tests__/unit/resources.test.ts
@@ -73,6 +73,13 @@ async function runTests() {
     assert.ok(help.includes('searxng') || help.includes('search') || help.includes('SearXNG'));
   }, results);
 
+  await testFunction('help resource names the optional MCP Streamable HTTP transport', () => {
+    const help = createHelpResource();
+
+    assert.ok(help.includes('MCP Streamable HTTP transport'));
+    assert.ok(!help.includes('RESTful HTTP transport'));
+  }, results);
+
   await testFunction('config resource advertises all registered tools', () => {
     const config = JSON.parse(createConfigResource());
 

--- a/docker-compose.http.yml
+++ b/docker-compose.http.yml
@@ -1,0 +1,13 @@
+services:
+  mcp-searxng:
+    stdin_open: false
+    environment:
+      - "MCP_HTTP_PORT=${MCP_HTTP_PORT:-3000}"
+      - "MCP_HTTP_HOST=0.0.0.0"
+      - "MCP_HTTP_HARDEN=true"
+      - "MCP_HTTP_AUTH_TOKEN=${MCP_HTTP_AUTH_TOKEN:?Set MCP_HTTP_AUTH_TOKEN in the environment}"
+      - "MCP_HTTP_ALLOWED_ORIGINS=${MCP_HTTP_ALLOWED_ORIGINS:?Set MCP_HTTP_ALLOWED_ORIGINS in the environment}"
+      - MCP_HTTP_ALLOWED_HOSTS
+      - MCP_HTTP_TRUST_PROXY
+    ports:
+      - "${MCP_SEARXNG_HTTP_BIND_ADDRESS:-127.0.0.1}:${MCP_SEARXNG_HTTP_PUBLISHED_PORT:-3000}:${MCP_HTTP_PORT:-3000}"

--- a/docs/deployment-profiles.md
+++ b/docs/deployment-profiles.md
@@ -17,6 +17,12 @@ The baseline below was captured on 2026-07-29 from source commit
 - 20-result search responses and approximately 48 KiB HTML pages;
 - Docker CPU and memory sampled with `docker stats --no-stream`.
 
+This repository retains the point-in-time description and results below, but
+not the benchmark harness or raw `docker stats` output. The snapshot therefore
+cannot be independently rerun from repository artifacts alone. Treat it as
+historical starting evidence and measure the current image with your own
+representative workload before enforcing limits.
+
 Each client opened its own Streamable HTTP session. Every cycle called
 `searxng_web_search`, `web_url_read`, `searxng_search_suggestions`, and
 `searxng_instance_info`. Queries rotated across four cache keys, search pages
@@ -73,6 +79,7 @@ the balanced starting point:
 
 ```bash
 docker run -i --rm \
+  --name mcp-searxng-profile \
   --cpus 0.50 \
   --memory 256m \
   -e SEARXNG_URL=https://searxng.example.com \
@@ -84,26 +91,46 @@ values with the selected profile and watch for throttling or OOM termination.
 
 ### Standalone HTTP with Compose
 
-The optional `docker-compose.resources.yml` overlay applies balanced defaults
-without changing the base Compose service:
+The base `docker-compose.yml` remains STDIO-only. Add
+`docker-compose.http.yml` to enable a standalone hardened Streamable HTTP
+service, and optionally add `docker-compose.resources.yml` for balanced
+resource defaults.
+
+Before starting it, set `SEARXNG_URL`, `MCP_HTTP_AUTH_TOKEN`, and
+`MCP_HTTP_ALLOWED_ORIGINS` in the operator environment. Compose fails during
+interpolation, before creating a container, if either hardening value is
+missing.
 
 ```bash
-SEARXNG_URL=https://searxng.example.com \
 docker compose \
   -f docker-compose.yml \
+  -f docker-compose.http.yml \
   -f docker-compose.resources.yml \
   up -d
 ```
 
-Choose another point in the measured ranges through Compose interpolation:
+The published endpoint defaults to `127.0.0.1:3000`. Change the host-side
+address only with `MCP_SEARXNG_HTTP_BIND_ADDRESS`, and change the host-side port
+only with `MCP_SEARXNG_HTTP_PUBLISHED_PORT`. `MCP_HTTP_PORT` controls the
+container-side listener and defaults to `3000`; the overlay sets
+`MCP_HTTP_HOST=0.0.0.0` inside the container so Docker port forwarding can reach
+it.
+
+If `MCP_SEARXNG_HTTP_PUBLISHED_PORT` differs from `MCP_HTTP_PORT`, add the
+client-visible host and published port in `MCP_HTTP_ALLOWED_HOSTS`. Hardened
+mode derives its loopback defaults from the container-side `MCP_HTTP_PORT`,
+while clients send the host-side port in the `Host` header.
+
+For example, choose another point in the measured resource ranges without
+changing the loopback-only network default:
 
 ```bash
 MCP_SEARXNG_CPUS=1.50 \
 MCP_SEARXNG_MEMORY_LIMIT=768m \
 MCP_SEARXNG_MEMORY_RESERVATION=512m \
-SEARXNG_URL=https://searxng.example.com \
 docker compose \
   -f docker-compose.yml \
+  -f docker-compose.http.yml \
   -f docker-compose.resources.yml \
   up -d
 ```
@@ -116,9 +143,39 @@ reservation. See Docker's current
 [Compose service reference](https://docs.docker.com/reference/compose-file/services/)
 and [container resource guidance](https://docs.docker.com/engine/containers/resource_constraints/).
 
-HTTP deployments also need the transport and security settings in
-[Hardened HTTP Mode](../CONFIGURATION.md#hardened-http-mode). Resource limits
-do not replace authentication, host/origin validation, TLS, or rate limiting.
+When `MCP_HTTP_ALLOWED_HOSTS` is unset, hardened mode accepts the existing
+loopback hostname defaults and their configured-port forms. Setting it replaces
+those defaults, so list the exact `Host` forwarded by a reverse proxy.
+`MCP_HTTP_TRUST_PROXY` is also optional and disabled by default. Enable it only
+for a known proxy topology; otherwise clients can spoof `X-Forwarded-For` and
+therefore the IP identity used for rate limiting and logs.
+
+The overlay uses Compose pass-through syntax for those two optional variables.
+When either is absent from the operator environment, Compose passes no value for
+an optional variable. The server also treats a blank allowed-hosts value as
+unset and a blank trust-proxy value as disabled, preserving the safe defaults.
+
+To inspect the merged model before launch, supply only a disposable placeholder
+token:
+
+```bash
+MCP_HTTP_AUTH_TOKEN=compose-test-token \
+MCP_HTTP_ALLOWED_ORIGINS=https://client.example.invalid \
+SEARXNG_URL=https://searxng.example.com \
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.http.yml \
+  -f docker-compose.resources.yml \
+  config
+```
+
+`docker compose config` prints expanded environment values, including
+`MCP_HTTP_AUTH_TOKEN`. Never run or capture that command with a real production
+token in CI logs or shared output.
+
+Follow [Hardened HTTP Mode](../CONFIGURATION.md#hardened-http-mode) for exact
+Host, Origin, TLS, and reverse-proxy guidance. Resource limits do not replace
+authentication, Host/Origin validation, TLS, or rate limiting.
 
 ## Map workload to current controls
 
@@ -142,11 +199,31 @@ stays within its individual bound.
 
 ## Observe and adjust
 
-For Docker or Compose, sample the MCP container during representative traffic:
+For the named `docker run` example, sample the container during representative
+traffic:
 
 ```bash
-docker stats --no-stream mcp-searxng
-docker inspect mcp-searxng --format '{{.State.OOMKilled}} {{.RestartCount}}'
+docker stats --no-stream mcp-searxng-profile
+docker inspect mcp-searxng-profile \
+  --format '{{.State.OOMKilled}} {{.RestartCount}}'
+```
+
+For the three-file Compose HTTP profile, address the service through Compose
+instead of assuming Docker's generated container name:
+
+```bash
+docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.http.yml \
+  -f docker-compose.resources.yml \
+  stats --no-stream mcp-searxng
+
+container_id="$(docker compose \
+  -f docker-compose.yml \
+  -f docker-compose.http.yml \
+  -f docker-compose.resources.yml \
+  ps -q mcp-searxng)"
+docker inspect "$container_id" --format '{{.State.OOMKilled}} {{.RestartCount}}'
 ```
 
 Record the Node version, image digest, architecture, active environment,

--- a/docs/index.md
+++ b/docs/index.md
@@ -6,6 +6,9 @@
 - **[CONFIGURATION](../CONFIGURATION.md)** — Every environment variable with defaults and examples
 - **[Operating Self-Hosted SearXNG](self-hosted-searxng.md)** — SearXNG operation and MCP integration
 - **[Using a Public SearXNG Instance](public-searxng-instances.md)** — Trust, evaluation, and conservative-use guidance
+- **[MCP Client Configuration Cookbook](client-configurations.md)** — Verified local and remote recipes for eight MCP clients
+- **[Evidence-Focused Research Workflow](research-workflow.md)** — Bounded search, source inspection, cross-checking, and citation guidance
+- **[Measured MCP Deployment Profiles](deployment-profiles.md)** — Point-in-time MCP-process measurements and resource starting ranges
 - **[SECURITY](../SECURITY.md)** — Threat model, SSRF protection, HTTP hardening, and vulnerability reporting
 
 ## Topics

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -13,6 +13,7 @@ import {
   sanitizeErrorForTransport,
 } from "./diagnostic-sanitizer.js";
 import { writeDiagnostic } from "./diagnostic-output.js";
+import { parseStrictInteger } from "./env-int.js";
 import {
   getHttpSecurityConfig,
   isOriginAllowed,
@@ -52,7 +53,7 @@ export function resolveBindHost(envValue: string | undefined): string {
 
 /**
  * Parses a positive-integer rate-limit setting from the environment.
- * Absent/blank → fallback silently. Present-but-invalid (NaN or <= 0) →
+ * Absent/blank → fallback silently. Present-but-invalid or non-positive →
  * fallback plus a one-line console.warn so an operator typo cannot silently
  * disable rate limiting (a fail-open control). Uses console.warn, not the MCP
  * logMessage path, because makeRateLimiters runs without an McpServer in scope.
@@ -62,10 +63,10 @@ export function parseRateLimitEnv(name: string, fallback: number): number {
   if (raw === undefined || raw.trim() === "") {
     return fallback;
   }
-  const parsed = parseInt(raw, 10);
-  if (Number.isNaN(parsed) || parsed <= 0) {
+  const parsed = parseStrictInteger(raw);
+  if (parsed === undefined || parsed <= 0) {
     warnDiagnostic(
-      `⚠️  Ignoring invalid ${name}="${raw}". Expected a positive integer. Using default ${fallback}.`,
+      `⚠️  Ignoring invalid ${name}. Expected a positive integer. Using default ${fallback}.`,
     );
     return fallback;
   }

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -190,7 +190,7 @@ Common ones are listed below (failover/fan-out, caching, timeouts, result limits
 Standard input/output transport for desktop clients like Claude Desktop.
 
 ### HTTP (Optional)
-RESTful HTTP transport for web applications. Set \`MCP_HTTP_PORT\` to enable.
+MCP Streamable HTTP transport for remote clients. Set \`MCP_HTTP_PORT\` to enable.
 
 ### Hardened HTTP Mode (Optional)
 Default behavior remains compatible for existing deployments.


### PR DESCRIPTION
## Summary
- align README, configuration, security, deployment, and embedded help claims with the shipped server behavior
- add a fail-closed, loopback-published HTTP Compose overlay while preserving the STDIO-only base profile
- validate rate-limit environment values strictly and add regression coverage for deployment and security contracts

## Verification
- `npm run test:coverage` (600/600; 96.4% lines, 93.02% branches)
- `npm run lint`
- `npm run build`
- `npm audit --audit-level=high`
- `npm run test:e2e` (2 local tests passed; live suites skipped because no live URL was configured)
- base and HTTP Compose renders, including required-variable failure cases
- independent specification and code review completed