### PR TITLE
feat: add FlareSolverr support for protected URL reads

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -100,12 +100,17 @@ for trust, evaluation, and conservative-use guidance.
 
 `FLARESOLVERR_URL` accepts either the service base URL or an already-complete
 `/v1` endpoint; the suffix is normalized idempotently.
+`FLARESOLVERR_TIMEOUT_MS` is sent to the solver as its browser-work budget;
+the client permits up to 5 additional seconds to receive and validate the
+solver response.
 
 With `FLARESOLVERR_URL` configured, `web_url_read` first performs its normal
 target URL security and HEAD size preflight. It then requests only the browser
 session cookies and user-agent from the solver. The actual target is fetched by
 `mcp-searxng`, so redirect validation, URL-reader proxy selection, streaming
 size limits, content-type handling, and caching remain authoritative.
+Replay starts again at the originally requested URL rather than trusting a
+same-host path returned by the solver.
 
 A transient solver connection, timeout, overload, HTTP 408/429/5xx response,
 malformed response, or oversized response falls back once to the direct

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -98,18 +98,22 @@ for trust, evaluation, and conservative-use guidance.
 | `CACHE_TTL_MS` | No | `86400000` | URL cache TTL in milliseconds. Invalid or non-positive values fall back to the default (24 hours). |
 | `CACHE_MAX_ENTRIES` | No | `500` | Maximum number of cached URLs. When the cache exceeds this size, the least frequently used entry is evicted, with oldest entry used as the tie-breaker. Invalid or non-positive values fall back to the default. |
 
+`FLARESOLVERR_URL` accepts either the service base URL or an already-complete
+`/v1` endpoint; the suffix is normalized idempotently.
+
 With `FLARESOLVERR_URL` configured, `web_url_read` first performs its normal
 target URL security and HEAD size preflight. It then requests only the browser
 session cookies and user-agent from the solver. The actual target is fetched by
 `mcp-searxng`, so redirect validation, URL-reader proxy selection, streaming
 size limits, content-type handling, and caching remain authoritative.
 
-A transient solver connection, timeout, overload, malformed response, or
-oversized response falls back once to the direct URL-reader path. Invalid
-solver configuration, a solver result for a different hostname, and a
-non-success target status reported by the solver fail closed. Solver-backed
-cache entries are isolated from direct-fetch entries. PDFs remain unsupported
-by this feature and return the existing binary-content hint.
+A transient solver connection, timeout, overload, HTTP 408/429/5xx response,
+malformed response, or oversized response falls back once to the direct
+URL-reader path. Invalid solver configuration, other HTTP 4xx responses, a
+solver result for a different hostname, and a non-success target status
+reported by the solver fail closed. Solver-backed cache entries are isolated
+from direct-fetch entries. PDFs remain unsupported by this feature and return
+the existing binary-content hint.
 
 Example with the official FlareSolverr image:
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -92,8 +92,51 @@ for trust, evaluation, and conservative-use guidance.
 |---|---|---|---|
 | `URL_READ_MAX_CHARS` | No | — | Default maximum characters returned by `web_url_read` when the caller omits `maxLength`. Explicit `maxLength` always wins. Invalid values are ignored. |
 | `URL_READ_MAX_CONTENT_LENGTH_BYTES` | No | `5242880` | Maximum decompressed response-body bytes `web_url_read` will read while streaming a page. A HEAD `Content-Length` preflight may reject oversized pages before GET, but the streaming cap is authoritative. Invalid values fall back to the default. |
+| `FLARESOLVERR_URL` | No | — | Base URL of a trusted FlareSolverr or Byparr-compatible service, such as `http://flaresolverr:8191`. When set, `web_url_read` asks its `/v1` API for a browser session before each uncached URL read. |
+| `FLARESOLVERR_TIMEOUT_MS` | No | `60000` | Maximum session-acquisition time in milliseconds, from `1` through `300000`. Invalid values use the default. This is separate from `FETCH_TIMEOUT_MS`, which starts when the target is replayed. |
+| `FLARESOLVERR_MAX_CONCURRENT_REQUESTS` | No | `2` | Maximum concurrent solver acquisitions per MCP process, from `1` through `16`. When all slots are occupied, the request uses the direct URL-reader path instead of waiting in a queue. |
 | `CACHE_TTL_MS` | No | `86400000` | URL cache TTL in milliseconds. Invalid or non-positive values fall back to the default (24 hours). |
 | `CACHE_MAX_ENTRIES` | No | `500` | Maximum number of cached URLs. When the cache exceeds this size, the least frequently used entry is evicted, with oldest entry used as the tie-breaker. Invalid or non-positive values fall back to the default. |
+
+With `FLARESOLVERR_URL` configured, `web_url_read` first performs its normal
+target URL security and HEAD size preflight. It then requests only the browser
+session cookies and user-agent from the solver. The actual target is fetched by
+`mcp-searxng`, so redirect validation, URL-reader proxy selection, streaming
+size limits, content-type handling, and caching remain authoritative.
+
+A transient solver connection, timeout, overload, malformed response, or
+oversized response falls back once to the direct URL-reader path. Invalid
+solver configuration, a solver result for a different hostname, and a
+non-success target status reported by the solver fail closed. Solver-backed
+cache entries are isolated from direct-fetch entries. PDFs remain unsupported
+by this feature and return the existing binary-content hint.
+
+Example with the official FlareSolverr image:
+
+```yaml
+services:
+  mcp-searxng:
+    image: isokoliuk/mcp-searxng:latest
+    stdin_open: true
+    environment:
+      - SEARXNG_URL=${SEARXNG_URL:?Set SEARXNG_URL in the environment}
+      - FLARESOLVERR_URL=http://flaresolverr:8191
+    depends_on:
+      - flaresolverr
+
+  flaresolverr:
+    image: flaresolverr/flaresolverr:v3.5.0
+    environment:
+      - LOG_LEVEL=info
+      - LOG_HTML=false
+      - CAPTCHA_SOLVER=${CAPTCHA_SOLVER:-none}
+      - TZ=America/Chicago
+```
+
+The solver is an operator-trusted browser service. Keep it on a private
+container network, do not expose port 8191 publicly, and restrict its egress
+from private services and cloud metadata endpoints. See
+[SECURITY.md](SECURITY.md#delegated-browser-service) for the trust boundary.
 
 ## User-Agent
 
@@ -115,6 +158,11 @@ Interface-specific proxies take priority over global proxies for their respectiv
 | `SEARCH_HTTP_PROXY` / `SEARCH_HTTPS_PROXY` | No | — | Proxy for all SearXNG-bound traffic: search, suggestions, and capability discovery |
 | `URL_READER_HTTP_PROXY` / `URL_READER_HTTPS_PROXY` | No | — | Proxy for `web_url_read` only |
 | `NO_PROXY` | No | — | Comma-separated bypass list (e.g. `localhost,.internal,example.com`) |
+
+The solver API request uses only the global `HTTP_PROXY` / `HTTPS_PROXY` and
+`NO_PROXY` settings because `FLARESOLVERR_URL` identifies an operator-trusted
+service. The target replay continues to use the URL-reader-specific proxy
+settings first.
 
 ## TLS / Corporate CA
 
@@ -244,6 +292,9 @@ This combined MCP client configuration shows the supported option groups in one 
         "SEARXNG_HTML_FALLBACK": "false",
         "URL_READ_MAX_CHARS": "2000",
         "URL_READ_MAX_CONTENT_LENGTH_BYTES": "5242880",
+        "FLARESOLVERR_URL": "http://flaresolverr:8191",
+        "FLARESOLVERR_TIMEOUT_MS": "60000",
+        "FLARESOLVERR_MAX_CONCURRENT_REQUESTS": "2",
         "CACHE_TTL_MS": "86400000",
         "CACHE_MAX_ENTRIES": "500",
         "USER_AGENT": "MyBot/1.0",

--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@ For measured MCP-process CPU and memory starting points, see
 - **Search Suggestions**: Query autocomplete via SearXNG's `/autocompleter` endpoint.
 - **Instance Capability Discovery**: Inspect configured categories, engines, defaults, locales, and plugins from `/config`.
 - **URL Content Reading**: Content-type-aware Markdown conversion with pagination, section filtering, paragraph ranges, and heading extraction.
+- **Challenge-Page Support**: Optionally acquire a browser session from FlareSolverr or its Byparr-compatible API, then replay the returned user-agent and scoped cookies through the bounded URL reader.
 - **Intelligent Caching**: Both search results and URL content are cached in memory with configurable TTL and least-frequently-used (LFU) eviction, reducing redundant requests.
 - **SSRF Protection**: `web_url_read` blocks private/internal URLs and redirects by default in all transport modes.
 - **HTTP Transport**: Optional Streamable HTTP mode with opt-in hardening — bearer-token auth, CORS allowlist, and rate limiting.
@@ -147,6 +148,7 @@ For SearXNG deployment, configuration, and troubleshooting, see
     - Plain text, YAML, TOML, XML, and other safe explicit `text/*` responses are returned as readable fenced text
     - Missing or generic content types are read under the existing size cap; non-binary bodies continue through the HTML-to-markdown path for compatibility
   - Binary, media, archive, PDF, and octet-stream downloads are intentionally rejected with a short hint instead of returning raw bytes
+  - When `FLARESOLVERR_URL` is configured, challenge-protected URLs are solved first and then fetched through the normal URL-reader security, redirect, proxy, and size controls
   - Inputs:
     - `url` (string): The URL to fetch and process
     - `startChar` (number, optional): Starting character position for content extraction (default: 0)
@@ -209,6 +211,10 @@ Image signatures can be verified with Cosign — see [SECURITY.md](SECURITY.md) 
 ```
 
 To pass additional env vars, add `-e VAR_NAME` to `args` and the variable to `env`.
+For FlareSolverr or Byparr integration, pass `FLARESOLVERR_URL` as well and make
+the service reachable from this container. See
+[URL Reader Controls](CONFIGURATION.md#url-reader-controls) for the complete
+behavior and Docker Compose example.
 
 **Build locally:**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -62,8 +62,10 @@ Setting `FLARESOLVERR_URL` delegates challenge-page navigation to a trusted
 FlareSolverr or Byparr-compatible browser service. `mcp-searxng` validates the
 requested target before contacting the solver, accepts a solution only for the
 same hostname, filters returned cookies by domain, path, secure flag, and
-expiry, and performs the final target fetch through the normal URL-reader
-controls.
+expiry, rejects cookie names or values outside the HTTP cookie character set or
+above 4096 bytes per pair, and performs the final target fetch through the
+normal URL-reader controls. Replay restarts at the originally requested URL;
+the solver-returned URL is used only for same-host integrity validation.
 
 The browser service performs its own navigation internally. `mcp-searxng`
 cannot intercept or validate every redirect the browser follows while solving a

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -56,6 +56,31 @@ When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTP
 
 To allow private URL reads and private DNS-resolved targets (e.g. for internal deployments), set `MCP_HTTP_ALLOW_PRIVATE_URLS=true`. Do this only when internal fetching is intentional.
 
+### Delegated Browser Service
+
+Setting `FLARESOLVERR_URL` delegates challenge-page navigation to a trusted
+FlareSolverr or Byparr-compatible browser service. `mcp-searxng` validates the
+requested target before contacting the solver, accepts a solution only for the
+same hostname, filters returned cookies by domain, path, secure flag, and
+expiry, and performs the final target fetch through the normal URL-reader
+controls.
+
+The browser service performs its own navigation internally. `mcp-searxng`
+cannot intercept or validate every redirect the browser follows while solving a
+challenge. Treat that service as part of the trusted deployment boundary:
+
+- keep it on a private network and do not publish its API port;
+- use firewall or container-network egress rules to block private services,
+  localhost, and cloud metadata endpoints;
+- run it with the least privileges and resource limits appropriate to a browser
+  workload;
+- keep the solver image updated and review its own security guidance.
+
+Transient solver failures use the direct URL-reader path once. Invalid solver
+configuration and hostname-divergent solutions fail closed. The solver API
+response is capped at 256 KiB, and concurrent solver acquisitions are bounded
+by `FLARESOLVERR_MAX_CONCURRENT_REQUESTS`.
+
 ### Hardened HTTP Mode
 
 When `MCP_HTTP_PORT` is set, the server exposes an HTTP endpoint. By default it has no authentication. Enable hardened mode for any network-accessible deployment:

--- a/__tests__/e2e/flaresolverr.e2e.ts
+++ b/__tests__/e2e/flaresolverr.e2e.ts
@@ -60,7 +60,7 @@ function readUrlMessages(url: string): object[] {
 }
 
 async function runTests() {
-  console.log('ðŸŒ E2E Testing: FlareSolverr URL reader\n');
+  console.log('🌐 E2E Testing: FlareSolverr URL reader\n');
 
   const skip = checkSkipConditions(false);
   if (skip) {
@@ -143,7 +143,7 @@ async function runTests() {
       assert.ok(text.includes('Unsupported content type: application/pdf'), text);
     }, results);
   } else {
-    console.log('[SKIP] FLARESOLVERR_URL not set â€” skipping real protected-PDF test');
+    console.log('[SKIP] FLARESOLVERR_URL not set — skipping real protected-PDF test');
   }
 
   printTestSummary(results, 'E2E: FlareSolverr URL Reader');

--- a/__tests__/e2e/flaresolverr.e2e.ts
+++ b/__tests__/e2e/flaresolverr.e2e.ts
@@ -1,0 +1,157 @@
+#!/usr/bin/env tsx
+
+/**
+ * E2E Tests: FlareSolverr-backed web_url_read through the built MCP STDIO
+ * transport. The deterministic local test always runs. The real protected-PDF
+ * test runs when FLARESOLVERR_URL points at an available service.
+ */
+
+import { strict as assert } from 'node:assert';
+import http from 'node:http';
+import net from 'node:net';
+import { fileURLToPath } from 'node:url';
+import {
+  checkSkipConditions,
+  INIT_PARAMS,
+  spawnWithMessagesAsync,
+} from './helpers/spawn-server.js';
+import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
+
+const results = createTestResults();
+const PROTECTED_PDF_URL = 'https://eprint.iacr.org/2025/858.pdf';
+
+interface TestServer {
+  url: string;
+  close: () => Promise<void>;
+}
+
+function startServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<TestServer> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(handler);
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as net.AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${address.port}`,
+        close: () => new Promise<void>((done) => {
+          server.closeAllConnections();
+          server.close(() => done());
+        }),
+      });
+    });
+    server.once('error', reject);
+  });
+}
+
+function readUrlMessages(url: string): object[] {
+  return [
+    { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+    {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'web_url_read',
+        arguments: { url },
+      },
+    },
+  ];
+}
+
+async function runTests() {
+  console.log('ðŸŒ E2E Testing: FlareSolverr URL reader\n');
+
+  const skip = checkSkipConditions(false);
+  if (skip) {
+    console.log(skip);
+    return { passed: 0, failed: 0, errors: [] };
+  }
+
+  await testFunction('built MCP server replays a solved browser session', async () => {
+    let replayUserAgent = '';
+    let replayCookie = '';
+    const target = await startServer((req, res) => {
+      if (req.method === 'GET') {
+        replayUserAgent = req.headers['user-agent'] ?? '';
+        replayCookie = req.headers.cookie ?? '';
+      }
+      res.writeHead(req.method === 'HEAD' ? 403 : 200, {
+        'content-type': 'text/html; charset=utf-8',
+      });
+      res.end(req.method === 'HEAD' ? '' : '<html><body><h1>Solver E2E</h1></body></html>');
+    });
+    const solver = await startServer((req, res) => {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        const request = JSON.parse(body) as { url: string };
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          status: 'ok',
+          solution: {
+            url: request.url,
+            status: 200,
+            cookies: [{
+              name: 'cf_clearance',
+              value: 'e2e-token',
+              domain: '127.0.0.1',
+              path: '/',
+            }],
+            userAgent: 'flaresolverr-e2e-agent',
+          },
+        }));
+      });
+    });
+
+    try {
+      const responses = await spawnWithMessagesAsync(
+        readUrlMessages(target.url),
+        'https://test-searx.example.com',
+        15_000,
+        {
+          FLARESOLVERR_URL: solver.url,
+          MCP_HTTP_ALLOW_PRIVATE_URLS: 'true',
+          NO_PROXY: '127.0.0.1',
+        },
+      );
+      const response = responses[2];
+      assert.ok(response && !response.error, JSON.stringify(response?.error));
+      const text: string = response.result?.content?.[0]?.text ?? '';
+      assert.ok(text.includes('# Solver E2E'), text);
+      assert.equal(replayUserAgent, 'flaresolverr-e2e-agent');
+      assert.equal(replayCookie, 'cf_clearance=e2e-token');
+    } finally {
+      await solver.close();
+      await target.close();
+    }
+  }, results);
+
+  if (process.env.FLARESOLVERR_URL) {
+    await testFunction('real Cloudflare-protected IACR PDF is pulled through FlareSolverr', async () => {
+      const responses = await spawnWithMessagesAsync(
+        readUrlMessages(PROTECTED_PDF_URL),
+        'https://test-searx.example.com',
+        90_000,
+      );
+      const response = responses[2];
+      assert.ok(response && !response.error, JSON.stringify(response?.error));
+      const text: string = response.result?.content?.[0]?.text ?? '';
+      assert.ok(text.includes('Unsupported content type: application/pdf'), text);
+    }, results);
+  } else {
+    console.log('[SKIP] FLARESOLVERR_URL not set â€” skipping real protected-PDF test');
+  }
+
+  printTestSummary(results, 'E2E: FlareSolverr URL Reader');
+  return results;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runTests().then((result) => process.exit(result.failed > 0 ? 1 : 0)).catch(console.error);
+}
+
+export { runTests };

--- a/__tests__/e2e/helpers/spawn-server.ts
+++ b/__tests__/e2e/helpers/spawn-server.ts
@@ -12,7 +12,7 @@
  *   const toolResult = responses[2]; // keyed by id
  */
 
-import { spawnSync } from 'node:child_process';
+import { spawn, spawnSync } from 'node:child_process';
 import { existsSync } from 'node:fs';
 import path from 'node:path';
 
@@ -82,4 +82,80 @@ export function spawnWithMessages(
     }
   }
   return responses;
+}
+
+/**
+ * Asynchronous variant used when the parent process hosts local target or
+ * solver servers that must continue servicing requests while the MCP child is
+ * running.
+ */
+export async function spawnWithMessagesAsync(
+  messages: object[],
+  searxngUrl: string = LIVE_URL ?? '',
+  timeoutMs = 15000,
+  environmentOverrides: NodeJS.ProcessEnv = {},
+): Promise<Record<number, any>> {
+  const input = messages.map((message) => JSON.stringify(message)).join('\n') + '\n';
+
+  return await new Promise((resolve, reject) => {
+    const child = spawn('node', [DIST_CLI], {
+      env: {
+        ...process.env,
+        ...environmentOverrides,
+        SEARXNG_URL: searxngUrl,
+      },
+      stdio: ['pipe', 'pipe', 'pipe'],
+      windowsHide: true,
+    });
+    let stdout = '';
+    let stderr = '';
+    let timedOut = false;
+    const timeout = setTimeout(() => {
+      timedOut = true;
+      child.kill();
+    }, timeoutMs);
+
+    child.stdout.setEncoding('utf8');
+    child.stderr.setEncoding('utf8');
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk;
+    });
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk;
+    });
+    child.once('error', (error) => {
+      clearTimeout(timeout);
+      reject(error);
+    });
+    child.once('close', (code) => {
+      clearTimeout(timeout);
+      if (timedOut) {
+        reject(new Error(`MCP child timed out after ${timeoutMs}ms`));
+        return;
+      }
+      if (code !== 0) {
+        reject(new Error(`MCP child exited with code ${code}: ${stderr.trim()}`));
+        return;
+      }
+
+      const responses: Record<number, any> = {};
+      for (const line of stdout.split('\n')) {
+        const trimmed = line.trim();
+        if (!trimmed) {
+          continue;
+        }
+        try {
+          const message = JSON.parse(trimmed);
+          if (message.id !== undefined) {
+            responses[message.id] = message;
+          }
+        } catch {
+          // Notifications and unparseable lines are ignored.
+        }
+      }
+      resolve(responses);
+    });
+
+    child.stdin.end(input);
+  });
 }

--- a/__tests__/e2e/run-e2e.ts
+++ b/__tests__/e2e/run-e2e.ts
@@ -17,6 +17,7 @@ import { runTests as runSuggestionsTests } from './suggestions.e2e.js';
 import { runTests as runInstanceInfoTests } from './instance-info.e2e.js';
 import { runTests as runUrlReaderTests } from './url-reader.e2e.js';
 import { runTests as runTimeoutTests } from './timeout.e2e.js';
+import { runTests as runFlareSolverrTests } from './flaresolverr.e2e.js';
 
 async function main() {
   console.log('🚀 MCP SearXNG — E2E Test Suite\n');
@@ -36,6 +37,7 @@ async function main() {
     { name: 'Search Suggestions (live)', run: runSuggestionsTests },
     { name: 'Instance Info (live)', run: runInstanceInfoTests },
     { name: 'URL Reader (live)', run: runUrlReaderTests },
+    { name: 'FlareSolverr URL Reader', run: runFlareSolverrTests },
     { name: 'Timeout (local)', run: runTimeoutTests },
   ]) {
     try {

--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -17,6 +17,7 @@ import { runTests as runTypesTests } from './unit/types.test.js';
 import { runTests as runCacheTests } from './unit/cache.test.js';
 import { runTests as runSearchCacheTests } from './unit/search-cache.test.js';
 import { runTests as runProxyTests } from './unit/proxy.test.js';
+import { runTests as runFlareSolverrTests } from './unit/flaresolverr.test.js';
 import { runTests as runErrorHandlerTests } from './unit/error-handler.test.js';
 import { runTests as runSearxngInstancesTests } from './unit/searxng-instances.test.js';
 import { runTests as runResourcesTests } from './unit/resources.test.js';
@@ -54,6 +55,7 @@ const testSuites: TestSuite[] = [
   { name: 'Cache', category: 'unit', run: runCacheTests },
   { name: 'Search Cache', category: 'unit', run: runSearchCacheTests },
   { name: 'Proxy', category: 'unit', run: runProxyTests },
+  { name: 'FlareSolverr', category: 'unit', run: runFlareSolverrTests },
   { name: 'Error Handler', category: 'unit', run: runErrorHandlerTests },
   { name: 'SearXNG Instances', category: 'unit', run: runSearxngInstancesTests },
   { name: 'Resources', category: 'unit', run: runResourcesTests },

--- a/__tests__/unit/flaresolverr.test.ts
+++ b/__tests__/unit/flaresolverr.test.ts
@@ -1,0 +1,322 @@
+#!/usr/bin/env tsx
+
+import { strict as assert } from "node:assert";
+import * as http from "node:http";
+import * as net from "node:net";
+import { fileURLToPath } from "node:url";
+import {
+  acquireFlareSolverrSolution,
+  buildFlareSolverrHeaders,
+  createFlareSolverrCacheKey,
+  resolveFlareSolverrConfig,
+  type FlareSolverrConfig,
+} from "../../src/flaresolverr.js";
+import { createMockServer, createMockServerWithTracking } from "../helpers/mock-server.js";
+import { createTestResults, printTestSummary, testFunction } from "../helpers/test-utils.js";
+
+const results = createTestResults();
+
+interface TestServer {
+  url: string;
+  close: () => Promise<void>;
+}
+
+function startServer(
+  handler: (req: http.IncomingMessage, res: http.ServerResponse) => void,
+): Promise<TestServer> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer(handler);
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address() as net.AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${address.port}`,
+        close: () => new Promise<void>((done) => {
+          server.closeAllConnections();
+          server.close(() => done());
+        }),
+      });
+    });
+    server.once("error", reject);
+  });
+}
+
+async function readJsonBody(req: http.IncomingMessage): Promise<any> {
+  const chunks: Buffer[] = [];
+  for await (const chunk of req) {
+    chunks.push(Buffer.isBuffer(chunk) ? chunk : Buffer.from(chunk));
+  }
+  return JSON.parse(Buffer.concat(chunks).toString("utf8"));
+}
+
+function jsonSolution(url: string, extra: Record<string, unknown> = {}) {
+  return {
+    status: "ok",
+    message: "Challenge solved!",
+    solution: {
+      url,
+      status: 200,
+      cookies: [{
+        name: "clearance",
+        value: "abc",
+        domain: ".example.com",
+        path: "/",
+        secure: true,
+        expires: 4102444800,
+      }],
+      userAgent: "SolverUA/1.0",
+      ...extra,
+    },
+  };
+}
+
+async function runTests() {
+  console.log("🧪 Testing: flaresolverr.ts\n");
+
+  await testFunction("unset and blank FLARESOLVERR_URL disable the solver", () => {
+    const server = createMockServer();
+    delete process.env.FLARESOLVERR_URL;
+    assert.equal(resolveFlareSolverrConfig(server as any), null);
+    process.env.FLARESOLVERR_URL = "   ";
+    assert.equal(resolveFlareSolverrConfig(server as any), null);
+  }, results);
+
+  await testFunction("configuration normalizes a base path and bounded defaults", () => {
+    process.env.FLARESOLVERR_URL = "http://solver.example/base";
+    delete process.env.FLARESOLVERR_TIMEOUT_MS;
+    delete process.env.FLARESOLVERR_MAX_CONCURRENT_REQUESTS;
+
+    const config = resolveFlareSolverrConfig(createMockServer() as any);
+    assert.equal(config?.endpoint.href, "http://solver.example/base/v1");
+    assert.equal(config?.timeoutMs, 60000);
+    assert.equal(config?.maxConcurrentRequests, 2);
+  }, results);
+
+  await testFunction("invalid numeric controls warn and use bounded defaults", async () => {
+    process.env.FLARESOLVERR_URL = "http://solver.example";
+    process.env.FLARESOLVERR_TIMEOUT_MS = "300001";
+    process.env.FLARESOLVERR_MAX_CONCURRENT_REQUESTS = "17";
+    const { server, getLoggingCalls } = createMockServerWithTracking();
+
+    const config = resolveFlareSolverrConfig(server as any);
+    await new Promise((resolve) => setImmediate(resolve));
+
+    assert.equal(config?.timeoutMs, 60000);
+    assert.equal(config?.maxConcurrentRequests, 2);
+    const messages = getLoggingCalls().map((entry) => entry.data?.message ?? "");
+    assert.equal(messages.filter((message) => message.includes("FLARESOLVERR_")).length, 2);
+    assert.ok(messages.every((message) => !message.includes("300001") && !message.includes("17")));
+  }, results);
+
+  await testFunction("invalid FLARESOLVERR_URL fails closed", () => {
+    process.env.FLARESOLVERR_URL = "file:///tmp/solver";
+    assert.throws(
+      () => resolveFlareSolverrConfig(createMockServer() as any),
+      /FLARESOLVERR_URL.*http.*https/iu,
+    );
+
+    process.env.FLARESOLVERR_URL = "http://solver.example/path?query=1";
+    assert.throws(
+      () => resolveFlareSolverrConfig(createMockServer() as any),
+      /FLARESOLVERR_URL/u,
+    );
+  }, results);
+
+  await testFunction("solver request uses the shared cookie-only API contract", async () => {
+    let receivedPath = "";
+    let receivedBody: any;
+    const target = new URL("https://example.com/paper");
+    const solver = await startServer(async (req, res) => {
+      receivedPath = req.url ?? "";
+      receivedBody = await readJsonBody(req);
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(jsonSolution(target.href)));
+    });
+
+    try {
+      const config: FlareSolverrConfig = {
+        endpoint: new URL(`${solver.url}/v1`),
+        timeoutMs: 1000,
+        maxConcurrentRequests: 2,
+      };
+      const acquisition = await acquireFlareSolverrSolution(
+        createMockServer() as any,
+        config,
+        target,
+      );
+
+      assert.equal(receivedPath, "/v1");
+      assert.deepEqual(receivedBody, {
+        cmd: "request.get",
+        url: target.href,
+        maxTimeout: 1000,
+        returnOnlyCookies: true,
+      });
+      assert.equal(acquisition.kind, "solved");
+      if (acquisition.kind === "solved") {
+        assert.equal(acquisition.solution.userAgent, "SolverUA/1.0");
+        assert.equal(acquisition.solution.cookies.length, 1);
+      }
+    } finally {
+      await solver.close();
+    }
+  }, results);
+
+  await testFunction("small Byparr-style extra response fields are ignored", async () => {
+    const target = new URL("https://example.com/paper");
+    const solver = await startServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(jsonSolution(target.href, { response: "<html>ignored</html>" })));
+    });
+
+    try {
+      const acquisition = await acquireFlareSolverrSolution(
+        createMockServer() as any,
+        { endpoint: new URL(`${solver.url}/v1`), timeoutMs: 1000, maxConcurrentRequests: 2 },
+        target,
+      );
+      assert.equal(acquisition.kind, "solved");
+    } finally {
+      await solver.close();
+    }
+  }, results);
+
+  await testFunction("oversized, malformed, top-level error, and timed-out responses fall back", async () => {
+    const target = new URL("https://example.com/paper");
+    const cases = [
+      "x".repeat(262145),
+      "{not-json",
+      JSON.stringify({ status: "error", message: "private solver detail" }),
+    ];
+
+    for (const body of cases) {
+      const { server: mockServer, getLoggingCalls } = createMockServerWithTracking();
+      const solver = await startServer((_req, res) => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(body);
+      });
+      try {
+        const acquisition = await acquireFlareSolverrSolution(
+          mockServer as any,
+          { endpoint: new URL(`${solver.url}/v1`), timeoutMs: 1000, maxConcurrentRequests: 2 },
+          target,
+        );
+        assert.deepEqual(acquisition, { kind: "fallback", reason: "unavailable" });
+        await new Promise((resolve) => setImmediate(resolve));
+        assert.ok(JSON.stringify(getLoggingCalls()).includes("direct"));
+        assert.ok(!JSON.stringify(getLoggingCalls()).includes("private solver detail"));
+      } finally {
+        await solver.close();
+      }
+    }
+
+    const hanging = await startServer(() => {});
+    try {
+      const acquisition = await acquireFlareSolverrSolution(
+        createMockServer() as any,
+        { endpoint: new URL(`${hanging.url}/v1`), timeoutMs: 25, maxConcurrentRequests: 2 },
+        target,
+      );
+      assert.deepEqual(acquisition, { kind: "fallback", reason: "unavailable" });
+    } finally {
+      await hanging.close();
+    }
+  }, results);
+
+  await testFunction("concurrency saturation falls back and releases slots", async () => {
+    const target = new URL("https://example.com/paper");
+    const pending: http.ServerResponse[] = [];
+    let releaseReady!: () => void;
+    const ready = new Promise<void>((resolve) => { releaseReady = resolve; });
+    const solver = await startServer((_req, res) => {
+      pending.push(res);
+      if (pending.length === 2) releaseReady();
+    });
+    const config: FlareSolverrConfig = {
+      endpoint: new URL(`${solver.url}/v1`),
+      timeoutMs: 1000,
+      maxConcurrentRequests: 2,
+    };
+
+    try {
+      const first = acquireFlareSolverrSolution(createMockServer() as any, config, target);
+      const second = acquireFlareSolverrSolution(createMockServer() as any, config, target);
+      await ready;
+      const third = await acquireFlareSolverrSolution(createMockServer() as any, config, target);
+      assert.deepEqual(third, { kind: "fallback", reason: "busy" });
+
+      for (const response of pending) {
+        response.writeHead(200, { "content-type": "application/json" });
+        response.end(JSON.stringify(jsonSolution(target.href)));
+      }
+      assert.equal((await first).kind, "solved");
+      assert.equal((await second).kind, "solved");
+
+      const fourth = acquireFlareSolverrSolution(createMockServer() as any, config, target);
+      while (pending.length < 3) {
+        await new Promise((resolve) => setImmediate(resolve));
+      }
+      pending[2].writeHead(200, { "content-type": "application/json" });
+      pending[2].end(JSON.stringify(jsonSolution(target.href)));
+      assert.equal((await fourth).kind, "solved");
+    } finally {
+      await solver.close();
+    }
+  }, results);
+
+  await testFunction("cookie scope, expiry, security, and path specificity are enforced", () => {
+    const solution = {
+      url: "https://sub.example.com/a/b",
+      status: 200,
+      userAgent: "SolverUA/1.0",
+      cookies: [
+        { name: "domain", value: "2", domain: ".example.com", path: "/", secure: true, expires: 4102444800 },
+        { name: "deep", value: "1", domain: "sub.example.com", path: "/a", secure: true, expires: 4102444800 },
+        { name: "session", value: "3", path: "/", secure: false, expires: -1 },
+        { name: "expired", value: "x", domain: ".example.com", path: "/", expires: 1000 },
+        { name: "wrong-domain", value: "x", domain: ".other.example", path: "/" },
+        { name: "wrong-path", value: "x", domain: ".example.com", path: "/other" },
+        { name: "secure-http", value: "x", domain: ".example.com", path: "/", secure: true },
+        { name: "", value: "x", domain: ".example.com", path: "/" },
+      ],
+    };
+
+    assert.deepEqual(
+      buildFlareSolverrHeaders(solution, new URL("https://sub.example.com/a/b"), 2000),
+      {
+        "User-Agent": "SolverUA/1.0",
+        Cookie: "deep=1; domain=2; session=3; secure-http=x",
+      },
+    );
+    assert.deepEqual(
+      buildFlareSolverrHeaders(solution, new URL("http://sub.example.com/a/b"), 2000),
+      {
+        "User-Agent": "SolverUA/1.0",
+        Cookie: "session=3",
+      },
+    );
+    assert.deepEqual(
+      buildFlareSolverrHeaders(
+        { ...solution, cookies: [] },
+        new URL("https://sub.example.com/a/b"),
+        2000,
+      ),
+      { "User-Agent": "SolverUA/1.0" },
+    );
+  }, results);
+
+  await testFunction("solver cache key uses the original requested URL", () => {
+    assert.equal(
+      createFlareSolverrCacheKey("https://example.com/original"),
+      "solver:https://example.com/original",
+    );
+  }, results);
+
+  printTestSummary(results, "FlareSolverr Module");
+  return results;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runTests().then((result) => process.exit(result.failed > 0 ? 1 : 0)).catch(console.error);
+}
+
+export { runTests };

--- a/__tests__/unit/flaresolverr.test.ts
+++ b/__tests__/unit/flaresolverr.test.ts
@@ -186,6 +186,27 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction("solver response transfer has grace beyond the browser timeout", async () => {
+    const target = new URL("https://example.com/paper");
+    const solver = await startServer((_req, res) => {
+      setTimeout(() => {
+        res.writeHead(200, { "content-type": "application/json" });
+        res.end(JSON.stringify(jsonSolution(target.href)));
+      }, 35);
+    });
+
+    try {
+      const acquisition = await acquireFlareSolverrSolution(
+        createMockServer() as any,
+        { endpoint: new URL(`${solver.url}/v1`), timeoutMs: 20, maxConcurrentRequests: 2 },
+        target,
+      );
+      assert.equal(acquisition.kind, "solved");
+    } finally {
+      await solver.close();
+    }
+  }, results);
+
   await testFunction("persistent solver HTTP 4xx fails closed while transient statuses fall back", async () => {
     const target = new URL("https://example.com/paper");
     for (const status of [400, 404]) {
@@ -323,6 +344,9 @@ async function runTests() {
         { name: "wrong-domain", value: "x", domain: ".other.example", path: "/" },
         { name: "wrong-path", value: "x", domain: ".example.com", path: "/other" },
         { name: "secure-http", value: "x", domain: ".example.com", path: "/", secure: true },
+        { name: "bad\nname", value: "x", domain: ".example.com", path: "/" },
+        { name: "bad-value", value: "x;y", domain: ".example.com", path: "/" },
+        { name: "oversized", value: "x".repeat(5000), domain: ".example.com", path: "/" },
         { name: "", value: "x", domain: ".example.com", path: "/" },
       ],
     };

--- a/__tests__/unit/flaresolverr.test.ts
+++ b/__tests__/unit/flaresolverr.test.ts
@@ -302,6 +302,14 @@ async function runTests() {
       ),
       { "User-Agent": "SolverUA/1.0" },
     );
+    assert.deepEqual(
+      buildFlareSolverrHeaders(
+        solution,
+        new URL("https://other.example.com/a/b"),
+        2000,
+      ),
+      { "User-Agent": "SolverUA/1.0" },
+    );
   }, results);
 
   await testFunction("solver cache key uses the original requested URL", () => {

--- a/__tests__/unit/flaresolverr.test.ts
+++ b/__tests__/unit/flaresolverr.test.ts
@@ -89,6 +89,12 @@ async function runTests() {
     assert.equal(config?.endpoint.href, "http://solver.example/base/v1");
     assert.equal(config?.timeoutMs, 60000);
     assert.equal(config?.maxConcurrentRequests, 2);
+
+    process.env.FLARESOLVERR_URL = "http://solver.example/base/v1/";
+    assert.equal(
+      resolveFlareSolverrConfig(createMockServer() as any)?.endpoint.href,
+      "http://solver.example/base/v1",
+    );
   }, results);
 
   await testFunction("invalid numeric controls warn and use bounded defaults", async () => {
@@ -177,6 +183,47 @@ async function runTests() {
       assert.equal(acquisition.kind, "solved");
     } finally {
       await solver.close();
+    }
+  }, results);
+
+  await testFunction("persistent solver HTTP 4xx fails closed while transient statuses fall back", async () => {
+    const target = new URL("https://example.com/paper");
+    for (const status of [400, 404]) {
+      const solver = await startServer((_req, res) => {
+        res.writeHead(status, { "content-type": "text/plain" });
+        res.end("private response detail");
+      });
+      try {
+        await assert.rejects(
+          acquireFlareSolverrSolution(
+            createMockServer() as any,
+            { endpoint: new URL(`${solver.url}/v1`), timeoutMs: 1000, maxConcurrentRequests: 2 },
+            target,
+          ),
+          /Configuration Error.*endpoint rejected/iu,
+        );
+      } finally {
+        await solver.close();
+      }
+    }
+
+    for (const status of [408, 429, 500]) {
+      const solver = await startServer((_req, res) => {
+        res.writeHead(status, { "content-type": "text/plain" });
+        res.end("transient");
+      });
+      try {
+        assert.deepEqual(
+          await acquireFlareSolverrSolution(
+            createMockServer() as any,
+            { endpoint: new URL(`${solver.url}/v1`), timeoutMs: 1000, maxConcurrentRequests: 2 },
+            target,
+          ),
+          { kind: "fallback", reason: "unavailable" },
+        );
+      } finally {
+        await solver.close();
+      }
     }
   }, results);
 

--- a/__tests__/unit/proxy.test.ts
+++ b/__tests__/unit/proxy.test.ts
@@ -537,6 +537,35 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('trusted solver endpoint ignores URL-reader-only proxy configuration', () => {
+    envManager.delete('HTTP_PROXY');
+    envManager.delete('HTTPS_PROXY');
+    envManager.delete('http_proxy');
+    envManager.delete('https_proxy');
+    envManager.set('URL_READER_HTTP_PROXY', 'http://reader-proxy:8080');
+
+    assert.equal(createProxyAgent('http://flaresolverr:8191'), undefined);
+    envManager.restore();
+  }, results);
+
+  await testFunction('trusted solver endpoint uses global proxy configuration', () => {
+    envManager.set('HTTP_PROXY', 'http://global-proxy:8080');
+
+    assert.equal(
+      createProxyAgent('http://flaresolverr:8191')?.constructor.name,
+      'ProxyAgent',
+    );
+    envManager.restore();
+  }, results);
+
+  await testFunction('trusted solver endpoint honors NO_PROXY', () => {
+    envManager.set('HTTP_PROXY', 'http://global-proxy:8080');
+    envManager.set('NO_PROXY', 'flaresolverr');
+
+    assert.equal(createProxyAgent('http://flaresolverr:8191'), undefined);
+    envManager.restore();
+  }, results);
+
   printTestSummary(results, 'Proxy Module');
   return results;
 }

--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -321,6 +321,7 @@ async function runTests() {
     assert.ok(LITE_READ_URL_TOOL.description.includes('XML'), LITE_READ_URL_TOOL.description);
     assert.ok(LITE_READ_URL_TOOL.description.includes('binary'), LITE_READ_URL_TOOL.description);
     assert.ok(LITE_READ_URL_TOOL.description.includes('rejected'), LITE_READ_URL_TOOL.description);
+    assert.ok(LITE_READ_URL_TOOL.description.includes('FlareSolverr'), LITE_READ_URL_TOOL.description);
   }, results);
 
   await testFunction('Full WEB_SEARCH_TOOL schema has multiple properties including language', () => {
@@ -349,6 +350,7 @@ async function runTests() {
     assert.ok(READ_URL_TOOL.description.includes('Binary'), READ_URL_TOOL.description);
     assert.ok(READ_URL_TOOL.description.includes('media'), READ_URL_TOOL.description);
     assert.ok(READ_URL_TOOL.description.includes('rejected'), READ_URL_TOOL.description);
+    assert.ok(READ_URL_TOOL.description.includes('FlareSolverr'), READ_URL_TOOL.description);
   }, results);
 
   await testFunction('isSearXNGSearchSuggestionsArgs accepts query and optional language', () => {

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -223,11 +223,13 @@ async function runTests() {
   await testFunction('configured FlareSolverr session is replayed with its user agent and cookies', async () => {
     urlCache.clear();
     let targetGetCount = 0;
+    let targetGetPath = '';
     let receivedUserAgent = '';
     let receivedCookie = '';
     const target = await startHttpServer((req, res) => {
       if (req.method === 'GET') {
         targetGetCount++;
+        targetGetPath = req.url ?? '';
         receivedUserAgent = req.headers['user-agent'] ?? '';
         receivedCookie = req.headers.cookie ?? '';
       }
@@ -249,7 +251,7 @@ async function runTests() {
         res.end(JSON.stringify({
           status: 'ok',
           solution: {
-            url: target.url,
+            url: `${target.url}/solver-final`,
             status: 200,
             cookies: [{
               name: 'cf_clearance',
@@ -266,14 +268,16 @@ async function runTests() {
     try {
       envManager.set('FLARESOLVERR_URL', solver.url);
       envManager.set('NO_PROXY', '127.0.0.1');
-      const result = await fetchAndConvertToMarkdown(createMockServer() as any, target.url);
+      const requestedUrl = `${target.url}/original`;
+      const result = await fetchAndConvertToMarkdown(createMockServer() as any, requestedUrl);
 
       assert.ok(result.includes('# Solved page'));
       assert.equal(targetGetCount, 1);
+      assert.equal(targetGetPath, '/original');
       assert.equal(receivedUserAgent, 'flaresolverr-browser-agent');
       assert.equal(receivedCookie, 'cf_clearance=clearance-token');
       assert.equal(solverRequest?.cmd, 'request.get');
-      assert.equal(solverRequest?.url, `${target.url}/`);
+      assert.equal(solverRequest?.url, requestedUrl);
       assert.equal(solverRequest?.returnOnlyCookies, true);
     } finally {
       envManager.restore();
@@ -286,9 +290,12 @@ async function runTests() {
   await testFunction('transient FlareSolverr failure falls back once to the direct fetch path', async () => {
     urlCache.clear();
     let targetGetCount = 0;
+    let targetHeadCount = 0;
     const target = await startHttpServer((req, res) => {
       if (req.method === 'GET') {
         targetGetCount++;
+      } else if (req.method === 'HEAD') {
+        targetHeadCount++;
       }
       res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
       res.end(req.method === 'HEAD' ? '' : '<html><body><h1>Direct fallback</h1></body></html>');
@@ -310,6 +317,7 @@ async function runTests() {
       assert.ok(result.includes('# Direct fallback'));
       assert.equal(solverPostCount, 1);
       assert.equal(targetGetCount, 1);
+      assert.equal(targetHeadCount, 1);
     } finally {
       envManager.restore();
       urlCache.clear();

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -220,6 +220,299 @@ async function runTests() {
 
   // ── network-error wrapping ────────────────────────────────────────────────
 
+  await testFunction('configured FlareSolverr session is replayed with its user agent and cookies', async () => {
+    urlCache.clear();
+    let targetGetCount = 0;
+    let receivedUserAgent = '';
+    let receivedCookie = '';
+    const target = await startHttpServer((req, res) => {
+      if (req.method === 'GET') {
+        targetGetCount++;
+        receivedUserAgent = req.headers['user-agent'] ?? '';
+        receivedCookie = req.headers.cookie ?? '';
+      }
+      res.writeHead(req.method === 'HEAD' ? 403 : 200, {
+        'content-type': 'text/html; charset=utf-8',
+      });
+      res.end(req.method === 'HEAD' ? '' : '<html><body><h1>Solved page</h1></body></html>');
+    });
+    let solverRequest: Record<string, unknown> | null = null;
+    const solver = await startHttpServer((req, res) => {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        solverRequest = JSON.parse(body) as Record<string, unknown>;
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          status: 'ok',
+          solution: {
+            url: target.url,
+            status: 200,
+            cookies: [{
+              name: 'cf_clearance',
+              value: 'clearance-token',
+              domain: '127.0.0.1',
+              path: '/',
+            }],
+            userAgent: 'flaresolverr-browser-agent',
+          },
+        }));
+      });
+    });
+
+    try {
+      envManager.set('FLARESOLVERR_URL', solver.url);
+      envManager.set('NO_PROXY', '127.0.0.1');
+      const result = await fetchAndConvertToMarkdown(createMockServer() as any, target.url);
+
+      assert.ok(result.includes('# Solved page'));
+      assert.equal(targetGetCount, 1);
+      assert.equal(receivedUserAgent, 'flaresolverr-browser-agent');
+      assert.equal(receivedCookie, 'cf_clearance=clearance-token');
+      assert.equal(solverRequest?.cmd, 'request.get');
+      assert.equal(solverRequest?.url, `${target.url}/`);
+      assert.equal(solverRequest?.returnOnlyCookies, true);
+    } finally {
+      envManager.restore();
+      urlCache.clear();
+      await solver.close();
+      await target.close();
+    }
+  }, results);
+
+  await testFunction('transient FlareSolverr failure falls back once to the direct fetch path', async () => {
+    urlCache.clear();
+    let targetGetCount = 0;
+    const target = await startHttpServer((req, res) => {
+      if (req.method === 'GET') {
+        targetGetCount++;
+      }
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(req.method === 'HEAD' ? '' : '<html><body><h1>Direct fallback</h1></body></html>');
+    });
+    let solverPostCount = 0;
+    const solver = await startHttpServer((req, res) => {
+      if (req.method === 'POST') {
+        solverPostCount++;
+      }
+      res.writeHead(503, { 'content-type': 'text/plain' });
+      res.end('unavailable');
+    });
+
+    try {
+      envManager.set('FLARESOLVERR_URL', solver.url);
+      envManager.set('NO_PROXY', '127.0.0.1');
+      const result = await fetchAndConvertToMarkdown(createMockServer() as any, target.url);
+
+      assert.ok(result.includes('# Direct fallback'));
+      assert.equal(solverPostCount, 1);
+      assert.equal(targetGetCount, 1);
+    } finally {
+      envManager.restore();
+      urlCache.clear();
+      await solver.close();
+      await target.close();
+    }
+  }, results);
+
+  await testFunction('solver cache entries are isolated from direct URL cache entries', async () => {
+    urlCache.clear();
+    let targetBody = '<html><body><h1>Direct version</h1></body></html>';
+    const target = await startHttpServer((req, res) => {
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end(req.method === 'HEAD' ? '' : targetBody);
+    });
+    let solverPostCount = 0;
+    const solver = await startHttpServer((req, res) => {
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        solverPostCount++;
+        const request = JSON.parse(body) as { url: string };
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          status: 'ok',
+          solution: {
+            url: request.url,
+            status: 200,
+            cookies: [],
+            userAgent: 'solver-agent',
+          },
+        }));
+      });
+    });
+
+    try {
+      envManager.delete('FLARESOLVERR_URL');
+      envManager.set('NO_PROXY', '127.0.0.1');
+      const direct = await fetchAndConvertToMarkdown(createMockServer() as any, target.url);
+      assert.ok(direct.includes('# Direct version'));
+
+      targetBody = '<html><body><h1>Solver version</h1></body></html>';
+      envManager.set('FLARESOLVERR_URL', solver.url);
+      const solved = await fetchAndConvertToMarkdown(createMockServer() as any, target.url);
+      const cachedSolved = await fetchAndConvertToMarkdown(createMockServer() as any, target.url);
+
+      assert.ok(solved.includes('# Solver version'));
+      assert.equal(cachedSolved, solved);
+      assert.equal(solverPostCount, 1);
+    } finally {
+      envManager.restore();
+      urlCache.clear();
+      await solver.close();
+      await target.close();
+    }
+  }, results);
+
+  await testFunction('non-success solver status is surfaced without a direct replay', async () => {
+    urlCache.clear();
+    let targetGetCount = 0;
+    const target = await startHttpServer((req, res) => {
+      if (req.method === 'GET') {
+        targetGetCount++;
+      }
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end();
+    });
+    const solver = await startHttpServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        status: 'ok',
+        solution: {
+          url: target.url,
+          status: 403,
+          cookies: [],
+          userAgent: 'solver-agent',
+        },
+      }));
+    });
+
+    try {
+      envManager.set('FLARESOLVERR_URL', solver.url);
+      envManager.set('NO_PROXY', '127.0.0.1');
+      await assert.rejects(
+        fetchAndConvertToMarkdown(createMockServer() as any, target.url),
+        /403/u,
+      );
+      assert.equal(targetGetCount, 0);
+    } finally {
+      envManager.restore();
+      urlCache.clear();
+      await solver.close();
+      await target.close();
+    }
+  }, results);
+
+  await testFunction('hostname-divergent solver solutions fail closed before replay', async () => {
+    urlCache.clear();
+    let targetGetCount = 0;
+    const target = await startHttpServer((req, res) => {
+      if (req.method === 'GET') {
+        targetGetCount++;
+      }
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end();
+    });
+    const targetPort = new URL(target.url).port;
+    const solver = await startHttpServer((_req, res) => {
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({
+        status: 'ok',
+        solution: {
+          url: `http://localhost:${targetPort}/`,
+          status: 200,
+          cookies: [],
+          userAgent: 'solver-agent',
+        },
+      }));
+    });
+
+    try {
+      envManager.set('FLARESOLVERR_URL', solver.url);
+      envManager.set('NO_PROXY', '127.0.0.1,localhost');
+      await assert.rejects(
+        fetchAndConvertToMarkdown(createMockServer() as any, target.url),
+        /different or unsupported hostname/iu,
+      );
+      assert.equal(targetGetCount, 0);
+    } finally {
+      envManager.restore();
+      urlCache.clear();
+      await solver.close();
+      await target.close();
+    }
+  }, results);
+
+  await testFunction('URL security policy blocks a target before contacting FlareSolverr', async () => {
+    urlCache.clear();
+    let solverPostCount = 0;
+    const target = await startTestServer();
+    const solver = await startHttpServer((_req, res) => {
+      solverPostCount++;
+      res.writeHead(500);
+      res.end();
+    });
+
+    try {
+      envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
+      envManager.set('FLARESOLVERR_URL', solver.url);
+      envManager.set('NO_PROXY', '127.0.0.1');
+      await assert.rejects(
+        fetchAndConvertToMarkdown(createMockServer() as any, target.url),
+        /not allowed|security/iu,
+      );
+      assert.equal(solverPostCount, 0);
+    } finally {
+      envManager.restore();
+      urlCache.clear();
+      await solver.close();
+      await target.close();
+    }
+  }, results);
+
+  await testFunction('oversized target HEAD response is rejected before contacting FlareSolverr', async () => {
+    urlCache.clear();
+    let targetGetCount = 0;
+    const target = await startHttpServer((req, res) => {
+      if (req.method === 'GET') {
+        targetGetCount++;
+      }
+      res.writeHead(200, {
+        'content-type': 'text/html; charset=utf-8',
+        'content-length': '100',
+      });
+      res.end();
+    });
+    let solverPostCount = 0;
+    const solver = await startHttpServer((_req, res) => {
+      solverPostCount++;
+      res.writeHead(500);
+      res.end();
+    });
+
+    try {
+      envManager.set('FLARESOLVERR_URL', solver.url);
+      envManager.set('URL_READ_MAX_CONTENT_LENGTH_BYTES', '8');
+      envManager.set('NO_PROXY', '127.0.0.1');
+      const result = await fetchAndConvertToMarkdown(createMockServer() as any, target.url);
+
+      assert.ok(result.includes('Content too large'));
+      assert.equal(solverPostCount, 0);
+      assert.equal(targetGetCount, 0);
+    } finally {
+      envManager.restore();
+      urlCache.clear();
+      await solver.close();
+      await target.close();
+    }
+  }, results);
+
   await testFunction('Network error handling', async () => {
     const mockServer = createMockServer();
     // Obtain a free port then release it — connecting right after yields ECONNREFUSED.

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -227,16 +227,24 @@ async function runTests() {
     let receivedUserAgent = '';
     let receivedCookie = '';
     const target = await startHttpServer((req, res) => {
-      if (req.method === 'GET') {
+      const isHeadRequest = req.method === 'HEAD';
+      if (!isHeadRequest) {
         targetGetCount++;
         targetGetPath = req.url ?? '';
         receivedUserAgent = req.headers['user-agent'] ?? '';
         receivedCookie = req.headers.cookie ?? '';
       }
-      res.writeHead(req.method === 'HEAD' ? 403 : 200, {
+      if (isHeadRequest) {
+        res.writeHead(403, {
+          'content-type': 'text/html; charset=utf-8',
+        });
+        res.end();
+        return;
+      }
+      res.writeHead(200, {
         'content-type': 'text/html; charset=utf-8',
       });
-      res.end(req.method === 'HEAD' ? '' : '<html><body><h1>Solved page</h1></body></html>');
+      res.end('<html><body><h1>Solved page</h1></body></html>');
     });
     let solverRequest: Record<string, unknown> | null = null;
     const solver = await startHttpServer((req, res) => {

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -230,9 +230,9 @@ async function runTests() {
       const isHeadRequest = req.method === 'HEAD';
       if (!isHeadRequest) {
         targetGetCount++;
-        targetGetPath = req.url ?? '';
-        receivedUserAgent = req.headers['user-agent'] ?? '';
-        receivedCookie = req.headers.cookie ?? '';
+        targetGetPath = req.url as string;
+        receivedUserAgent = req.headers['user-agent'] as string;
+        receivedCookie = req.headers.cookie as string;
       }
       if (isHeadRequest) {
         res.writeHead(403, {
@@ -326,6 +326,7 @@ async function runTests() {
       assert.equal(solverPostCount, 1);
       assert.equal(targetGetCount, 1);
       assert.equal(targetHeadCount, 1);
+      assert.equal(urlCache.getStats().size, 0);
     } finally {
       envManager.restore();
       urlCache.clear();

--- a/src/flaresolverr.ts
+++ b/src/flaresolverr.ts
@@ -162,9 +162,20 @@ function asRecord(value: unknown): Record<string, unknown> | null {
   return value as Record<string, unknown>;
 }
 
+function isInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isInteger(value);
+}
+
+function isNonEmptyString(value: unknown): value is string {
+  return typeof value === "string" && value.trim() !== "";
+}
+
 function parseSolution(value: unknown): FlareSolverrSolution | null {
   const envelope = asRecord(value);
-  if (!envelope || envelope.status !== "ok") {
+  if (!envelope) {
+    return null;
+  }
+  if (envelope.status !== "ok") {
     return null;
   }
   const solution = asRecord(envelope.solution);
@@ -174,13 +185,13 @@ function parseSolution(value: unknown): FlareSolverrSolution | null {
   if (typeof solution.url !== "string") {
     return null;
   }
-  if (typeof solution.status !== "number" || !Number.isInteger(solution.status)) {
+  if (!isInteger(solution.status)) {
     return null;
   }
   if (!Array.isArray(solution.cookies)) {
     return null;
   }
-  if (typeof solution.userAgent !== "string" || solution.userAgent.trim() === "") {
+  if (!isNonEmptyString(solution.userAgent)) {
     return null;
   }
 
@@ -222,16 +233,14 @@ async function requestFlareSolverrSession(
   config: FlareSolverrConfig,
   requestedUrl: URL,
 ): Promise<string | null> {
-  const controller = new AbortController();
-  const timeoutId = setTimeout(
-    () => controller.abort(),
+  const timeoutSignal = AbortSignal.timeout(
     config.timeoutMs + FLARESOLVERR_RESPONSE_GRACE_MS,
   );
 
   try {
     const requestOptions: RequestInit = {
       method: "POST",
-      signal: controller.signal,
+      signal: timeoutSignal,
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({
         cmd: "request.get",
@@ -265,8 +274,6 @@ async function requestFlareSolverrSession(
       throw error;
     }
     return null;
-  } finally {
-    clearTimeout(timeoutId);
   }
 }
 
@@ -381,6 +388,30 @@ function isUnexpired(cookie: FlareSolverrCookie, nowSeconds: number): boolean {
     || cookie.expires > nowSeconds;
 }
 
+interface NamedCookie extends FlareSolverrCookie {
+  name: string;
+  value: string;
+}
+
+function hasCookieIdentity(cookie: FlareSolverrCookie): cookie is NamedCookie {
+  return typeof cookie.name === "string" && typeof cookie.value === "string";
+}
+
+function cookieTransportMatches(
+  cookie: FlareSolverrCookie,
+  path: string,
+  targetUrl: URL,
+  requestHostname: string,
+  solutionHostname: string,
+  nowSeconds: number,
+): boolean {
+  const secureTransportAllowed = cookie.secure !== true || targetUrl.protocol === "https:";
+  return domainMatches(cookie, requestHostname, solutionHostname)
+    && pathMatches(targetUrl.pathname, path)
+    && secureTransportAllowed
+    && isUnexpired(cookie, nowSeconds);
+}
+
 function cookieMatchesTarget(
   entry: IndexedCookie,
   targetUrl: URL,
@@ -392,14 +423,18 @@ function cookieMatchesTarget(
   if (requestHostname !== solutionHostname) {
     return false;
   }
-  if (typeof cookie.name !== "string" || typeof cookie.value !== "string") {
+  if (!hasCookieIdentity(cookie)) {
     return false;
   }
   return isValidCookiePair(cookie.name, cookie.value)
-    && domainMatches(cookie, requestHostname, solutionHostname)
-    && pathMatches(targetUrl.pathname || "/", path)
-    && (cookie.secure !== true || targetUrl.protocol === "https:")
-    && isUnexpired(cookie, nowSeconds);
+    && cookieTransportMatches(
+      cookie,
+      path,
+      targetUrl,
+      requestHostname,
+      solutionHostname,
+      nowSeconds,
+    );
 }
 
 export function buildFlareSolverrHeaders(

--- a/src/flaresolverr.ts
+++ b/src/flaresolverr.ts
@@ -155,27 +155,32 @@ async function readBoundedResponse(response: Response): Promise<string | null> {
   return new TextDecoder("utf-8").decode(bytes);
 }
 
-function parseSolution(value: unknown): FlareSolverrSolution | null {
+function asRecord(value: unknown): Record<string, unknown> | null {
   if (!value || typeof value !== "object" || Array.isArray(value)) {
     return null;
   }
-  const envelope = value as Record<string, unknown>;
-  if (envelope.status !== "ok") {
+  return value as Record<string, unknown>;
+}
+
+function parseSolution(value: unknown): FlareSolverrSolution | null {
+  const envelope = asRecord(value);
+  if (!envelope || envelope.status !== "ok") {
     return null;
   }
-  const rawSolution = envelope.solution;
-  if (!rawSolution || typeof rawSolution !== "object" || Array.isArray(rawSolution)) {
+  const solution = asRecord(envelope.solution);
+  if (!solution) {
     return null;
   }
-  const solution = rawSolution as Record<string, unknown>;
-  if (
-    typeof solution.url !== "string"
-    || typeof solution.status !== "number"
-    || !Number.isInteger(solution.status)
-    || !Array.isArray(solution.cookies)
-    || typeof solution.userAgent !== "string"
-    || solution.userAgent.trim() === ""
-  ) {
+  if (typeof solution.url !== "string") {
+    return null;
+  }
+  if (typeof solution.status !== "number" || !Number.isInteger(solution.status)) {
+    return null;
+  }
+  if (!Array.isArray(solution.cookies)) {
+    return null;
+  }
+  if (typeof solution.userAgent !== "string" || solution.userAgent.trim() === "") {
     return null;
   }
 
@@ -213,6 +218,69 @@ function logDirectFallback(mcpServer: McpServer): void {
   );
 }
 
+async function requestFlareSolverrSession(
+  config: FlareSolverrConfig,
+  requestedUrl: URL,
+): Promise<string | null> {
+  const controller = new AbortController();
+  const timeoutId = setTimeout(
+    () => controller.abort(),
+    config.timeoutMs + FLARESOLVERR_RESPONSE_GRACE_MS,
+  );
+
+  try {
+    const requestOptions: RequestInit = {
+      method: "POST",
+      signal: controller.signal,
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({
+        cmd: "request.get",
+        url: requestedUrl.href,
+        maxTimeout: config.timeoutMs,
+        returnOnlyCookies: true,
+      }),
+    };
+    applyTrustedServiceRequestConfig(requestOptions, config.endpoint.href);
+    const response = await (undiciFetch as unknown as typeof fetch)(
+      config.endpoint,
+      requestOptions,
+    );
+    const isPersistentClientError = response.status >= 400
+      && response.status < 500
+      && response.status !== 408
+      && response.status !== 429;
+    if (isPersistentClientError) {
+      await response.body?.cancel();
+      throw createConfigurationError(
+        "FlareSolverr endpoint rejected the request. Check FLARESOLVERR_URL and service API compatibility.",
+      );
+    }
+    if (!response.ok) {
+      await response.body?.cancel();
+      return null;
+    }
+    return await readBoundedResponse(response);
+  } catch (error: any) {
+    if (error?.name === "MCPSearXNGError") {
+      throw error;
+    }
+    return null;
+  } finally {
+    clearTimeout(timeoutId);
+  }
+}
+
+function decodeSolution(responseText: string | null): FlareSolverrSolution | null {
+  if (responseText === null) {
+    return null;
+  }
+  try {
+    return parseSolution(JSON.parse(responseText));
+  } catch {
+    return null;
+  }
+}
+
 export async function acquireFlareSolverrSolution(
   mcpServer: McpServer,
   config: FlareSolverrConfig,
@@ -229,71 +297,9 @@ export async function acquireFlareSolverrSolution(
 
   activeSolverRequests++;
   try {
-    const controller = new AbortController();
-    const timeoutId = setTimeout(
-      () => controller.abort(),
-      config.timeoutMs + FLARESOLVERR_RESPONSE_GRACE_MS,
+    const solution = decodeSolution(
+      await requestFlareSolverrSession(config, requestedUrl),
     );
-    let responseText: string | null;
-
-    try {
-      const requestOptions: RequestInit = {
-        method: "POST",
-        signal: controller.signal,
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          cmd: "request.get",
-          url: requestedUrl.href,
-          maxTimeout: config.timeoutMs,
-          returnOnlyCookies: true,
-        }),
-      };
-      applyTrustedServiceRequestConfig(requestOptions, config.endpoint.href);
-      const response = await (undiciFetch as unknown as typeof fetch)(
-        config.endpoint,
-        requestOptions,
-      );
-      if (
-        response.status >= 400
-        && response.status < 500
-        && response.status !== 408
-        && response.status !== 429
-      ) {
-        await response.body?.cancel();
-        throw createConfigurationError(
-          "FlareSolverr endpoint rejected the request. Check FLARESOLVERR_URL and service API compatibility.",
-        );
-      }
-      if (!response.ok) {
-        await response.body?.cancel();
-        logDirectFallback(mcpServer);
-        return { kind: "fallback", reason: "unavailable" };
-      }
-      responseText = await readBoundedResponse(response);
-    } catch (error: any) {
-      if (error?.name === "MCPSearXNGError") {
-        throw error;
-      }
-      logDirectFallback(mcpServer);
-      return { kind: "fallback", reason: "unavailable" };
-    } finally {
-      clearTimeout(timeoutId);
-    }
-
-    if (responseText === null) {
-      logDirectFallback(mcpServer);
-      return { kind: "fallback", reason: "unavailable" };
-    }
-
-    let decoded: unknown;
-    try {
-      decoded = JSON.parse(responseText);
-    } catch {
-      logDirectFallback(mcpServer);
-      return { kind: "fallback", reason: "unavailable" };
-    }
-
-    const solution = parseSolution(decoded);
     if (!solution) {
       logDirectFallback(mcpServer);
       return { kind: "fallback", reason: "unavailable" };
@@ -353,25 +359,47 @@ function isValidCookieName(name: string): boolean {
 }
 
 function isValidCookieValue(value: string): boolean {
-  for (const character of value) {
-    const code = character.charCodeAt(0);
-    if (!(
-      code === 0x21
-      || (code >= 0x23 && code <= 0x2b)
-      || (code >= 0x2d && code <= 0x3a)
-      || (code >= 0x3c && code <= 0x5b)
-      || (code >= 0x5d && code <= 0x7e)
-    )) {
-      return false;
-    }
-  }
-  return true;
+  return /^[\x21\x23-\x2B\x2D-\x3A\x3C-\x5B\x5D-\x7E]*$/u.test(value);
 }
 
 function isValidCookiePair(name: string, value: string): boolean {
   return isValidCookieName(name)
     && isValidCookieValue(value)
     && new TextEncoder().encode(`${name}=${value}`).byteLength <= MAX_COOKIE_PAIR_BYTES;
+}
+
+interface IndexedCookie {
+  cookie: FlareSolverrCookie;
+  index: number;
+  path: string;
+}
+
+function isUnexpired(cookie: FlareSolverrCookie, nowSeconds: number): boolean {
+  return typeof cookie.expires !== "number"
+    || !Number.isFinite(cookie.expires)
+    || cookie.expires <= 0
+    || cookie.expires > nowSeconds;
+}
+
+function cookieMatchesTarget(
+  entry: IndexedCookie,
+  targetUrl: URL,
+  requestHostname: string,
+  solutionHostname: string,
+  nowSeconds: number,
+): boolean {
+  const { cookie, path } = entry;
+  if (requestHostname !== solutionHostname) {
+    return false;
+  }
+  if (typeof cookie.name !== "string" || typeof cookie.value !== "string") {
+    return false;
+  }
+  return isValidCookiePair(cookie.name, cookie.value)
+    && domainMatches(cookie, requestHostname, solutionHostname)
+    && pathMatches(targetUrl.pathname || "/", path)
+    && (cookie.secure !== true || targetUrl.protocol === "https:")
+    && isUnexpired(cookie, nowSeconds);
 }
 
 export function buildFlareSolverrHeaders(
@@ -383,20 +411,12 @@ export function buildFlareSolverrHeaders(
   const solutionHostname = new URL(solution.url).hostname.toLowerCase();
   const matches = solution.cookies
     .map((cookie, index) => ({ cookie, index, path: cookiePath(cookie) }))
-    .filter(({ cookie, path }) => (
-      requestHostname === solutionHostname
-      && typeof cookie.name === "string"
-      && typeof cookie.value === "string"
-      && isValidCookiePair(cookie.name, cookie.value)
-      && domainMatches(cookie, requestHostname, solutionHostname)
-      && pathMatches(targetUrl.pathname || "/", path)
-      && (cookie.secure !== true || targetUrl.protocol === "https:")
-      && !(
-        typeof cookie.expires === "number"
-        && Number.isFinite(cookie.expires)
-        && cookie.expires > 0
-        && cookie.expires <= nowSeconds
-      )
+    .filter((entry) => cookieMatchesTarget(
+      entry,
+      targetUrl,
+      requestHostname,
+      solutionHostname,
+      nowSeconds,
     ))
     .sort((left, right) => right.path.length - left.path.length || left.index - right.index);
 

--- a/src/flaresolverr.ts
+++ b/src/flaresolverr.ts
@@ -83,7 +83,10 @@ function normalizeSolverEndpoint(rawValue: string): URL {
     );
   }
 
-  endpoint.pathname = `${endpoint.pathname.replace(/\/?$/u, "/")}v1`;
+  const pathWithoutTrailingSlash = endpoint.pathname.replace(/\/+$/u, "");
+  endpoint.pathname = pathWithoutTrailingSlash.endsWith("/v1")
+    ? pathWithoutTrailingSlash
+    : `${pathWithoutTrailingSlash}/v1`;
   return endpoint;
 }
 
@@ -245,13 +248,27 @@ export async function acquireFlareSolverrSolution(
         config.endpoint,
         requestOptions,
       );
+      if (
+        response.status >= 400
+        && response.status < 500
+        && response.status !== 408
+        && response.status !== 429
+      ) {
+        await response.body?.cancel();
+        throw createConfigurationError(
+          "FlareSolverr endpoint rejected the request. Check FLARESOLVERR_URL and service API compatibility.",
+        );
+      }
       if (!response.ok) {
         await response.body?.cancel();
         logDirectFallback(mcpServer);
         return { kind: "fallback", reason: "unavailable" };
       }
       responseText = await readBoundedResponse(response);
-    } catch {
+    } catch (error: any) {
+      if (error?.name === "MCPSearXNGError") {
+        throw error;
+      }
       logDirectFallback(mcpServer);
       return { kind: "fallback", reason: "unavailable" };
     } finally {

--- a/src/flaresolverr.ts
+++ b/src/flaresolverr.ts
@@ -321,7 +321,8 @@ export function buildFlareSolverrHeaders(
   const matches = solution.cookies
     .map((cookie, index) => ({ cookie, index, path: cookiePath(cookie) }))
     .filter(({ cookie, path }) => (
-      typeof cookie.name === "string"
+      requestHostname === solutionHostname
+      && typeof cookie.name === "string"
       && cookie.name !== ""
       && typeof cookie.value === "string"
       && domainMatches(cookie, requestHostname, solutionHostname)

--- a/src/flaresolverr.ts
+++ b/src/flaresolverr.ts
@@ -1,0 +1,359 @@
+import type { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { fetch as undiciFetch } from "undici";
+import { createConfigurationError, createContentError } from "./error-handler.js";
+import { parseStrictInteger } from "./env-int.js";
+import { logMessage } from "./logging.js";
+import { applyTrustedServiceRequestConfig } from "./proxy.js";
+
+const DEFAULT_FLARESOLVERR_TIMEOUT_MS = 60_000;
+const MAX_FLARESOLVERR_TIMEOUT_MS = 300_000;
+const DEFAULT_FLARESOLVERR_CONCURRENCY = 2;
+const MAX_FLARESOLVERR_CONCURRENCY = 16;
+const MAX_FLARESOLVERR_RESPONSE_BYTES = 256 * 1024;
+
+export interface FlareSolverrConfig {
+  endpoint: URL;
+  timeoutMs: number;
+  maxConcurrentRequests: number;
+}
+
+export interface FlareSolverrCookie {
+  name?: unknown;
+  value?: unknown;
+  domain?: unknown;
+  path?: unknown;
+  secure?: unknown;
+  expires?: unknown;
+}
+
+export interface FlareSolverrSolution {
+  url: string;
+  status: number;
+  cookies: FlareSolverrCookie[];
+  userAgent: string;
+}
+
+export type FlareSolverrAcquisition =
+  | { kind: "solved"; solution: FlareSolverrSolution }
+  | { kind: "fallback"; reason: "busy" | "unavailable" };
+
+let activeSolverRequests = 0;
+
+function resolveBoundedInteger(
+  mcpServer: McpServer,
+  name: "FLARESOLVERR_TIMEOUT_MS" | "FLARESOLVERR_MAX_CONCURRENT_REQUESTS",
+  fallback: number,
+  maximum: number,
+): number {
+  const rawValue = process.env[name];
+  if (rawValue === undefined || rawValue.trim() === "") {
+    return fallback;
+  }
+
+  const parsed = parseStrictInteger(rawValue);
+  if (parsed === undefined || parsed <= 0 || parsed > maximum) {
+    logMessage(
+      mcpServer,
+      "warning",
+      `Ignoring invalid ${name}. Expected an integer from 1 through ${maximum}; using default ${fallback}.`,
+    );
+    return fallback;
+  }
+
+  return parsed;
+}
+
+function normalizeSolverEndpoint(rawValue: string): URL {
+  let endpoint: URL;
+  try {
+    endpoint = new URL(rawValue.trim());
+  } catch {
+    throw createConfigurationError(
+      "FLARESOLVERR_URL must be an absolute HTTP or HTTPS service base URL.",
+    );
+  }
+
+  if (
+    !["http:", "https:"].includes(endpoint.protocol)
+    || endpoint.search !== ""
+    || endpoint.hash !== ""
+  ) {
+    throw createConfigurationError(
+      "FLARESOLVERR_URL must be an absolute HTTP or HTTPS service base URL without a query or fragment.",
+    );
+  }
+
+  endpoint.pathname = `${endpoint.pathname.replace(/\/?$/u, "/")}v1`;
+  return endpoint;
+}
+
+export function resolveFlareSolverrConfig(
+  mcpServer: McpServer,
+): FlareSolverrConfig | null {
+  const rawUrl = process.env.FLARESOLVERR_URL;
+  if (rawUrl === undefined || rawUrl.trim() === "") {
+    return null;
+  }
+
+  return {
+    endpoint: normalizeSolverEndpoint(rawUrl),
+    timeoutMs: resolveBoundedInteger(
+      mcpServer,
+      "FLARESOLVERR_TIMEOUT_MS",
+      DEFAULT_FLARESOLVERR_TIMEOUT_MS,
+      MAX_FLARESOLVERR_TIMEOUT_MS,
+    ),
+    maxConcurrentRequests: resolveBoundedInteger(
+      mcpServer,
+      "FLARESOLVERR_MAX_CONCURRENT_REQUESTS",
+      DEFAULT_FLARESOLVERR_CONCURRENCY,
+      MAX_FLARESOLVERR_CONCURRENCY,
+    ),
+  };
+}
+
+async function readBoundedResponse(response: Response): Promise<string | null> {
+  if (response.body === null) {
+    return "";
+  }
+
+  const reader = response.body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytesRead = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+      bytesRead += value.byteLength;
+      if (bytesRead > MAX_FLARESOLVERR_RESPONSE_BYTES) {
+        await reader.cancel();
+        return null;
+      }
+      chunks.push(value);
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  const bytes = new Uint8Array(bytesRead);
+  let offset = 0;
+  for (const chunk of chunks) {
+    bytes.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return new TextDecoder("utf-8").decode(bytes);
+}
+
+function parseSolution(value: unknown): FlareSolverrSolution | null {
+  if (!value || typeof value !== "object" || Array.isArray(value)) {
+    return null;
+  }
+  const envelope = value as Record<string, unknown>;
+  if (envelope.status !== "ok") {
+    return null;
+  }
+  const rawSolution = envelope.solution;
+  if (!rawSolution || typeof rawSolution !== "object" || Array.isArray(rawSolution)) {
+    return null;
+  }
+  const solution = rawSolution as Record<string, unknown>;
+  if (
+    typeof solution.url !== "string"
+    || typeof solution.status !== "number"
+    || !Number.isInteger(solution.status)
+    || !Array.isArray(solution.cookies)
+    || typeof solution.userAgent !== "string"
+    || solution.userAgent.trim() === ""
+  ) {
+    return null;
+  }
+
+  return {
+    url: solution.url,
+    status: solution.status,
+    cookies: solution.cookies as FlareSolverrCookie[],
+    userAgent: solution.userAgent,
+  };
+}
+
+function validateSolutionUrl(solution: FlareSolverrSolution, requestedUrl: URL): void {
+  let solvedUrl: URL;
+  try {
+    solvedUrl = new URL(solution.url);
+  } catch {
+    throw createContentError("FlareSolverr returned an invalid solution URL.", requestedUrl.href);
+  }
+  if (
+    !["http:", "https:"].includes(solvedUrl.protocol)
+    || solvedUrl.hostname.toLowerCase() !== requestedUrl.hostname.toLowerCase()
+  ) {
+    throw createContentError(
+      "FlareSolverr returned a solution URL on a different or unsupported hostname.",
+      requestedUrl.href,
+    );
+  }
+}
+
+function logDirectFallback(mcpServer: McpServer): void {
+  logMessage(
+    mcpServer,
+    "warning",
+    "FlareSolverr session acquisition failed; using the direct URL fetch path.",
+  );
+}
+
+export async function acquireFlareSolverrSolution(
+  mcpServer: McpServer,
+  config: FlareSolverrConfig,
+  requestedUrl: URL,
+): Promise<FlareSolverrAcquisition> {
+  if (activeSolverRequests >= config.maxConcurrentRequests) {
+    logMessage(
+      mcpServer,
+      "warning",
+      "FlareSolverr concurrency limit reached; using the direct URL fetch path.",
+    );
+    return { kind: "fallback", reason: "busy" };
+  }
+
+  activeSolverRequests++;
+  try {
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), config.timeoutMs);
+    let responseText: string | null;
+
+    try {
+      const requestOptions: RequestInit = {
+        method: "POST",
+        signal: controller.signal,
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          cmd: "request.get",
+          url: requestedUrl.href,
+          maxTimeout: config.timeoutMs,
+          returnOnlyCookies: true,
+        }),
+      };
+      applyTrustedServiceRequestConfig(requestOptions, config.endpoint.href);
+      const response = await (undiciFetch as unknown as typeof fetch)(
+        config.endpoint,
+        requestOptions,
+      );
+      if (!response.ok) {
+        await response.body?.cancel();
+        logDirectFallback(mcpServer);
+        return { kind: "fallback", reason: "unavailable" };
+      }
+      responseText = await readBoundedResponse(response);
+    } catch {
+      logDirectFallback(mcpServer);
+      return { kind: "fallback", reason: "unavailable" };
+    } finally {
+      clearTimeout(timeoutId);
+    }
+
+    if (responseText === null) {
+      logDirectFallback(mcpServer);
+      return { kind: "fallback", reason: "unavailable" };
+    }
+
+    let decoded: unknown;
+    try {
+      decoded = JSON.parse(responseText);
+    } catch {
+      logDirectFallback(mcpServer);
+      return { kind: "fallback", reason: "unavailable" };
+    }
+
+    const solution = parseSolution(decoded);
+    if (!solution) {
+      logDirectFallback(mcpServer);
+      return { kind: "fallback", reason: "unavailable" };
+    }
+    validateSolutionUrl(solution, requestedUrl);
+    return { kind: "solved", solution };
+  } finally {
+    activeSolverRequests--;
+  }
+}
+
+function cookiePath(cookie: FlareSolverrCookie): string {
+  return typeof cookie.path === "string" && cookie.path.startsWith("/")
+    ? cookie.path
+    : "/";
+}
+
+function pathMatches(requestPath: string, candidate: string): boolean {
+  if (requestPath === candidate) {
+    return true;
+  }
+  if (!requestPath.startsWith(candidate)) {
+    return false;
+  }
+  return candidate.endsWith("/") || requestPath[candidate.length] === "/";
+}
+
+function domainMatches(
+  cookie: FlareSolverrCookie,
+  requestHostname: string,
+  solutionHostname: string,
+): boolean {
+  if (typeof cookie.domain !== "string" || cookie.domain.trim() === "") {
+    return requestHostname === solutionHostname;
+  }
+  const domain = cookie.domain.trim().toLowerCase().replace(/^\./u, "");
+  return requestHostname === domain || requestHostname.endsWith(`.${domain}`);
+}
+
+export function buildFlareSolverrHeaders(
+  solution: FlareSolverrSolution,
+  targetUrl: URL,
+  nowSeconds: number = Date.now() / 1000,
+): Record<string, string> {
+  const requestHostname = targetUrl.hostname.toLowerCase();
+  const solutionHostname = new URL(solution.url).hostname.toLowerCase();
+  const matches = solution.cookies
+    .map((cookie, index) => ({ cookie, index, path: cookiePath(cookie) }))
+    .filter(({ cookie, path }) => (
+      typeof cookie.name === "string"
+      && cookie.name !== ""
+      && typeof cookie.value === "string"
+      && domainMatches(cookie, requestHostname, solutionHostname)
+      && pathMatches(targetUrl.pathname || "/", path)
+      && (cookie.secure !== true || targetUrl.protocol === "https:")
+      && !(
+        typeof cookie.expires === "number"
+        && Number.isFinite(cookie.expires)
+        && cookie.expires > 0
+        && cookie.expires <= nowSeconds
+      )
+    ))
+    .sort((left, right) => right.path.length - left.path.length || left.index - right.index);
+
+  const selected = new Set<string>();
+  const pairs: string[] = [];
+  for (const { cookie } of matches) {
+    const name = cookie.name as string;
+    if (selected.has(name)) {
+      continue;
+    }
+    selected.add(name);
+    pairs.push(`${name}=${cookie.value as string}`);
+  }
+
+  const headers: Record<string, string> = { "User-Agent": solution.userAgent };
+  if (pairs.length > 0) {
+    headers.Cookie = pairs.join("; ");
+  }
+  return headers;
+}
+
+export function createFlareSolverrCacheKey(requestedUrl: string): string {
+  return `solver:${requestedUrl}`;
+}

--- a/src/flaresolverr.ts
+++ b/src/flaresolverr.ts
@@ -10,6 +10,8 @@ const MAX_FLARESOLVERR_TIMEOUT_MS = 300_000;
 const DEFAULT_FLARESOLVERR_CONCURRENCY = 2;
 const MAX_FLARESOLVERR_CONCURRENCY = 16;
 const MAX_FLARESOLVERR_RESPONSE_BYTES = 256 * 1024;
+const FLARESOLVERR_RESPONSE_GRACE_MS = 5_000;
+const MAX_COOKIE_PAIR_BYTES = 4_096;
 
 export interface FlareSolverrConfig {
   endpoint: URL;
@@ -228,7 +230,10 @@ export async function acquireFlareSolverrSolution(
   activeSolverRequests++;
   try {
     const controller = new AbortController();
-    const timeoutId = setTimeout(() => controller.abort(), config.timeoutMs);
+    const timeoutId = setTimeout(
+      () => controller.abort(),
+      config.timeoutMs + FLARESOLVERR_RESPONSE_GRACE_MS,
+    );
     let responseText: string | null;
 
     try {
@@ -328,6 +333,47 @@ function domainMatches(
   return requestHostname === domain || requestHostname.endsWith(`.${domain}`);
 }
 
+function isValidCookieName(name: string): boolean {
+  if (name === "") {
+    return false;
+  }
+  const punctuation = "!#$%&'*+-.^_`|~";
+  for (const character of name) {
+    const code = character.charCodeAt(0);
+    const isAlphaNumeric = (
+      (code >= 0x30 && code <= 0x39)
+      || (code >= 0x41 && code <= 0x5a)
+      || (code >= 0x61 && code <= 0x7a)
+    );
+    if (!isAlphaNumeric && !punctuation.includes(character)) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isValidCookieValue(value: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0);
+    if (!(
+      code === 0x21
+      || (code >= 0x23 && code <= 0x2b)
+      || (code >= 0x2d && code <= 0x3a)
+      || (code >= 0x3c && code <= 0x5b)
+      || (code >= 0x5d && code <= 0x7e)
+    )) {
+      return false;
+    }
+  }
+  return true;
+}
+
+function isValidCookiePair(name: string, value: string): boolean {
+  return isValidCookieName(name)
+    && isValidCookieValue(value)
+    && new TextEncoder().encode(`${name}=${value}`).byteLength <= MAX_COOKIE_PAIR_BYTES;
+}
+
 export function buildFlareSolverrHeaders(
   solution: FlareSolverrSolution,
   targetUrl: URL,
@@ -340,8 +386,8 @@ export function buildFlareSolverrHeaders(
     .filter(({ cookie, path }) => (
       requestHostname === solutionHostname
       && typeof cookie.name === "string"
-      && cookie.name !== ""
       && typeof cookie.value === "string"
+      && isValidCookiePair(cookie.name, cookie.value)
       && domainMatches(cookie, requestHostname, solutionHostname)
       && pathMatches(targetUrl.pathname || "/", path)
       && (cookie.secure !== true || targetUrl.protocol === "https:")

--- a/src/proxy.ts
+++ b/src/proxy.ts
@@ -358,6 +358,21 @@ export function applySearchRequestConfig(
 }
 
 /**
+ * Apply global proxy and trust-store configuration to an operator-trusted side
+ * service. Type-specific search and URL-reader proxy variables deliberately do
+ * not apply.
+ */
+export function applyTrustedServiceRequestConfig(
+  requestOptions: RequestInit,
+  targetUrl: string,
+): void {
+  const dispatcher = createProxyAgent(targetUrl) ?? createDefaultAgent();
+  if (dispatcher) {
+    (requestOptions as any).dispatcher = dispatcher;
+  }
+}
+
+/**
  * Returns a singleton undici Agent for direct `web_url_read` requests.
  *
  * Unlike the shared default agent, this is always created so the URL reader's

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,7 +350,7 @@ export const LITE_INSTANCE_INFO_TOOL: Tool = {
 export const LITE_READ_URL_TOOL: Tool = {
   name: "web_url_read",
   description:
-    "Fetch URL. Converts HTML to markdown; returns explicit JSON, plain text, YAML, TOML, and XML as readable markdown; binary/media/archive downloads are rejected.",
+    "Fetch URL. Converts HTML to markdown; returns explicit JSON, plain text, YAML, TOML, and XML as readable markdown; binary/media/archive downloads are rejected. An operator-configured FlareSolverr or Byparr service can acquire browser sessions for challenge-protected URLs.",
   inputSchema: {
     type: "object",
     properties: { url: { type: "string", description: "URL to fetch." } },
@@ -364,6 +364,7 @@ export const READ_URL_TOOL: Tool = {
     "Fetches a URL and returns readable content as markdown. " +
     "Content-type aware: HTML is converted to markdown; JSON is pretty-printed; plain text, YAML, TOML, and XML are returned as fenced readable text. " +
     "Binary, media, archive, PDF, and octet-stream downloads are intentionally rejected instead of being returned as raw bytes. " +
+    "When the operator configures FlareSolverr or Byparr, challenge-protected URLs are solved before the normal bounded URL-reader fetch. " +
     "Three modes: " +
     "(1) Full content — omit filtering params; use `startChar`/`maxLength` to paginate large pages. " +
     "(2) Section extraction — set `section` to return content under a specific heading. " +

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -521,6 +521,7 @@ export async function fetchAndConvertToMarkdown(
 
   let flareSolverrSolution: FlareSolverrSolution | null = null;
   let cacheKey = url;
+  let shouldCacheResult = true;
   let skipInitialReplayHead = false;
   if (flareSolverrConfig) {
     const preflightProxyAgent = createProxyAgent(parsedUrl.toString(), ProxyType.URL_READER);
@@ -562,6 +563,7 @@ export async function fetchAndConvertToMarkdown(
       cacheKey = configuredCacheKey;
     } else {
       skipInitialReplayHead = true;
+      shouldCacheResult = false;
     }
   }
 
@@ -723,7 +725,9 @@ export async function fetchAndConvertToMarkdown(
     }
 
     // Only cache successful markdown conversion
-    urlCache.set(cacheKey, markdownContent);
+    if (shouldCacheResult) {
+      urlCache.set(cacheKey, markdownContent);
+    }
 
     // Apply pagination options
     const result = applyPaginationOptions(markdownContent, paginationOptions);

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -634,7 +634,6 @@ export async function fetchAndConvertToMarkdown(
 
         const nextUrl = new URL(location, currentUrl);
         assertUrlAllowed(nextUrl);
-        await cancelResponseBody(response);
         currentUrl = nextUrl;
       }
     } catch (error: any) {

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -521,6 +521,7 @@ export async function fetchAndConvertToMarkdown(
 
   let flareSolverrSolution: FlareSolverrSolution | null = null;
   let cacheKey = url;
+  let skipInitialReplayHead = false;
   if (flareSolverrConfig) {
     const preflightProxyAgent = createProxyAgent(parsedUrl.toString(), ProxyType.URL_READER);
     const preflightDispatcher = preflightProxyAgent ?? createUrlReaderAgent();
@@ -559,6 +560,8 @@ export async function fetchAndConvertToMarkdown(
         );
       }
       cacheKey = configuredCacheKey;
+    } else {
+      skipInitialReplayHead = true;
     }
   }
 
@@ -581,9 +584,7 @@ export async function fetchAndConvertToMarkdown(
       : {};
 
     let response!: Response;
-    let currentUrl = flareSolverrSolution
-      ? new URL(flareSolverrSolution.url)
-      : parsedUrl;
+    let currentUrl = parsedUrl;
     assertUrlAllowed(currentUrl);
     let usedDispatcher = false;
     try {
@@ -602,15 +603,17 @@ export async function fetchAndConvertToMarkdown(
           (currentRequestOptions as any).dispatcher = dispatcher;
         }
 
-        const contentLength = await checkContentLength(
-          mcpServer,
-          currentUrl.toString(),
-          timeoutMs,
-          dispatcher,
-          currentRequestOptions,
-        );
-        if (contentLength !== null && contentLength > maxContentLengthBytes) {
-          return createContentTooLargeMessage(contentLength, maxContentLengthBytes);
+        if (!(skipInitialReplayHead && redirects === 0)) {
+          const contentLength = await checkContentLength(
+            mcpServer,
+            currentUrl.toString(),
+            timeoutMs,
+            dispatcher,
+            currentRequestOptions,
+          );
+          if (contentLength !== null && contentLength > maxContentLengthBytes) {
+            return createContentTooLargeMessage(contentLength, maxContentLengthBytes);
+          }
         }
 
         // Fetch the URL with the abort signal.

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -7,6 +7,13 @@ import { urlCache } from "./cache.js";
 import { assertUrlAllowed, isUrlSecurityPolicyDnsError } from "./url-security.js";
 import { parseStrictInteger } from "./env-int.js";
 import {
+  acquireFlareSolverrSolution,
+  buildFlareSolverrHeaders,
+  createFlareSolverrCacheKey,
+  resolveFlareSolverrConfig,
+  type FlareSolverrSolution,
+} from "./flaresolverr.js";
+import {
   createURLFormatError,
   createURLSecurityPolicyError,
   createNetworkError,
@@ -485,8 +492,13 @@ export async function fetchAndConvertToMarkdown(
   const startTime = Date.now();
   logMessage(mcpServer, "info", `Fetching URL: ${url}`);
 
+  const flareSolverrConfig = resolveFlareSolverrConfig(mcpServer);
+  const configuredCacheKey = flareSolverrConfig
+    ? createFlareSolverrCacheKey(url)
+    : url;
+
   // Check cache first
-  const cachedEntry = urlCache.get(url);
+  const cachedEntry = urlCache.get(configuredCacheKey);
   if (cachedEntry) {
     logMessage(mcpServer, "info", `Using cached content for URL: ${url}`);
     const result = applyPaginationOptions(cachedEntry.markdownContent, paginationOptions);
@@ -507,6 +519,49 @@ export async function fetchAndConvertToMarkdown(
   assertUrlAllowed(parsedUrl);
   const maxContentLengthBytes = getMaxContentLengthBytes(mcpServer);
 
+  let flareSolverrSolution: FlareSolverrSolution | null = null;
+  let cacheKey = url;
+  if (flareSolverrConfig) {
+    const preflightProxyAgent = createProxyAgent(parsedUrl.toString(), ProxyType.URL_READER);
+    const preflightDispatcher = preflightProxyAgent ?? createUrlReaderAgent();
+    const preflightHeaders: Record<string, string> = {};
+    const configuredUserAgent = process.env.URL_READER_USER_AGENT || process.env.USER_AGENT;
+    if (configuredUserAgent) {
+      preflightHeaders["User-Agent"] = configuredUserAgent;
+    }
+    const contentLength = await checkContentLength(
+      mcpServer,
+      parsedUrl.toString(),
+      timeoutMs,
+      preflightDispatcher,
+      {
+        redirect: "manual",
+        headers: preflightHeaders,
+      },
+    );
+    if (contentLength !== null && contentLength > maxContentLengthBytes) {
+      return createContentTooLargeMessage(contentLength, maxContentLengthBytes);
+    }
+
+    const acquisition = await acquireFlareSolverrSolution(
+      mcpServer,
+      flareSolverrConfig,
+      parsedUrl,
+    );
+    if (acquisition.kind === "solved") {
+      flareSolverrSolution = acquisition.solution;
+      if (flareSolverrSolution.status < 200 || flareSolverrSolution.status >= 300) {
+        throw createServerError(
+          flareSolverrSolution.status,
+          "",
+          "",
+          { url },
+        );
+      }
+      cacheKey = configuredCacheKey;
+    }
+  }
+
   // Create an AbortController instance
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
@@ -518,17 +573,18 @@ export async function fetchAndConvertToMarkdown(
       redirect: "manual",
     };
 
-    // Add User-Agent header if configured (URL_READER_USER_AGENT takes priority over USER_AGENT)
+    // Add User-Agent header if configured (URL_READER_USER_AGENT takes priority over USER_AGENT).
+    // A solved browser session replaces these headers for the replay.
     const userAgent = process.env.URL_READER_USER_AGENT || process.env.USER_AGENT;
-    if (userAgent) {
-      requestOptions.headers = {
-        ...requestOptions.headers,
-        'User-Agent': userAgent
-      };
-    }
+    const directHeaders: Record<string, string> = userAgent
+      ? { "User-Agent": userAgent }
+      : {};
 
     let response!: Response;
-    let currentUrl = parsedUrl;
+    let currentUrl = flareSolverrSolution
+      ? new URL(flareSolverrSolution.url)
+      : parsedUrl;
+    assertUrlAllowed(currentUrl);
     let usedDispatcher = false;
     try {
       for (let redirects = 0; redirects <= MAX_REDIRECTS; redirects++) {
@@ -538,6 +594,9 @@ export async function fetchAndConvertToMarkdown(
         usedDispatcher = !!dispatcher;
         const currentRequestOptions = {
           ...requestOptions,
+          headers: flareSolverrSolution
+            ? buildFlareSolverrHeaders(flareSolverrSolution, currentUrl)
+            : directHeaders,
         };
         if (dispatcher) {
           (currentRequestOptions as any).dispatcher = dispatcher;
@@ -575,6 +634,7 @@ export async function fetchAndConvertToMarkdown(
 
         const nextUrl = new URL(location, currentUrl);
         assertUrlAllowed(nextUrl);
+        await cancelResponseBody(response);
         currentUrl = nextUrl;
       }
     } catch (error: any) {
@@ -661,7 +721,7 @@ export async function fetchAndConvertToMarkdown(
     }
 
     // Only cache successful markdown conversion
-    urlCache.set(url, markdownContent);
+    urlCache.set(cacheKey, markdownContent);
 
     // Apply pagination options
     const result = applyPaginationOptions(markdownContent, paginationOptions);


### PR DESCRIPTION
## Summary
- add opt-in FlareSolverr/Byparr session acquisition for `web_url_read` and `web_url_read_lite` through `FLARESOLVERR_URL`
- replay the returned browser user agent and scoped cookies through the existing bounded URL-reader pipeline
- document timeout, concurrency, proxy, isolation, and Docker Compose configuration

## Why
Challenge-protected URLs can reject the normal HTTP reader even when the operator has a trusted solver sidecar. This keeps solving optional and preserves the reader's DNS, redirect, size, content-type, and timeout checks for the actual response.

## Validation
- 621/621 tests passed
- 96.27% line coverage; 92.70% branch coverage
- build, lint, dependency audit, packed-consumer verification, diff check, and full E2E suite passed
- live FlareSolverr 3.5.0 test pulled `https://eprint.iacr.org/2025/858.pdf` through the built MCP server and reached the real `application/pdf` response instead of Cloudflare HTTP 403

Related to #166.