### PR TITLE
Add bounded PDF text extraction to web_url_read

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -269,7 +269,7 @@ For direct URL-reader requests without a proxy, DNS answers are validated before
 
 When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTPS_PROXY`, `HTTP_PROXY`, or `HTTPS_PROXY`), the proxy performs DNS resolution. Client-side DNS-answer validation cannot inspect proxied resolutions, so proxied deployments should rely on proxy, firewall, and egress controls.
 
-`URL_READ_MAX_CONTENT_LENGTH_BYTES` is enforced while streaming the response body, including chunked responses and responses whose GET body is larger than the HEAD `Content-Length` value. The limit is measured after transparent response decompression. For `application/pdf`, both the downloaded input and extracted UTF-8 text are limited to the lower of this value and 16 MiB; extraction is limited to 500 pages and does not perform OCR.
+`URL_READ_MAX_CONTENT_LENGTH_BYTES` is enforced while streaming the response body, including chunked responses and responses whose GET body is larger than the HEAD `Content-Length` value. The limit is measured after transparent response decompression. For `application/pdf`, both the downloaded input and extracted UTF-8 text are limited to the lower of this value and 16 MiB; extraction is limited to 500 pages and does not perform OCR. PDF parsing starts only after the response body is complete and has its own 30-second worker budget, so the maximum processing time is `FETCH_TIMEOUT_MS` plus up to 30 seconds.
 
 Set `MCP_HTTP_ALLOW_PRIVATE_URLS=true` only when internal URL reads are intentional for your deployment. This also allows hostnames that DNS-resolve to private/internal addresses.
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -91,7 +91,7 @@ for trust, evaluation, and conservative-use guidance.
 | Variable | Required | Default | Description |
 |---|---|---|---|
 | `URL_READ_MAX_CHARS` | No | — | Default maximum characters returned by `web_url_read` when the caller omits `maxLength`. Explicit `maxLength` always wins. Invalid values are ignored. |
-| `URL_READ_MAX_CONTENT_LENGTH_BYTES` | No | `5242880` | Maximum decompressed response-body bytes `web_url_read` will read while streaming a page. A HEAD `Content-Length` preflight may reject oversized pages before GET, but the streaming cap is authoritative. Invalid values fall back to the default. |
+| `URL_READ_MAX_CONTENT_LENGTH_BYTES` | No | `5242880` | Maximum decompressed response-body bytes `web_url_read` will read while streaming a page. A HEAD `Content-Length` preflight may reject oversized pages before GET, but the streaming cap is authoritative. PDF input and extracted text additionally have a fixed 16 MiB ceiling. Invalid values fall back to the default. |
 | `FLARESOLVERR_URL` | No | — | Base URL of a trusted FlareSolverr or Byparr-compatible service, such as `http://flaresolverr:8191`. When set, `web_url_read` asks its `/v1` API for a browser session before each uncached URL read. |
 | `FLARESOLVERR_TIMEOUT_MS` | No | `60000` | Maximum session-acquisition time in milliseconds, from `1` through `300000`. Invalid values use the default. This is separate from `FETCH_TIMEOUT_MS`, which starts when the target is replayed. |
 | `FLARESOLVERR_MAX_CONCURRENT_REQUESTS` | No | `2` | Maximum concurrent solver acquisitions per MCP process, from `1` through `16`. When all slots are occupied, the request uses the direct URL-reader path instead of waiting in a queue. |
@@ -117,8 +117,8 @@ malformed response, or oversized response falls back once to the direct
 URL-reader path. Invalid solver configuration, other HTTP 4xx responses, a
 solver result for a different hostname, and a non-success target status
 reported by the solver fail closed. Solver-backed cache entries are isolated
-from direct-fetch entries. PDFs remain unsupported by this feature and return
-the existing binary-content hint.
+from direct-fetch entries. When the replay response is `application/pdf`, the
+URL reader applies its bounded PDF text-extraction path.
 
 Example with the official FlareSolverr image:
 
@@ -269,7 +269,7 @@ For direct URL-reader requests without a proxy, DNS answers are validated before
 
 When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTPS_PROXY`, `HTTP_PROXY`, or `HTTPS_PROXY`), the proxy performs DNS resolution. Client-side DNS-answer validation cannot inspect proxied resolutions, so proxied deployments should rely on proxy, firewall, and egress controls.
 
-`URL_READ_MAX_CONTENT_LENGTH_BYTES` is enforced while streaming the response body, including chunked responses and responses whose GET body is larger than the HEAD `Content-Length` value. The limit is measured after transparent response decompression.
+`URL_READ_MAX_CONTENT_LENGTH_BYTES` is enforced while streaming the response body, including chunked responses and responses whose GET body is larger than the HEAD `Content-Length` value. The limit is measured after transparent response decompression. For `application/pdf`, both the downloaded input and extracted UTF-8 text are limited to the lower of this value and 16 MiB; extraction is limited to 500 pages and does not perform OCR.
 
 Set `MCP_HTTP_ALLOW_PRIVATE_URLS=true` only when internal URL reads are intentional for your deployment. This also allows hostnames that DNS-resolve to private/internal addresses.
 

--- a/README.md
+++ b/README.md
@@ -146,8 +146,10 @@ For SearXNG deployment, configuration, and troubleshooting, see
     - HTML (`text/html`, `application/xhtml+xml`) is converted to markdown
     - JSON (`application/json`, `*+json`) is pretty-printed in a fenced block
     - Plain text, YAML, TOML, XML, and other safe explicit `text/*` responses are returned as readable fenced text
+    - PDF (`application/pdf`) text is extracted in a resource-bounded worker for documents up to 500 pages
     - Missing or generic content types are read under the existing size cap; non-binary bodies continue through the HTML-to-markdown path for compatibility
-  - Binary, media, archive, PDF, and octet-stream downloads are intentionally rejected with a short hint instead of returning raw bytes
+  - PDF input and extracted text are each capped at the lower of `URL_READ_MAX_CONTENT_LENGTH_BYTES` and 16 MiB. OCR is not supported, and scanned/image-only or password-protected PDFs return a short explanation.
+  - Other binary, media, archive, and octet-stream downloads are intentionally rejected with a short hint instead of returning raw bytes
   - When `FLARESOLVERR_URL` is configured, challenge-protected URLs are solved first and then fetched through the normal URL-reader security, redirect, proxy, and size controls
   - Inputs:
     - `url` (string): The URL to fetch and process

--- a/README.md
+++ b/README.md
@@ -149,6 +149,7 @@ For SearXNG deployment, configuration, and troubleshooting, see
     - PDF (`application/pdf`) text is extracted in a resource-bounded worker for documents up to 500 pages
     - Missing or generic content types are read under the existing size cap; non-binary bodies continue through the HTML-to-markdown path for compatibility
   - PDF input and extracted text are each capped at the lower of `URL_READ_MAX_CONTENT_LENGTH_BYTES` and 16 MiB. OCR is not supported, and scanned/image-only or password-protected PDFs return a short explanation.
+  - PDF parsing has a separate 30-second worker budget after the response body is downloaded, so its maximum processing time is the configured fetch budget plus up to 30 seconds
   - Other binary, media, archive, and octet-stream downloads are intentionally rejected with a short hint instead of returning raw bytes
   - When `FLARESOLVERR_URL` is configured, challenge-protected URLs are solved first and then fetched through the normal URL-reader security, redirect, proxy, and size controls
   - Inputs:

--- a/__tests__/e2e/flaresolverr.e2e.ts
+++ b/__tests__/e2e/flaresolverr.e2e.ts
@@ -16,6 +16,7 @@ import {
   spawnWithMessagesAsync,
 } from './helpers/spawn-server.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
+import { createTextPdf } from '../helpers/pdf-fixtures.js';
 
 const results = createTestResults();
 const PROTECTED_PDF_URL = 'https://eprint.iacr.org/2025/858.pdf';
@@ -77,9 +78,9 @@ async function runTests() {
         replayCookie = req.headers.cookie ?? '';
       }
       res.writeHead(req.method === 'HEAD' ? 403 : 200, {
-        'content-type': 'text/html; charset=utf-8',
+        'content-type': 'application/pdf',
       });
-      res.end(req.method === 'HEAD' ? '' : '<html><body><h1>Solver E2E</h1></body></html>');
+      res.end(req.method === 'HEAD' ? '' : Buffer.from(createTextPdf(['Solver PDF E2E'])));
     });
     const solver = await startServer((req, res) => {
       let body = '';
@@ -121,7 +122,7 @@ async function runTests() {
       const response = responses[2];
       assert.ok(response && !response.error, JSON.stringify(response?.error));
       const text: string = response.result?.content?.[0]?.text ?? '';
-      assert.ok(text.includes('# Solver E2E'), text);
+      assert.ok(text.includes('Solver PDF E2E'), text);
       assert.equal(replayUserAgent, 'flaresolverr-e2e-agent');
       assert.equal(replayCookie, 'cf_clearance=e2e-token');
     } finally {

--- a/__tests__/e2e/flaresolverr.e2e.ts
+++ b/__tests__/e2e/flaresolverr.e2e.ts
@@ -131,7 +131,7 @@ async function runTests() {
   }, results);
 
   if (process.env.FLARESOLVERR_URL) {
-    await testFunction('real Cloudflare-protected IACR PDF is pulled through FlareSolverr', async () => {
+    await testFunction('real Cloudflare-protected IACR PDF text is extracted through FlareSolverr', async () => {
       const responses = await spawnWithMessagesAsync(
         readUrlMessages(PROTECTED_PDF_URL),
         'https://test-searx.example.com',
@@ -140,7 +140,9 @@ async function runTests() {
       const response = responses[2];
       assert.ok(response && !response.error, JSON.stringify(response?.error));
       const text: string = response.result?.content?.[0]?.text ?? '';
-      assert.ok(text.includes('Unsupported content type: application/pdf'), text);
+      assert.ok(text.includes('Encrypted Matrix-Vector Products'), text);
+      assert.ok(text.includes('Abstract'), text);
+      assert.ok(!text.includes('Unsupported content type'), text);
     }, results);
   } else {
     console.log('[SKIP] FLARESOLVERR_URL not set — skipping real protected-PDF test');

--- a/__tests__/helpers/pdf-fixtures.ts
+++ b/__tests__/helpers/pdf-fixtures.ts
@@ -1,0 +1,53 @@
+function escapePdfText(text: string): string {
+  return text.replaceAll("\\", "\\\\").replaceAll("(", "\\(").replaceAll(")", "\\)");
+}
+
+export function createTextPdf(pageTexts: string[]): Uint8Array {
+  const pageCount = pageTexts.length;
+  const fontObjectId = pageCount + 3;
+  const firstContentObjectId = fontObjectId + 1;
+  const objects: string[] = [];
+
+  objects[1] = "<< /Type /Catalog /Pages 2 0 R >>";
+  const pageReferences = pageTexts.map((_, index) => `${index + 3} 0 R`).join(" ");
+  objects[2] = `<< /Type /Pages /Kids [${pageReferences}] /Count ${pageCount} >>`;
+
+  for (let index = 0; index < pageCount; index++) {
+    const pageObjectId = index + 3;
+    const contentObjectId = firstContentObjectId + index;
+    objects[pageObjectId] =
+      `<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] ` +
+      `/Resources << /Font << /F1 ${fontObjectId} 0 R >> >> /Contents ${contentObjectId} 0 R >>`;
+
+    const content = pageTexts[index] === ""
+      ? ""
+      : `BT /F1 12 Tf 72 720 Td (${escapePdfText(pageTexts[index])}) Tj ET`;
+    objects[contentObjectId] = `<< /Length ${Buffer.byteLength(content, "latin1")} >>\nstream\n${content}\nendstream`;
+  }
+
+  objects[fontObjectId] = "<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>";
+
+  let pdf = "%PDF-1.4\n";
+  const offsets: number[] = [0];
+  for (let objectId = 1; objectId < objects.length; objectId++) {
+    offsets[objectId] = Buffer.byteLength(pdf, "latin1");
+    pdf += `${objectId} 0 obj\n${objects[objectId]}\nendobj\n`;
+  }
+
+  const xrefOffset = Buffer.byteLength(pdf, "latin1");
+  pdf += `xref\n0 ${objects.length}\n`;
+  pdf += "0000000000 65535 f \n";
+  for (let objectId = 1; objectId < objects.length; objectId++) {
+    pdf += `${offsets[objectId].toString().padStart(10, "0")} 00000 n \n`;
+  }
+  pdf += `trailer\n<< /Size ${objects.length} /Root 1 0 R >>\nstartxref\n${xrefOffset}\n%%EOF\n`;
+
+  return new Uint8Array(Buffer.from(pdf, "latin1"));
+}
+
+const ENCRYPTED_BLANK_PDF_BASE64 =
+  "JVBERi0xLjMKJeLjz9MKMSAwIG9iago8PAovUHJvZHVjZXIgPDM1YzY5Y2I1ZTA+Cj4+CmVuZG9iagoyIDAgb2JqCjw8Ci9UeXBlIC9QYWdlcwovQ291bnQgMQovS2lkcyBbIDQgMCBSIF0KPj4KZW5kb2JqCjMgMCBvYmoKPDwKL1R5cGUgL0NhdGFsb2cKL1BhZ2VzIDIgMCBSCj4+CmVuZG9iago0IDAgb2JqCjw8Ci9UeXBlIC9QYWdlCi9SZXNvdXJjZXMgPDwKPj4KL01lZGlhQm94IFsgMC4wIDAuMCA3MiA3MiBdCi9QYXJlbnQgMiAwIFIKPj4KZW5kb2JqCjUgMCBvYmoKPDwKL1YgMgovUiAzCi9MZW5ndGggMTI4Ci9QIDQyOTQ5NjcyOTIKL0ZpbHRlciAvU3RhbmRhcmQKL08gPDBlNTIyOTI1YTNlNGU4NzRjM2NmYWNiZWY1MTFhNzNhYzRlYzJiZDg2NWRjZDNkNDYyNzYxNDkxN2FiZmQ3ZTQ+Ci9VIDxiNjIzNzAzMjY3YTBjODJlMzliYmIwMTc0YTVlODUzNDI4YmY0ZTVlNGU3NThhNDE2NDAwNGU1NmZmZmEwMTA4Pgo+PgplbmRvYmoKeHJlZgowIDYKMDAwMDAwMDAwMCA2NTUzNSBmIAowMDAwMDAwMDE1IDAwMDAwIG4gCjAwMDAwMDAwNTkgMDAwMDAgbiAKMDAwMDAwMDExOCAwMDAwMCBuIAowMDAwMDAwMTY3IDAwMDAwIG4gCjAwMDAwMDAyNTkgMDAwMDAgbiAKdHJhaWxlcgo8PAovU2l6ZSA2Ci9Sb290IDMgMCBSCi9JbmZvIDEgMCBSCi9JRCBbIDw2NDY2NjM2MTY2MzUzNDMyMzczOTMwMzMzMjMwMzY2NDY0MzEzMTM0MzQzMTY0MzA2MjM1NjI2MTM5MzYzMTYyPiA8NjQ2NjYzNjE2NjM1MzQzMjM3MzkzMDMzMzIzMDM2NjQ2NDMxMzEzNDM0MzE2NDMwNjIzNTYyNjEzOTM2MzE2Mj4gXQovRW5jcnlwdCA1IDAgUgo+PgpzdGFydHhyZWYKNDc0CiUlRU9GCg==";
+
+export function createEncryptedPdf(): Uint8Array {
+  return new Uint8Array(Buffer.from(ENCRYPTED_BLANK_PDF_BASE64, "base64"));
+}

--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -19,6 +19,7 @@ import { runTests as runSearchCacheTests } from './unit/search-cache.test.js';
 import { runTests as runProxyTests } from './unit/proxy.test.js';
 import { runTests as runFlareSolverrTests } from './unit/flaresolverr.test.js';
 import { runTests as runPdfReaderTests } from './unit/pdf-reader.test.js';
+import { runTests as runPdfNetworkGuardTests } from './unit/pdf-network-guard.test.js';
 import { runTests as runErrorHandlerTests } from './unit/error-handler.test.js';
 import { runTests as runSearxngInstancesTests } from './unit/searxng-instances.test.js';
 import { runTests as runResourcesTests } from './unit/resources.test.js';
@@ -58,6 +59,7 @@ const testSuites: TestSuite[] = [
   { name: 'Proxy', category: 'unit', run: runProxyTests },
   { name: 'FlareSolverr', category: 'unit', run: runFlareSolverrTests },
   { name: 'PDF Reader', category: 'unit', run: runPdfReaderTests },
+  { name: 'PDF Network Guard', category: 'unit', run: runPdfNetworkGuardTests },
   { name: 'Error Handler', category: 'unit', run: runErrorHandlerTests },
   { name: 'SearXNG Instances', category: 'unit', run: runSearxngInstancesTests },
   { name: 'Resources', category: 'unit', run: runResourcesTests },

--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -18,6 +18,7 @@ import { runTests as runCacheTests } from './unit/cache.test.js';
 import { runTests as runSearchCacheTests } from './unit/search-cache.test.js';
 import { runTests as runProxyTests } from './unit/proxy.test.js';
 import { runTests as runFlareSolverrTests } from './unit/flaresolverr.test.js';
+import { runTests as runPdfReaderTests } from './unit/pdf-reader.test.js';
 import { runTests as runErrorHandlerTests } from './unit/error-handler.test.js';
 import { runTests as runSearxngInstancesTests } from './unit/searxng-instances.test.js';
 import { runTests as runResourcesTests } from './unit/resources.test.js';
@@ -56,6 +57,7 @@ const testSuites: TestSuite[] = [
   { name: 'Search Cache', category: 'unit', run: runSearchCacheTests },
   { name: 'Proxy', category: 'unit', run: runProxyTests },
   { name: 'FlareSolverr', category: 'unit', run: runFlareSolverrTests },
+  { name: 'PDF Reader', category: 'unit', run: runPdfReaderTests },
   { name: 'Error Handler', category: 'unit', run: runErrorHandlerTests },
   { name: 'SearXNG Instances', category: 'unit', run: runSearxngInstancesTests },
   { name: 'Resources', category: 'unit', run: runResourcesTests },

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -110,6 +110,19 @@ function collectJsonServers(config: Record<string, unknown>): Record<string, unk
 export async function runTests(): Promise<TestResult> {
   console.log('Testing: public documentation guides\n');
 
+  await testFunction('README documents bounded PDF text extraction and its limits', () => {
+    const readme = readText(new URL('../../README.md', import.meta.url));
+    for (const statement of [
+      'PDF (`application/pdf`) text is extracted',
+      '16 MiB',
+      '500 pages',
+      'OCR is not supported',
+      'password-protected',
+    ]) {
+      assert.ok(readme.includes(statement), `README must document: ${statement}`);
+    }
+  }, results);
+
   await testFunction('cookbook exists and README links to it', () => {
     const guide = readText(guideUrl);
     const readme = readText(new URL('../../README.md', import.meta.url));

--- a/__tests__/unit/packed-consumer.test.ts
+++ b/__tests__/unit/packed-consumer.test.ts
@@ -227,6 +227,7 @@ async function runWorkflowContractTests(): Promise<void> {
           files: [
             { path: 'package.json' },
             { path: 'dist/cli.js' },
+            { path: 'dist/pdf-worker.js' },
           ],
         },
         {
@@ -255,7 +256,7 @@ async function runWorkflowContractTests(): Promise<void> {
       () => assertArtifactMetadata(
         {
           filename: 'mcp-searxng-1.12.0.tgz',
-          files: [{ path: 'package.json' }],
+          files: [{ path: 'package.json' }, { path: 'dist/pdf-worker.js' }],
         },
         {
           name: 'mcp-searxng',
@@ -270,6 +271,16 @@ async function runWorkflowContractTests(): Promise<void> {
         { name: 'mcp-searxng', dependencies: {} },
       ),
       /artifact_metadata:.*file entry/,
+    );
+    assert.throws(
+      () => assertArtifactMetadata(
+        {
+          filename: 'mcp-searxng-1.12.0.tgz',
+          files: [{ path: 'package.json' }, { path: 'dist/cli.js' }],
+        },
+        { name: 'mcp-searxng', dependencies: {} },
+      ),
+      /artifact_metadata:.*pdf-worker\.js/,
     );
   }, results);
 
@@ -311,6 +322,7 @@ async function runOrchestrationTests(): Promise<void> {
             files: [
               { path: 'package.json' },
               { path: 'dist/cli.js' },
+              { path: 'dist/pdf-worker.js' },
             ],
           }]),
           stderr: '',
@@ -354,6 +366,9 @@ async function runOrchestrationTests(): Promise<void> {
           stderr: '',
         };
       }
+      if (args.includes('--input-type=module')) {
+        return { status: 0, signal: null, stdout: 'packed-pdf-ok\n', stderr: '' };
+      }
       return {
         status: 0,
         signal: null,
@@ -387,7 +402,7 @@ async function runOrchestrationTests(): Promise<void> {
         args.find((argument) => ['pack', 'install', 'ls', 'audit'].includes(argument))
         ?? args[0]
       )),
-      ['pack', 'install', 'ls', 'audit', path.join('node_modules', 'mcp-searxng', 'dist', 'cli.js')],
+      ['pack', 'install', '--input-type=module', 'ls', 'audit', path.join('node_modules', 'mcp-searxng', 'dist', 'cli.js')],
     );
     const installCall = calls[1];
     assert.ok(installCall.args.includes('--ignore-scripts'));
@@ -428,6 +443,7 @@ async function runOrchestrationTests(): Promise<void> {
             files: [
               { path: 'package.json' },
               { path: 'dist/cli.js' },
+              { path: 'dist/pdf-worker.js' },
             ],
           }]),
           stderr: '',
@@ -445,6 +461,9 @@ async function runOrchestrationTests(): Promise<void> {
             dependencies: { '@modelcontextprotocol/sdk': '1.30.0' },
           }),
         );
+      }
+      if (args.includes('--input-type=module')) {
+        return { status: 0, signal: null, stdout: 'packed-pdf-ok\n', stderr: '' };
       }
       if (args.includes('ls')) {
         return {

--- a/__tests__/unit/pdf-network-guard.test.ts
+++ b/__tests__/unit/pdf-network-guard.test.ts
@@ -1,0 +1,61 @@
+import assert from "node:assert/strict";
+import http from "node:http";
+import https from "node:https";
+import net from "node:net";
+import tls from "node:tls";
+import {
+  ExternalFetchAttemptError,
+  installPdfNetworkGuards,
+} from "../../src/pdf-network-guard.js";
+import { createTestResults, printTestSummary, testFunction } from "../helpers/test-utils.js";
+
+export async function runTests() {
+  const results = createTestResults();
+
+  await testFunction("blocks PDF worker fetch and socket egress and restores every channel", () => {
+    const originals = {
+      fetch: globalThis.fetch,
+      httpGet: http.get,
+      httpRequest: http.request,
+      httpsGet: https.get,
+      httpsRequest: https.request,
+      netConnect: net.connect,
+      netCreateConnection: net.createConnection,
+      tlsConnect: tls.connect,
+    };
+
+    const restore = installPdfNetworkGuards();
+    try {
+      for (const operation of [
+        () => globalThis.fetch("https://example.com"),
+        () => http.get("http://example.com"),
+        () => http.request("http://example.com"),
+        () => https.get("https://example.com"),
+        () => https.request("https://example.com"),
+        () => net.connect(80, "example.com"),
+        () => net.createConnection(80, "example.com"),
+        () => tls.connect(443, "example.com"),
+      ]) {
+        assert.throws(operation, ExternalFetchAttemptError);
+      }
+    } finally {
+      restore();
+    }
+
+    assert.equal(globalThis.fetch, originals.fetch);
+    assert.equal(http.get, originals.httpGet);
+    assert.equal(http.request, originals.httpRequest);
+    assert.equal(https.get, originals.httpsGet);
+    assert.equal(https.request, originals.httpsRequest);
+    assert.equal(net.connect, originals.netConnect);
+    assert.equal(net.createConnection, originals.netCreateConnection);
+    assert.equal(tls.connect, originals.tlsConnect);
+  }, results);
+
+  printTestSummary(results, "PDF Network Guard");
+  return results;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void runTests();
+}

--- a/__tests__/unit/pdf-reader.test.ts
+++ b/__tests__/unit/pdf-reader.test.ts
@@ -112,6 +112,26 @@ export async function runTests() {
     assert.deepEqual(result, { version: 1, kind: "external_fetch_attempt" });
   }, results);
 
+  await testFunction("does not consume a worker slot when copying input bytes fails", async () => {
+    const bytes = createTextPdf(["copy failure"]);
+    Object.defineProperty(bytes, "slice", {
+      value: () => {
+        throw new Error("simulated copy failure");
+      },
+    });
+
+    await assert.rejects(extractPdfText(bytes, 1024), /simulated copy failure/);
+
+    const workerUrl = createDelayedWorkerUrl(100);
+    const first = extractPdfText(createTextPdf(["one"]), 1024, { workerUrl });
+    const second = extractPdfText(createTextPdf(["two"]), 1024, { workerUrl });
+    const third = await extractPdfText(createTextPdf(["three"]), 1024, { workerUrl });
+
+    assert.deepEqual(third, { version: 1, kind: "busy" });
+    assert.equal((await first).kind, "text");
+    assert.equal((await second).kind, "text");
+  }, results);
+
   await testFunction("admits at most two concurrent PDF workers without queueing", async () => {
     const workerUrl = createDelayedWorkerUrl(100);
     const first = extractPdfText(createTextPdf(["one"]), 1024, { workerUrl });

--- a/__tests__/unit/pdf-reader.test.ts
+++ b/__tests__/unit/pdf-reader.test.ts
@@ -1,5 +1,10 @@
 import assert from "node:assert/strict";
-import { extractPdfText } from "../../src/pdf-reader.js";
+import {
+  extractPdfText,
+  PDF_PARSE_TIMEOUT_MS,
+  PDF_WORKER_RESOURCE_LIMITS,
+} from "../../src/pdf-reader.js";
+import { PDF_DOCUMENT_OPTIONS } from "../../src/pdf-worker.js";
 import { createTestResults, printTestSummary, testFunction } from "../helpers/test-utils.js";
 import { createEncryptedPdf, createTextPdf } from "../helpers/pdf-fixtures.js";
 
@@ -12,6 +17,24 @@ function createDelayedWorkerUrl(delayMs: number): URL {
 
 export async function runTests() {
   const results = createTestResults();
+
+  await testFunction("keeps the parser hardening and resource envelope explicit", () => {
+    assert.equal(PDF_PARSE_TIMEOUT_MS, 30_000);
+    assert.deepEqual(PDF_WORKER_RESOURCE_LIMITS, {
+      maxOldGenerationSizeMb: 192,
+      stackSizeMb: 4,
+    });
+    assert.deepEqual(PDF_DOCUMENT_OPTIONS, {
+      isEvalSupported: false,
+      enableXfa: false,
+      useSystemFonts: false,
+      disableFontFace: true,
+      disableAutoFetch: true,
+      disableStream: true,
+      useWorkerFetch: false,
+      verbosity: 0,
+    });
+  }, results);
 
   await testFunction("extracts text from a real in-memory PDF", async () => {
     const result = await extractPdfText(createTextPdf(["Hello PDF", "Second page"]), 1024);
@@ -56,6 +79,16 @@ export async function runTests() {
       workerUrl: createDelayedWorkerUrl(1000),
     });
     assert.deepEqual(result, { version: 1, kind: "timeout" });
+  }, results);
+
+  await testFunction("accepts the worker external-fetch sentinel without leaking details", async () => {
+    const source =
+      `import { parentPort } from "node:worker_threads";` +
+      `parentPort.postMessage({version:1,kind:"external_fetch_attempt"});`;
+    const result = await extractPdfText(createTextPdf(["ignored"]), 1024, {
+      workerUrl: new URL(`data:text/javascript,${encodeURIComponent(source)}`),
+    });
+    assert.deepEqual(result, { version: 1, kind: "external_fetch_attempt" });
   }, results);
 
   await testFunction("admits at most two concurrent PDF workers without queueing", async () => {

--- a/__tests__/unit/pdf-reader.test.ts
+++ b/__tests__/unit/pdf-reader.test.ts
@@ -1,0 +1,78 @@
+import assert from "node:assert/strict";
+import { extractPdfText } from "../../src/pdf-reader.js";
+import { createTestResults, printTestSummary, testFunction } from "../helpers/test-utils.js";
+import { createEncryptedPdf, createTextPdf } from "../helpers/pdf-fixtures.js";
+
+function createDelayedWorkerUrl(delayMs: number): URL {
+  const source =
+    `import { parentPort } from "node:worker_threads";` +
+    `setTimeout(() => parentPort.postMessage({version:1,kind:"text",text:"delayed",totalPages:1,textBytes:7}), ${delayMs});`;
+  return new URL(`data:text/javascript,${encodeURIComponent(source)}`);
+}
+
+export async function runTests() {
+  const results = createTestResults();
+
+  await testFunction("extracts text from a real in-memory PDF", async () => {
+    const result = await extractPdfText(createTextPdf(["Hello PDF", "Second page"]), 1024);
+    assert.deepEqual(result, {
+      version: 1,
+      kind: "text",
+      text: "Hello PDF\nSecond page",
+      totalPages: 2,
+      textBytes: 21,
+    });
+  }, results);
+
+  await testFunction("reports PDFs with no extractable text", async () => {
+    const result = await extractPdfText(createTextPdf([""]), 1024);
+    assert.deepEqual(result, { version: 1, kind: "no_text", totalPages: 1 });
+  }, results);
+
+  await testFunction("rejects malformed PDF bytes without exposing parser errors", async () => {
+    const result = await extractPdfText(new TextEncoder().encode("%PDF-not-valid"), 1024);
+    assert.deepEqual(result, { version: 1, kind: "parse_error" });
+  }, results);
+
+  await testFunction("classifies an actual encrypted PDF without exposing parser errors", async () => {
+    const result = await extractPdfText(createEncryptedPdf(), 1024);
+    assert.deepEqual(result, { version: 1, kind: "password_protected" });
+  }, results);
+
+  await testFunction("caps extracted text by UTF-8 byte length", async () => {
+    const result = await extractPdfText(createTextPdf(["This text is too long"]), 8);
+    assert.equal(result.kind, "text_too_large");
+    assert.ok(result.kind !== "text_too_large" || result.bytes > 8);
+  }, results);
+
+  await testFunction("rejects documents over the page limit", async () => {
+    const result = await extractPdfText(createTextPdf(Array.from({ length: 501 }, () => "")), 1024);
+    assert.deepEqual(result, { version: 1, kind: "too_many_pages", totalPages: 501 });
+  }, results);
+
+  await testFunction("terminates a worker when the parser budget expires", async () => {
+    const result = await extractPdfText(createTextPdf(["ignored"]), 1024, {
+      timeoutMs: 20,
+      workerUrl: createDelayedWorkerUrl(1000),
+    });
+    assert.deepEqual(result, { version: 1, kind: "timeout" });
+  }, results);
+
+  await testFunction("admits at most two concurrent PDF workers without queueing", async () => {
+    const workerUrl = createDelayedWorkerUrl(100);
+    const first = extractPdfText(createTextPdf(["one"]), 1024, { workerUrl });
+    const second = extractPdfText(createTextPdf(["two"]), 1024, { workerUrl });
+    const third = await extractPdfText(createTextPdf(["three"]), 1024, { workerUrl });
+
+    assert.deepEqual(third, { version: 1, kind: "busy" });
+    assert.equal((await first).kind, "text");
+    assert.equal((await second).kind, "text");
+  }, results);
+
+  printTestSummary(results, "PDF Reader");
+  return results;
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  void runTests();
+}

--- a/__tests__/unit/pdf-reader.test.ts
+++ b/__tests__/unit/pdf-reader.test.ts
@@ -32,6 +32,11 @@ export async function runTests() {
       disableAutoFetch: true,
       disableStream: true,
       useWorkerFetch: false,
+      useWasm: false,
+      cMapUrl: undefined,
+      standardFontDataUrl: undefined,
+      wasmUrl: undefined,
+      iccUrl: undefined,
       verbosity: 0,
     });
   }, results);
@@ -45,6 +50,22 @@ export async function runTests() {
       totalPages: 2,
       textBytes: 21,
     });
+  }, results);
+
+  await testFunction("removes unsafe control characters from extracted text", async () => {
+    const result = await extractPdfText(createTextPdf(["safe\u0000text\u0007"]), 1024);
+    assert.equal(result.kind, "text");
+    assert.ok(result.kind !== "text" || result.text === "safe text");
+    assert.ok(
+      result.kind !== "text"
+      || [...result.text].every((character) => {
+        const codePoint = character.codePointAt(0) ?? 0;
+        return codePoint === 0x09
+          || codePoint === 0x0a
+          || codePoint === 0x0d
+          || (codePoint >= 0x20 && codePoint !== 0x7f);
+      }),
+    );
   }, results);
 
   await testFunction("reports PDFs with no extractable text", async () => {

--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -319,6 +319,8 @@ async function runTests() {
     assert.ok(LITE_READ_URL_TOOL.description.includes('YAML'), LITE_READ_URL_TOOL.description);
     assert.ok(LITE_READ_URL_TOOL.description.includes('TOML'), LITE_READ_URL_TOOL.description);
     assert.ok(LITE_READ_URL_TOOL.description.includes('XML'), LITE_READ_URL_TOOL.description);
+    assert.ok(LITE_READ_URL_TOOL.description.includes('PDF'), LITE_READ_URL_TOOL.description);
+    assert.ok(LITE_READ_URL_TOOL.description.includes('text extraction'), LITE_READ_URL_TOOL.description);
     assert.ok(LITE_READ_URL_TOOL.description.includes('binary'), LITE_READ_URL_TOOL.description);
     assert.ok(LITE_READ_URL_TOOL.description.includes('rejected'), LITE_READ_URL_TOOL.description);
     assert.ok(LITE_READ_URL_TOOL.description.includes('FlareSolverr'), LITE_READ_URL_TOOL.description);
@@ -347,6 +349,8 @@ async function runTests() {
     assert.ok(READ_URL_TOOL.description.includes('YAML'), READ_URL_TOOL.description);
     assert.ok(READ_URL_TOOL.description.includes('TOML'), READ_URL_TOOL.description);
     assert.ok(READ_URL_TOOL.description.includes('XML'), READ_URL_TOOL.description);
+    assert.ok(READ_URL_TOOL.description.includes('PDF'), READ_URL_TOOL.description);
+    assert.ok(READ_URL_TOOL.description.includes('text extraction'), READ_URL_TOOL.description);
     assert.ok(READ_URL_TOOL.description.includes('Binary'), READ_URL_TOOL.description);
     assert.ok(READ_URL_TOOL.description.includes('media'), READ_URL_TOOL.description);
     assert.ok(READ_URL_TOOL.description.includes('rejected'), READ_URL_TOOL.description);

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -1414,13 +1414,47 @@ async function runTests() {
     try {
       const first = await fetchAndConvertToMarkdown(mockServer as any, url, 10000, { maxLength: 32 });
       const second = await fetchAndConvertToMarkdown(mockServer as any, url, 10000, { startChar: 0 });
-      assert.equal(first, 'Encrypted Matrix-Vector Products');
+      assert.equal(first.length, 32);
+      assert.ok(first.startsWith('```text\nEncrypted Matrix-'));
       assert.ok(second.includes('Encrypted Matrix-Vector Products'));
       assert.ok(second.includes('Abstract test content'));
+      assert.ok(second.startsWith('```text\n'));
+      assert.ok(second.endsWith('\n```'));
       assert.equal(requestCount, 2, 'Successful PDF text should be cached after one HEAD and GET');
     } finally {
       await close();
       urlCache.clear();
+    }
+  }, results);
+
+  await testFunction('application/pdf enforces both configured and fixed input byte ceilings', async () => {
+    const mockServer = createMockServer();
+    urlCache.clear();
+    const limits = [
+      { configured: '64', bodyBytes: 65, expectedLimit: '64 bytes' },
+      {
+        configured: String(20 * 1024 * 1024),
+        bodyBytes: 16 * 1024 * 1024 + 1,
+        expectedLimit: '16.00 MB (16777216 bytes)',
+      },
+    ];
+
+    for (const limit of limits) {
+      envManager.set('URL_READ_MAX_CONTENT_LENGTH_BYTES', limit.configured);
+      const body = Buffer.alloc(limit.bodyBytes);
+      body.write('%PDF-', 0, 'ascii');
+      const { url, close } = await startHttpServer((req, res) => {
+        res.writeHead(200, { 'content-type': 'application/pdf' });
+        res.end(req.method === 'HEAD' ? undefined : body);
+      });
+      try {
+        const result = await fetchAndConvertToMarkdown(mockServer as any, url);
+        assert.ok(result.startsWith('Content too large:'), result);
+        assert.ok(result.includes(limit.expectedLimit), result);
+      } finally {
+        await close();
+        urlCache.clear();
+      }
     }
   }, results);
 

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -1485,6 +1485,29 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('application/pdf body timeouts preserve the standard timeout error', async () => {
+    const mockServer = createMockServer();
+    urlCache.clear();
+    const { url, close } = await startHttpServer((req, res) => {
+      res.writeHead(200, { 'content-type': 'application/pdf' });
+      if (req.method === 'HEAD') {
+        res.end();
+        return;
+      }
+      res.write('%PDF-');
+    });
+
+    try {
+      await assert.rejects(
+        fetchAndConvertToMarkdown(mockServer as any, url, 100),
+        (error: any) => error.message.includes('Timeout Error'),
+      );
+    } finally {
+      await close();
+      urlCache.clear();
+    }
+  }, results);
+
   await testFunction('application/pdf reports malformed and no-text documents without caching them', async () => {
     const mockServer = createMockServer();
     urlCache.clear();

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -22,6 +22,7 @@ import { urlCache } from '../../src/cache.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 import { createMockServer, createMockServerWithTracking } from '../helpers/mock-server.js';
 import { EnvManager } from '../helpers/env-utils.js';
+import { createTextPdf } from '../helpers/pdf-fixtures.js';
 
 const results = createTestResults();
 const envManager = new EnvManager();
@@ -1321,7 +1322,6 @@ async function runTests() {
     urlCache.clear();
 
     const cases = [
-      'application/pdf',
       'application/zip',
       'image/png',
       'video/mp4',
@@ -1365,7 +1365,7 @@ async function runTests() {
         return;
       }
 
-      res.writeHead(200, { 'content-type': 'application/pdf' });
+      res.writeHead(200, { 'content-type': 'application/zip' });
       res.on('close', () => {
         responseClosed = true;
         resolveResponseClosed();
@@ -1397,6 +1397,79 @@ async function runTests() {
     } finally {
       await close();
       urlCache.clear();
+    }
+  }, results);
+
+  await testFunction('application/pdf responses return extracted text and use the normal cache and pagination', async () => {
+    const mockServer = createMockServer();
+    urlCache.clear();
+    let requestCount = 0;
+    const pdf = Buffer.from(createTextPdf(['Encrypted Matrix-Vector Products', 'Abstract test content']));
+    const { url, close } = await startHttpServer((req, res) => {
+      requestCount++;
+      res.writeHead(200, { 'content-type': 'application/pdf' });
+      res.end(req.method === 'HEAD' ? undefined : pdf);
+    });
+
+    try {
+      const first = await fetchAndConvertToMarkdown(mockServer as any, url, 10000, { maxLength: 32 });
+      const second = await fetchAndConvertToMarkdown(mockServer as any, url, 10000, { startChar: 0 });
+      assert.equal(first, 'Encrypted Matrix-Vector Products');
+      assert.ok(second.includes('Encrypted Matrix-Vector Products'));
+      assert.ok(second.includes('Abstract test content'));
+      assert.equal(requestCount, 2, 'Successful PDF text should be cached after one HEAD and GET');
+    } finally {
+      await close();
+      urlCache.clear();
+    }
+  }, results);
+
+  await testFunction('application/pdf rejects a mismatched signature without starting a parser', async () => {
+    const mockServer = createMockServer();
+    urlCache.clear();
+    const { url, close } = await startTestServer({
+      headers: { 'content-type': 'application/pdf' },
+      body: 'not a pdf',
+    });
+
+    try {
+      const result = await fetchAndConvertToMarkdown(mockServer as any, url);
+      assert.equal(result, 'Response declared application/pdf but did not contain a PDF document.');
+    } finally {
+      await close();
+      urlCache.clear();
+    }
+  }, results);
+
+  await testFunction('application/pdf reports malformed and no-text documents without caching them', async () => {
+    const mockServer = createMockServer();
+    urlCache.clear();
+    const cases = [
+      {
+        body: Buffer.from('%PDF-not-valid'),
+        expected: 'Unable to extract text from PDF.',
+      },
+      {
+        body: Buffer.from(createTextPdf([''])),
+        expected: 'No extractable text (likely a scanned/image PDF; OCR is not supported).',
+      },
+    ];
+
+    for (const testCase of cases) {
+      let requestCount = 0;
+      const { url, close } = await startHttpServer((req, res) => {
+        requestCount++;
+        res.writeHead(200, { 'content-type': 'application/pdf' });
+        res.end(req.method === 'HEAD' ? undefined : testCase.body);
+      });
+      try {
+        assert.equal(await fetchAndConvertToMarkdown(mockServer as any, url), testCase.expected);
+        assert.equal(await fetchAndConvertToMarkdown(mockServer as any, url), testCase.expected);
+        assert.equal(requestCount, 4, 'Failed PDF extraction must not be cached');
+      } finally {
+        await close();
+        urlCache.clear();
+      }
     }
   }, results);
 
@@ -1541,7 +1614,7 @@ async function runTests() {
         return;
       }
 
-      res.writeHead(200, { 'content-type': 'application/pdf' });
+      res.writeHead(200, { 'content-type': 'application/zip' });
       res.end(Buffer.from([0, 1, 2, 3]));
     });
 

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -1431,11 +1431,17 @@ async function runTests() {
     const mockServer = createMockServer();
     urlCache.clear();
     const limits = [
-      { configured: '64', bodyBytes: 65, expectedLimit: '64 bytes' },
+      {
+        configured: '64',
+        bodyBytes: 65,
+        expectedLimit: '64 bytes',
+        expectedHint: 'raise URL_READ_MAX_CONTENT_LENGTH_BYTES',
+      },
       {
         configured: String(20 * 1024 * 1024),
         bodyBytes: 16 * 1024 * 1024 + 1,
         expectedLimit: '16.00 MB (16777216 bytes)',
+        expectedHint: 'fixed PDF input ceiling',
       },
     ];
 
@@ -1451,6 +1457,10 @@ async function runTests() {
         const result = await fetchAndConvertToMarkdown(mockServer as any, url);
         assert.ok(result.startsWith('Content too large:'), result);
         assert.ok(result.includes(limit.expectedLimit), result);
+        assert.ok(result.includes(limit.expectedHint), result);
+        if (limit.expectedHint === 'fixed PDF input ceiling') {
+          assert.ok(!result.includes('raise URL_READ_MAX_CONTENT_LENGTH_BYTES'), result);
+        }
       } finally {
         await close();
         urlCache.clear();

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -1497,6 +1497,10 @@ async function runTests() {
         body: Buffer.from(createTextPdf([''])),
         expected: 'No extractable text (likely a scanned/image PDF; OCR is not supported).',
       },
+      {
+        body: Buffer.from(createTextPdf(Array.from({ length: 501 }, () => ''))),
+        expected: 'PDF has too many pages to extract safely (observed: 501; limit: 500).',
+      },
     ];
 
     for (const testCase of cases) {

--- a/package-lock.json
+++ b/package-lock.json
@@ -17,7 +17,8 @@
                 "express-rate-limit": "^8.5.2",
                 "node-html-markdown": "^2.0.0",
                 "node-html-parser": "^6.1.13",
-                "undici": "7.29.0"
+                "undici": "7.29.0",
+                "unpdf": "1.7.0"
             },
             "bin": {
                 "mcp-searxng": "dist/cli.js"
@@ -4323,6 +4324,20 @@
             "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
             "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
             "license": "MIT"
+        },
+        "node_modules/unpdf": {
+            "version": "1.7.0",
+            "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.7.0.tgz",
+            "integrity": "sha512-MiDhbougTETOvbw/x3hnNr18jzFFrlSitevfO/BHInvtUx68R3Fke9A36GLQfN1LpG1NiJZaV4oPvjioPk9vKQ==",
+            "license": "MIT",
+            "peerDependencies": {
+                "@napi-rs/canvas": "^0.1.69"
+            },
+            "peerDependenciesMeta": {
+                "@napi-rs/canvas": {
+                    "optional": true
+                }
+            }
         },
         "node_modules/unpipe": {
             "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -57,7 +57,8 @@
         "express-rate-limit": "^8.5.2",
         "node-html-markdown": "^2.0.0",
         "node-html-parser": "^6.1.13",
-        "undici": "7.29.0"
+        "undici": "7.29.0",
+        "unpdf": "1.7.0"
     },
     "devDependencies": {
         "@types/node": "22.20.1",

--- a/scripts/packed-consumer-contracts.mjs
+++ b/scripts/packed-consumer-contracts.mjs
@@ -141,6 +141,12 @@ function assertPackFilesSafe(files) {
   }
 }
 
+function assertPdfWorkerIncluded(files) {
+  if (!files.some((file) => file?.path === 'dist/pdf-worker.js')) {
+    fail('artifact_metadata', 'dist/pdf-worker.js is missing from the packed artifact');
+  }
+}
+
 function assertInstalledPackageSafe(installedPackage) {
   if (!installedPackage || typeof installedPackage !== 'object') {
     fail('artifact_metadata', 'installed package manifest is missing');
@@ -151,8 +157,10 @@ function assertInstalledPackageSafe(installedPackage) {
 }
 
 export function assertArtifactMetadata(packReport, installedPackage) {
-  assertPackFilesSafe(requirePackFiles(packReport));
+  const files = requirePackFiles(packReport);
+  assertPackFilesSafe(files);
   assertInstalledPackageSafe(installedPackage);
+  assertPdfWorkerIncluded(files);
   return true;
 }
 

--- a/scripts/verify-packed-consumer.mjs
+++ b/scripts/verify-packed-consumer.mjs
@@ -148,6 +148,21 @@ function mcpSmokeInput() {
   ].map((message) => JSON.stringify(message)).join('\n') + '\n';
 }
 
+function packedPdfSmokeScript() {
+  const fixture =
+    'JVBERi0xLjQKMSAwIG9iago8PCAvVHlwZSAvQ2F0YWxvZyAvUGFnZXMgMiAwIFIgPj4KZW5kb2JqCjIgMCBvYmoKPDwgL1R5cGUgL1BhZ2VzIC9LaWRzIFszIDAgUl0gL0NvdW50IDEgPj4KZW5kb2JqCjMgMCBvYmoKPDwgL1R5cGUgL1BhZ2UgL1BhcmVudCAyIDAgUiAvTWVkaWFCb3ggWzAgMCA2MTIgNzkyXSAvUmVzb3VyY2VzIDw8IC9Gb250IDw8IC9GMSA0IDAgUiA+PiA+PiAvQ29udGVudHMgNSAwIFIgPj4KZW5kb2JqCjQgMCBvYmoKPDwgL1R5cGUgL0ZvbnQgL1N1YnR5cGUgL1R5cGUxIC9CYXNlRm9udCAvSGVsdmV0aWNhID4+CmVuZG9iago1IDAgb2JqCjw8IC9MZW5ndGggNDggPj4Kc3RyZWFtCkJUIC9GMSAxMiBUZiA3MiA3MjAgVGQgKFBhY2tlZCBQREYgd29ya2VyKSBUaiBFVAplbmRzdHJlYW0KZW5kb2JqCnhyZWYKMCA2CjAwMDAwMDAwMDAgNjU1MzUgZiAKMDAwMDAwMDAwOSAwMDAwMCBuIAowMDAwMDAwMDU4IDAwMDAwIG4gCjAwMDAwMDAxMTUgMDAwMDAgbiAKMDAwMDAwMDI0MSAwMDAwMCBuIAowMDAwMDAwMzExIDAwMDAwIG4gCnRyYWlsZXIKPDwgL1NpemUgNiAvUm9vdCAxIDAgUiA+PgpzdGFydHhyZWYKNDA5CiUlRU9GCg==';
+  return [
+    "import path from 'node:path';",
+    "import { pathToFileURL } from 'node:url';",
+    "const moduleUrl = pathToFileURL(path.resolve('node_modules/mcp-searxng/dist/pdf-reader.js')).href;",
+    "const { extractPdfText } = await import(moduleUrl);",
+    `const bytes = new Uint8Array(Buffer.from('${fixture}', 'base64'));`,
+    "const result = await extractPdfText(bytes, 1024);",
+    "if (result.kind !== 'text' || !result.text.includes('Packed PDF worker')) process.exit(1);",
+    "process.stdout.write('packed-pdf-ok\\n');",
+  ].join('\n');
+}
+
 function copyVerifiedArtifact(artifactPath, artifactOutput) {
   try {
     copyFileSync(artifactPath, path.resolve(artifactOutput));
@@ -277,6 +292,31 @@ export function verifyPackedConsumer({
       fail('artifact_metadata', 'installed package manifest is unreadable');
     }
     assertArtifactMetadata(packedArtifacts[0], installedPackage);
+
+    const installedPdfWorkerPath = path.join(
+      consumerDirectory,
+      'node_modules',
+      'mcp-searxng',
+      'dist',
+      'pdf-worker.js',
+    );
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- path is fixed beneath the verifier-created consumer
+    if (!existsSync(installedPdfWorkerPath) && spawn === spawnSync) {
+      fail('artifact_metadata', 'installed PDF worker is missing');
+    }
+    const pdfSmokeOutput = runCheckedCommand(
+      process.execPath,
+      ['--input-type=module', '--eval', packedPdfSmokeScript()],
+      {
+        cwd: consumerDirectory,
+        env: allowlistedProcessEnvironment(),
+        timeoutMs: 30_000,
+        spawn,
+      },
+    );
+    if (pdfSmokeOutput.trim() !== 'packed-pdf-ok') {
+      fail('artifact_runtime', 'installed PDF worker did not extract fixture text');
+    }
 
     const treeInvocation = npmInvocation(
       ['ls', '--all', '--json'],

--- a/src/pdf-network-guard.ts
+++ b/src/pdf-network-guard.ts
@@ -1,0 +1,61 @@
+import http from "node:http";
+import https from "node:https";
+import net from "node:net";
+import tls from "node:tls";
+
+export class ExternalFetchAttemptError extends Error {
+  constructor() {
+    super("PDF_EXTERNAL_FETCH_ATTEMPT");
+    this.name = "ExternalFetchAttemptError";
+  }
+}
+
+type MutableNetworkModules = {
+  http: { get: typeof http.get; request: typeof http.request };
+  https: { get: typeof https.get; request: typeof https.request };
+  net: { connect: typeof net.connect; createConnection: typeof net.createConnection };
+  tls: { connect: typeof tls.connect };
+};
+
+export function installPdfNetworkGuards(): () => void {
+  const modules: MutableNetworkModules = { http, https, net, tls };
+  const originals = {
+    fetch: globalThis.fetch,
+    httpGet: modules.http.get,
+    httpRequest: modules.http.request,
+    httpsGet: modules.https.get,
+    httpsRequest: modules.https.request,
+    netConnect: modules.net.connect,
+    netCreateConnection: modules.net.createConnection,
+    tlsConnect: modules.tls.connect,
+  };
+  const blocked = (() => {
+    throw new ExternalFetchAttemptError();
+  }) as typeof http.get
+    & typeof http.request
+    & typeof https.get
+    & typeof https.request
+    & typeof net.connect
+    & typeof net.createConnection
+    & typeof tls.connect;
+
+  globalThis.fetch = blocked as unknown as typeof globalThis.fetch;
+  modules.http.get = blocked;
+  modules.http.request = blocked;
+  modules.https.get = blocked;
+  modules.https.request = blocked;
+  modules.net.connect = blocked;
+  modules.net.createConnection = blocked;
+  modules.tls.connect = blocked;
+
+  return () => {
+    globalThis.fetch = originals.fetch;
+    modules.http.get = originals.httpGet;
+    modules.http.request = originals.httpRequest;
+    modules.https.get = originals.httpsGet;
+    modules.https.request = originals.httpsRequest;
+    modules.net.connect = originals.netConnect;
+    modules.net.createConnection = originals.netCreateConnection;
+    modules.tls.connect = originals.tlsConnect;
+  };
+}

--- a/src/pdf-reader.ts
+++ b/src/pdf-reader.ts
@@ -35,6 +35,22 @@ function isNonNegativeInteger(value: unknown): value is number {
   return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
 }
 
+type PdfWorkerResultValidator = (result: Record<string, unknown>) => boolean;
+
+const PDF_WORKER_RESULT_VALIDATORS = new Map<string, PdfWorkerResultValidator>([
+  ["text", (result) => (
+    typeof result.text === "string"
+    && isNonNegativeInteger(result.totalPages)
+    && isNonNegativeInteger(result.textBytes)
+  )],
+  ["no_text", (result) => isNonNegativeInteger(result.totalPages)],
+  ["too_many_pages", (result) => isNonNegativeInteger(result.totalPages)],
+  ["text_too_large", (result) => isNonNegativeInteger(result.bytes)],
+  ["password_protected", () => true],
+  ["parse_error", () => true],
+  ["external_fetch_attempt", () => true],
+]);
+
 function isPdfWorkerResult(value: unknown): value is PdfWorkerResult {
   if (typeof value !== "object" || value === null) {
     return false;
@@ -45,23 +61,8 @@ function isPdfWorkerResult(value: unknown): value is PdfWorkerResult {
     return false;
   }
 
-  switch (result.kind) {
-    case "text":
-      return typeof result.text === "string"
-        && isNonNegativeInteger(result.totalPages)
-        && isNonNegativeInteger(result.textBytes);
-    case "no_text":
-    case "too_many_pages":
-      return isNonNegativeInteger(result.totalPages);
-    case "text_too_large":
-      return isNonNegativeInteger(result.bytes);
-    case "password_protected":
-    case "parse_error":
-    case "external_fetch_attempt":
-      return true;
-    default:
-      return false;
-  }
+  const validator = PDF_WORKER_RESULT_VALIDATORS.get(result.kind);
+  return validator?.(result) ?? false;
 }
 
 function defaultPdfWorkerUrl(): URL {

--- a/src/pdf-reader.ts
+++ b/src/pdf-reader.ts
@@ -3,6 +3,10 @@ import { Worker } from "node:worker_threads";
 export const MAX_PDF_BYTES = 16 * 1024 * 1024;
 export const MAX_PDF_PAGES = 500;
 export const PDF_PARSE_TIMEOUT_MS = 30_000;
+export const PDF_WORKER_RESOURCE_LIMITS = Object.freeze({
+  maxOldGenerationSizeMb: 192,
+  stackSizeMb: 4,
+});
 const MAX_CONCURRENT_PDF_WORKERS = 2;
 
 export type PdfWorkerResult =
@@ -90,10 +94,7 @@ export async function extractPdfText(
           maxTextBytes,
         },
         transferList: [transferableBytes.buffer],
-        resourceLimits: {
-          maxOldGenerationSizeMb: 192,
-          stackSizeMb: 4,
-        },
+        resourceLimits: PDF_WORKER_RESOURCE_LIMITS,
       });
     } catch {
       activePdfWorkers--;
@@ -103,36 +104,41 @@ export async function extractPdfText(
 
     let settled = false;
     const timeoutId = setTimeout(() => {
-      void finish({ version: 1, kind: "timeout" });
+      finish({ version: 1, kind: "timeout" });
     }, options.timeoutMs ?? PDF_PARSE_TIMEOUT_MS);
 
-    async function finish(result: PdfExtractionResult): Promise<void> {
+    function finish(result: PdfExtractionResult): void {
       if (settled) {
         return;
       }
       settled = true;
       clearTimeout(timeoutId);
       worker.removeAllListeners();
+      activePdfWorkers--;
+      resolve(result);
       try {
-        await worker.terminate();
-      } finally {
-        activePdfWorkers--;
-        resolve(result);
+        void worker.terminate().catch(() => {
+          // The result and concurrency slot are already settled. A failed
+          // termination cannot wedge later reads into the busy state.
+        });
+      } catch {
+        // `terminate()` normally returns a promise, but a synchronous failure
+        // must not retain the process-wide concurrency slot.
       }
     }
 
     worker.once("message", (message: unknown) => {
-      void finish(
+      finish(
         isPdfWorkerResult(message)
           ? message
           : { version: 1, kind: "worker_failure" },
       );
     });
     worker.once("error", () => {
-      void finish({ version: 1, kind: "worker_failure" });
+      finish({ version: 1, kind: "worker_failure" });
     });
     worker.once("exit", () => {
-      void finish({ version: 1, kind: "worker_failure" });
+      finish({ version: 1, kind: "worker_failure" });
     });
   });
 }

--- a/src/pdf-reader.ts
+++ b/src/pdf-reader.ts
@@ -116,16 +116,17 @@ export async function extractPdfText(
       settled = true;
       clearTimeout(timeoutId);
       worker.removeAllListeners();
-      activePdfWorkers--;
-      resolve(result);
+
+      const releaseSlot = (): void => {
+        activePdfWorkers--;
+        resolve(result);
+      };
       try {
-        void worker.terminate().catch(() => {
-          // The result and concurrency slot are already settled. A failed
-          // termination cannot wedge later reads into the busy state.
-        });
+        void worker.terminate().then(releaseSlot, releaseSlot);
       } catch {
         // `terminate()` normally returns a promise, but a synchronous failure
         // must not retain the process-wide concurrency slot.
+        releaseSlot();
       }
     }
 

--- a/src/pdf-reader.ts
+++ b/src/pdf-reader.ts
@@ -65,8 +65,10 @@ function isPdfWorkerResult(value: unknown): value is PdfWorkerResult {
 }
 
 function defaultPdfWorkerUrl(): URL {
-  const extension = import.meta.url.endsWith(".ts") ? "ts" : "js";
-  return new URL(`./pdf-worker.${extension}`, import.meta.url);
+  if (import.meta.url.endsWith(".ts")) {
+    return new URL("./pdf-worker-bootstrap.mjs", import.meta.url);
+  }
+  return new URL("./pdf-worker.js", import.meta.url);
 }
 
 export async function extractPdfText(

--- a/src/pdf-reader.ts
+++ b/src/pdf-reader.ts
@@ -1,0 +1,138 @@
+import { Worker } from "node:worker_threads";
+
+export const MAX_PDF_BYTES = 16 * 1024 * 1024;
+export const MAX_PDF_PAGES = 500;
+export const PDF_PARSE_TIMEOUT_MS = 30_000;
+const MAX_CONCURRENT_PDF_WORKERS = 2;
+
+export type PdfWorkerResult =
+  | { version: 1; kind: "text"; text: string; totalPages: number; textBytes: number }
+  | { version: 1; kind: "no_text"; totalPages: number }
+  | { version: 1; kind: "text_too_large"; bytes: number }
+  | { version: 1; kind: "too_many_pages"; totalPages: number }
+  | { version: 1; kind: "password_protected" }
+  | { version: 1; kind: "parse_error" }
+  | { version: 1; kind: "external_fetch_attempt" };
+
+export type PdfExtractionResult =
+  | PdfWorkerResult
+  | { version: 1; kind: "timeout" }
+  | { version: 1; kind: "worker_failure" }
+  | { version: 1; kind: "busy" };
+
+interface PdfExtractionOptions {
+  timeoutMs?: number;
+  workerUrl?: URL;
+}
+
+let activePdfWorkers = 0;
+
+function isNonNegativeInteger(value: unknown): value is number {
+  return typeof value === "number" && Number.isSafeInteger(value) && value >= 0;
+}
+
+function isPdfWorkerResult(value: unknown): value is PdfWorkerResult {
+  if (typeof value !== "object" || value === null) {
+    return false;
+  }
+
+  const result = value as Record<string, unknown>;
+  if (result.version !== 1 || typeof result.kind !== "string") {
+    return false;
+  }
+
+  switch (result.kind) {
+    case "text":
+      return typeof result.text === "string"
+        && isNonNegativeInteger(result.totalPages)
+        && isNonNegativeInteger(result.textBytes);
+    case "no_text":
+    case "too_many_pages":
+      return isNonNegativeInteger(result.totalPages);
+    case "text_too_large":
+      return isNonNegativeInteger(result.bytes);
+    case "password_protected":
+    case "parse_error":
+    case "external_fetch_attempt":
+      return true;
+    default:
+      return false;
+  }
+}
+
+function defaultPdfWorkerUrl(): URL {
+  const extension = import.meta.url.endsWith(".ts") ? "ts" : "js";
+  return new URL(`./pdf-worker.${extension}`, import.meta.url);
+}
+
+export async function extractPdfText(
+  bytes: Uint8Array,
+  maxTextBytes: number,
+  options: PdfExtractionOptions = {},
+): Promise<PdfExtractionResult> {
+  if (activePdfWorkers >= MAX_CONCURRENT_PDF_WORKERS) {
+    return { version: 1, kind: "busy" };
+  }
+
+  activePdfWorkers++;
+  const transferableBytes = bytes.slice();
+
+  return await new Promise<PdfExtractionResult>((resolve) => {
+    let worker: Worker;
+    try {
+      worker = new Worker(options.workerUrl ?? defaultPdfWorkerUrl(), {
+        // `--input-type` is valid only for eval/stdin entrypoints and makes a
+        // file-backed Worker fail during startup when inherited from a caller.
+        execArgv: process.execArgv.filter((argument) => argument !== "--input-type=module"),
+        workerData: {
+          version: 1,
+          pdfBytes: transferableBytes.buffer,
+          maxTextBytes,
+        },
+        transferList: [transferableBytes.buffer],
+        resourceLimits: {
+          maxOldGenerationSizeMb: 192,
+          stackSizeMb: 4,
+        },
+      });
+    } catch {
+      activePdfWorkers--;
+      resolve({ version: 1, kind: "worker_failure" });
+      return;
+    }
+
+    let settled = false;
+    const timeoutId = setTimeout(() => {
+      void finish({ version: 1, kind: "timeout" });
+    }, options.timeoutMs ?? PDF_PARSE_TIMEOUT_MS);
+
+    async function finish(result: PdfExtractionResult): Promise<void> {
+      if (settled) {
+        return;
+      }
+      settled = true;
+      clearTimeout(timeoutId);
+      worker.removeAllListeners();
+      try {
+        await worker.terminate();
+      } finally {
+        activePdfWorkers--;
+        resolve(result);
+      }
+    }
+
+    worker.once("message", (message: unknown) => {
+      void finish(
+        isPdfWorkerResult(message)
+          ? message
+          : { version: 1, kind: "worker_failure" },
+      );
+    });
+    worker.once("error", () => {
+      void finish({ version: 1, kind: "worker_failure" });
+    });
+    worker.once("exit", () => {
+      void finish({ version: 1, kind: "worker_failure" });
+    });
+  });
+}

--- a/src/pdf-reader.ts
+++ b/src/pdf-reader.ts
@@ -81,8 +81,8 @@ export async function extractPdfText(
     return { version: 1, kind: "busy" };
   }
 
-  activePdfWorkers++;
   const transferableBytes = bytes.slice();
+  activePdfWorkers++;
 
   return await new Promise<PdfExtractionResult>((resolve) => {
     let worker: Worker;

--- a/src/pdf-worker-bootstrap.mjs
+++ b/src/pdf-worker-bootstrap.mjs
@@ -1,0 +1,11 @@
+// Node 20 resolves a worker's TypeScript entrypoint before tsx's inherited
+// loader hooks are active. Register tsx inside this JavaScript entrypoint for
+// source tests. Published builds run pdf-worker.js directly.
+import { register } from "tsx/esm/api";
+
+const unregister = register();
+try {
+  await import("./pdf-worker.ts");
+} finally {
+  unregister();
+}

--- a/src/pdf-worker.ts
+++ b/src/pdf-worker.ts
@@ -1,6 +1,10 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { getDocumentProxy } from "unpdf";
 import { MAX_PDF_PAGES, type PdfWorkerResult } from "./pdf-reader.js";
+import {
+  ExternalFetchAttemptError,
+  installPdfNetworkGuards,
+} from "./pdf-network-guard.js";
 
 interface PdfWorkerInput {
   version: 1;
@@ -8,12 +12,16 @@ interface PdfWorkerInput {
   maxTextBytes: number;
 }
 
-class ExternalFetchAttemptError extends Error {
-  constructor() {
-    super("PDF_EXTERNAL_FETCH_ATTEMPT");
-    this.name = "ExternalFetchAttemptError";
-  }
-}
+export const PDF_DOCUMENT_OPTIONS = Object.freeze({
+  isEvalSupported: false,
+  enableXfa: false,
+  useSystemFonts: false,
+  disableFontFace: true,
+  disableAutoFetch: true,
+  disableStream: true,
+  useWorkerFetch: false,
+  verbosity: 0,
+});
 
 function containsExternalFetchMarker(error: unknown): boolean {
   let current = error;
@@ -61,23 +69,14 @@ async function extract(): Promise<PdfWorkerResult> {
     return { version: 1, kind: "parse_error" };
   }
 
-  const originalFetch = globalThis.fetch;
-  globalThis.fetch = async () => {
-    throw new ExternalFetchAttemptError();
-  };
+  // The document loader receives bytes rather than a URL, so no target-derived
+  // filesystem path exists. Block the network primitives available to Node as
+  // a second layer while parsing untrusted document content.
+  const restoreNetwork = installPdfNetworkGuards();
 
   let pdf: Awaited<ReturnType<typeof getDocumentProxy>> | undefined;
   try {
-    pdf = await getDocumentProxy(new Uint8Array(input.pdfBytes), {
-      isEvalSupported: false,
-      enableXfa: false,
-      useSystemFonts: false,
-      disableFontFace: true,
-      disableAutoFetch: true,
-      disableStream: true,
-      useWorkerFetch: false,
-      verbosity: 0,
-    });
+    pdf = await getDocumentProxy(new Uint8Array(input.pdfBytes), PDF_DOCUMENT_OPTIONS);
 
     if (pdf.numPages > MAX_PDF_PAGES) {
       return { version: 1, kind: "too_many_pages", totalPages: pdf.numPages };
@@ -85,34 +84,32 @@ async function extract(): Promise<PdfWorkerResult> {
 
     const pageTexts: string[] = [];
     const encoder = new TextEncoder();
-    let provisionalBytes = 0;
+    let textBytes = 0;
     for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
       const page = await pdf.getPage(pageNumber);
       try {
         const content = await page.getTextContent();
-        const pageText = content.items
+        const pageText = normalizeMergedText([content.items
           .map((item) => "str" in item && typeof item.str === "string"
             ? item.str + (item.hasEOL ? "\n" : "")
             : "")
-          .join("");
-        pageTexts.push(pageText);
-        provisionalBytes += encoder.encode(pageText).byteLength + (pageNumber > 1 ? 1 : 0);
-        if (provisionalBytes > input.maxTextBytes) {
-          return { version: 1, kind: "text_too_large", bytes: provisionalBytes };
+          .join("")]);
+        if (pageText !== "") {
+          const pageBytes = encoder.encode(pageText).byteLength;
+          textBytes += pageBytes + (pageTexts.length > 0 ? 1 : 0);
+          if (textBytes > input.maxTextBytes) {
+            return { version: 1, kind: "text_too_large", bytes: textBytes };
+          }
+          pageTexts.push(pageText);
         }
       } finally {
         page.cleanup();
       }
     }
 
-    const text = normalizeMergedText(pageTexts);
+    const text = pageTexts.join("\n");
     if (text === "") {
       return { version: 1, kind: "no_text", totalPages: pdf.numPages };
-    }
-
-    const textBytes = encoder.encode(text).byteLength;
-    if (textBytes > input.maxTextBytes) {
-      return { version: 1, kind: "text_too_large", bytes: textBytes };
     }
 
     return { version: 1, kind: "text", text, totalPages: pdf.numPages, textBytes };
@@ -125,7 +122,7 @@ async function extract(): Promise<PdfWorkerResult> {
     }
     return { version: 1, kind: "parse_error" };
   } finally {
-    globalThis.fetch = originalFetch;
+    restoreNetwork();
     try {
       await pdf?.destroy();
     } catch {

--- a/src/pdf-worker.ts
+++ b/src/pdf-worker.ts
@@ -27,6 +27,7 @@ export const PDF_DOCUMENT_OPTIONS = Object.freeze({
 type PdfDocumentProxy = Awaited<
   ReturnType<(typeof import("unpdf"))["getDocumentProxy"]>
 >;
+type PdfPageProxy = Awaited<ReturnType<PdfDocumentProxy["getPage"]>>;
 
 function containsExternalFetchMarker(error: unknown): boolean {
   let current = error;
@@ -65,14 +66,74 @@ function removeUnsafeControlCharacters(text: string): string {
   return text.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 
+function isPdfWorkerInput(value: unknown): value is PdfWorkerInput {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const input = value as Partial<PdfWorkerInput>;
+  return input.version === 1
+    && input.pdfBytes instanceof ArrayBuffer
+    && Number.isSafeInteger(input.maxTextBytes)
+    && (input.maxTextBytes ?? 0) > 0;
+}
+
+function renderTextItem(item: unknown): string {
+  if (!item || typeof item !== "object" || !("str" in item) || typeof item.str !== "string") {
+    return "";
+  }
+  return item.str + ("hasEOL" in item && item.hasEOL ? "\n" : "");
+}
+
+async function readPageText(page: PdfPageProxy): Promise<string> {
+  try {
+    const content = await page.getTextContent();
+    const rawText = content.items.map(renderTextItem).join("");
+    return normalizeMergedText([removeUnsafeControlCharacters(rawText)]);
+  } finally {
+    page.cleanup();
+  }
+}
+
+async function extractDocumentText(
+  pdf: PdfDocumentProxy,
+  maxTextBytes: number,
+): Promise<PdfWorkerResult> {
+  if (pdf.numPages > MAX_PDF_PAGES) {
+    return { version: 1, kind: "too_many_pages", totalPages: pdf.numPages };
+  }
+
+  const pageTexts: string[] = [];
+  const encoder = new TextEncoder();
+  let textBytes = 0;
+  for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
+    const pageText = await readPageText(await pdf.getPage(pageNumber));
+    if (pageText === "") {
+      continue;
+    }
+    textBytes += encoder.encode(pageText).byteLength + (pageTexts.length > 0 ? 1 : 0);
+    if (textBytes > maxTextBytes) {
+      return { version: 1, kind: "text_too_large", bytes: textBytes };
+    }
+    pageTexts.push(pageText);
+  }
+
+  const text = pageTexts.join("\n");
+  return text === ""
+    ? { version: 1, kind: "no_text", totalPages: pdf.numPages }
+    : { version: 1, kind: "text", text, totalPages: pdf.numPages, textBytes };
+}
+
+function classifyParserError(error: unknown): PdfWorkerResult {
+  if (containsExternalFetchMarker(error)) {
+    return { version: 1, kind: "external_fetch_attempt" };
+  }
+  return isPasswordError(error)
+    ? { version: 1, kind: "password_protected" }
+    : { version: 1, kind: "parse_error" };
+}
+
 async function extract(): Promise<PdfWorkerResult> {
-  const input = workerData as PdfWorkerInput;
-  if (
-    input.version !== 1
-    || !(input.pdfBytes instanceof ArrayBuffer)
-    || !Number.isSafeInteger(input.maxTextBytes)
-    || input.maxTextBytes <= 0
-  ) {
+  if (!isPdfWorkerInput(workerData)) {
     return { version: 1, kind: "parse_error" };
   }
 
@@ -86,51 +147,10 @@ async function extract(): Promise<PdfWorkerResult> {
     // Import after the guards are active so parser dependencies cannot retain
     // unguarded references to Node network primitives during module loading.
     const { getDocumentProxy } = await import("unpdf");
-    pdf = await getDocumentProxy(new Uint8Array(input.pdfBytes), PDF_DOCUMENT_OPTIONS);
-
-    if (pdf.numPages > MAX_PDF_PAGES) {
-      return { version: 1, kind: "too_many_pages", totalPages: pdf.numPages };
-    }
-
-    const pageTexts: string[] = [];
-    const encoder = new TextEncoder();
-    let textBytes = 0;
-    for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
-      const page = await pdf.getPage(pageNumber);
-      try {
-        const content = await page.getTextContent();
-        const pageText = normalizeMergedText([removeUnsafeControlCharacters(content.items
-          .map((item) => "str" in item && typeof item.str === "string"
-            ? item.str + (item.hasEOL ? "\n" : "")
-            : "")
-          .join(""))]);
-        if (pageText !== "") {
-          const pageBytes = encoder.encode(pageText).byteLength;
-          textBytes += pageBytes + (pageTexts.length > 0 ? 1 : 0);
-          if (textBytes > input.maxTextBytes) {
-            return { version: 1, kind: "text_too_large", bytes: textBytes };
-          }
-          pageTexts.push(pageText);
-        }
-      } finally {
-        page.cleanup();
-      }
-    }
-
-    const text = pageTexts.join("\n");
-    if (text === "") {
-      return { version: 1, kind: "no_text", totalPages: pdf.numPages };
-    }
-
-    return { version: 1, kind: "text", text, totalPages: pdf.numPages, textBytes };
+    pdf = await getDocumentProxy(new Uint8Array(workerData.pdfBytes), PDF_DOCUMENT_OPTIONS);
+    return await extractDocumentText(pdf, workerData.maxTextBytes);
   } catch (error) {
-    if (containsExternalFetchMarker(error)) {
-      return { version: 1, kind: "external_fetch_attempt" };
-    }
-    if (isPasswordError(error)) {
-      return { version: 1, kind: "password_protected" };
-    }
-    return { version: 1, kind: "parse_error" };
+    return classifyParserError(error);
   } finally {
     restoreNetwork();
     try {

--- a/src/pdf-worker.ts
+++ b/src/pdf-worker.ts
@@ -1,5 +1,4 @@
 import { parentPort, workerData } from "node:worker_threads";
-import { getDocumentProxy } from "unpdf";
 import { MAX_PDF_PAGES, type PdfWorkerResult } from "./pdf-reader.js";
 import {
   ExternalFetchAttemptError,
@@ -20,8 +19,17 @@ export const PDF_DOCUMENT_OPTIONS = Object.freeze({
   disableAutoFetch: true,
   disableStream: true,
   useWorkerFetch: false,
+  useWasm: false,
+  cMapUrl: undefined,
+  standardFontDataUrl: undefined,
+  wasmUrl: undefined,
+  iccUrl: undefined,
   verbosity: 0,
 });
+
+type PdfDocumentProxy = Awaited<
+  ReturnType<(typeof import("unpdf"))["getDocumentProxy"]>
+>;
 
 function containsExternalFetchMarker(error: unknown): boolean {
   let current = error;
@@ -58,6 +66,22 @@ function normalizeMergedText(texts: string[]): string {
     .trim();
 }
 
+function removeUnsafeControlCharacters(text: string): string {
+  let sanitized = "";
+  for (const character of text) {
+    const codePoint = character.codePointAt(0) ?? 0;
+    if (
+      codePoint === 0x09
+      || codePoint === 0x0a
+      || codePoint === 0x0d
+      || (codePoint >= 0x20 && codePoint !== 0x7f)
+    ) {
+      sanitized += character;
+    }
+  }
+  return sanitized;
+}
+
 async function extract(): Promise<PdfWorkerResult> {
   const input = workerData as PdfWorkerInput;
   if (
@@ -74,8 +98,11 @@ async function extract(): Promise<PdfWorkerResult> {
   // a second layer while parsing untrusted document content.
   const restoreNetwork = installPdfNetworkGuards();
 
-  let pdf: Awaited<ReturnType<typeof getDocumentProxy>> | undefined;
+  let pdf: PdfDocumentProxy | undefined;
   try {
+    // Import after the guards are active so parser dependencies cannot retain
+    // unguarded references to Node network primitives during module loading.
+    const { getDocumentProxy } = await import("unpdf");
     pdf = await getDocumentProxy(new Uint8Array(input.pdfBytes), PDF_DOCUMENT_OPTIONS);
 
     if (pdf.numPages > MAX_PDF_PAGES) {
@@ -89,11 +116,11 @@ async function extract(): Promise<PdfWorkerResult> {
       const page = await pdf.getPage(pageNumber);
       try {
         const content = await page.getTextContent();
-        const pageText = normalizeMergedText([content.items
+        const pageText = normalizeMergedText([removeUnsafeControlCharacters(content.items
           .map((item) => "str" in item && typeof item.str === "string"
             ? item.str + (item.hasEOL ? "\n" : "")
             : "")
-          .join("")]);
+          .join(""))]);
         if (pageText !== "") {
           const pageBytes = encoder.encode(pageText).byteLength;
           textBytes += pageBytes + (pageTexts.length > 0 ? 1 : 0);

--- a/src/pdf-worker.ts
+++ b/src/pdf-worker.ts
@@ -138,8 +138,9 @@ async function extract(): Promise<PdfWorkerResult> {
   }
 
   // The document loader receives bytes rather than a URL, so no target-derived
-  // filesystem path exists. Block the network primitives available to Node as
-  // a second layer while parsing untrusted document content.
+  // filesystem path exists. Block the Node fetch, HTTP(S), TCP, and TLS
+  // primitives used by the parser as a second layer while parsing untrusted
+  // document content.
   const restoreNetwork = installPdfNetworkGuards();
 
   let pdf: PdfDocumentProxy | undefined;

--- a/src/pdf-worker.ts
+++ b/src/pdf-worker.ts
@@ -1,9 +1,6 @@
 import { parentPort, workerData } from "node:worker_threads";
 import { MAX_PDF_PAGES, type PdfWorkerResult } from "./pdf-reader.js";
-import {
-  ExternalFetchAttemptError,
-  installPdfNetworkGuards,
-} from "./pdf-network-guard.js";
+import { installPdfNetworkGuards } from "./pdf-network-guard.js";
 
 interface PdfWorkerInput {
   version: 1;
@@ -33,20 +30,18 @@ type PdfDocumentProxy = Awaited<
 
 function containsExternalFetchMarker(error: unknown): boolean {
   let current = error;
-  for (let depth = 0; depth < 4 && current; depth++) {
+  for (let depth = 0; depth < 4; depth++) {
+    if (!current || typeof current !== "object") {
+      return false;
+    }
+    const candidate = current as { name?: unknown; message?: unknown; cause?: unknown };
     if (
-      typeof current === "object"
-      && current !== null
-      && (
-        (current as { name?: unknown }).name === "ExternalFetchAttemptError"
-        || String((current as { message?: unknown }).message).includes("PDF_EXTERNAL_FETCH_ATTEMPT")
-      )
+      candidate.name === "ExternalFetchAttemptError"
+      || String(candidate.message).includes("PDF_EXTERNAL_FETCH_ATTEMPT")
     ) {
       return true;
     }
-    current = typeof current === "object" && current !== null
-      ? (current as { cause?: unknown }).cause
-      : undefined;
+    current = candidate.cause;
   }
   return false;
 }
@@ -67,19 +62,7 @@ function normalizeMergedText(texts: string[]): string {
 }
 
 function removeUnsafeControlCharacters(text: string): string {
-  let sanitized = "";
-  for (const character of text) {
-    const codePoint = character.codePointAt(0) ?? 0;
-    if (
-      codePoint === 0x09
-      || codePoint === 0x0a
-      || codePoint === 0x0d
-      || (codePoint >= 0x20 && codePoint !== 0x7f)
-    ) {
-      sanitized += character;
-    }
-  }
-  return sanitized;
+  return text.replace(/[\x00-\x08\x0b\x0c\x0e-\x1f\x7f]/g, "");
 }
 
 async function extract(): Promise<PdfWorkerResult> {

--- a/src/pdf-worker.ts
+++ b/src/pdf-worker.ts
@@ -1,0 +1,140 @@
+import { parentPort, workerData } from "node:worker_threads";
+import { getDocumentProxy } from "unpdf";
+import { MAX_PDF_PAGES, type PdfWorkerResult } from "./pdf-reader.js";
+
+interface PdfWorkerInput {
+  version: 1;
+  pdfBytes: ArrayBuffer;
+  maxTextBytes: number;
+}
+
+class ExternalFetchAttemptError extends Error {
+  constructor() {
+    super("PDF_EXTERNAL_FETCH_ATTEMPT");
+    this.name = "ExternalFetchAttemptError";
+  }
+}
+
+function containsExternalFetchMarker(error: unknown): boolean {
+  let current = error;
+  for (let depth = 0; depth < 4 && current; depth++) {
+    if (
+      typeof current === "object"
+      && current !== null
+      && (
+        (current as { name?: unknown }).name === "ExternalFetchAttemptError"
+        || String((current as { message?: unknown }).message).includes("PDF_EXTERNAL_FETCH_ATTEMPT")
+      )
+    ) {
+      return true;
+    }
+    current = typeof current === "object" && current !== null
+      ? (current as { cause?: unknown }).cause
+      : undefined;
+  }
+  return false;
+}
+
+function isPasswordError(error: unknown): boolean {
+  return typeof error === "object"
+    && error !== null
+    && (error as { name?: unknown }).name === "PasswordException";
+}
+
+function normalizeMergedText(texts: string[]): string {
+  return texts
+    .join("\n")
+    .replace(/[^\S\n]+/g, " ")
+    .replace(/ ?\n ?/g, "\n")
+    .replace(/\n{3,}/g, "\n\n")
+    .trim();
+}
+
+async function extract(): Promise<PdfWorkerResult> {
+  const input = workerData as PdfWorkerInput;
+  if (
+    input.version !== 1
+    || !(input.pdfBytes instanceof ArrayBuffer)
+    || !Number.isSafeInteger(input.maxTextBytes)
+    || input.maxTextBytes <= 0
+  ) {
+    return { version: 1, kind: "parse_error" };
+  }
+
+  const originalFetch = globalThis.fetch;
+  globalThis.fetch = async () => {
+    throw new ExternalFetchAttemptError();
+  };
+
+  let pdf: Awaited<ReturnType<typeof getDocumentProxy>> | undefined;
+  try {
+    pdf = await getDocumentProxy(new Uint8Array(input.pdfBytes), {
+      isEvalSupported: false,
+      enableXfa: false,
+      useSystemFonts: false,
+      disableFontFace: true,
+      disableAutoFetch: true,
+      disableStream: true,
+      useWorkerFetch: false,
+      verbosity: 0,
+    });
+
+    if (pdf.numPages > MAX_PDF_PAGES) {
+      return { version: 1, kind: "too_many_pages", totalPages: pdf.numPages };
+    }
+
+    const pageTexts: string[] = [];
+    const encoder = new TextEncoder();
+    let provisionalBytes = 0;
+    for (let pageNumber = 1; pageNumber <= pdf.numPages; pageNumber++) {
+      const page = await pdf.getPage(pageNumber);
+      try {
+        const content = await page.getTextContent();
+        const pageText = content.items
+          .map((item) => "str" in item && typeof item.str === "string"
+            ? item.str + (item.hasEOL ? "\n" : "")
+            : "")
+          .join("");
+        pageTexts.push(pageText);
+        provisionalBytes += encoder.encode(pageText).byteLength + (pageNumber > 1 ? 1 : 0);
+        if (provisionalBytes > input.maxTextBytes) {
+          return { version: 1, kind: "text_too_large", bytes: provisionalBytes };
+        }
+      } finally {
+        page.cleanup();
+      }
+    }
+
+    const text = normalizeMergedText(pageTexts);
+    if (text === "") {
+      return { version: 1, kind: "no_text", totalPages: pdf.numPages };
+    }
+
+    const textBytes = encoder.encode(text).byteLength;
+    if (textBytes > input.maxTextBytes) {
+      return { version: 1, kind: "text_too_large", bytes: textBytes };
+    }
+
+    return { version: 1, kind: "text", text, totalPages: pdf.numPages, textBytes };
+  } catch (error) {
+    if (containsExternalFetchMarker(error)) {
+      return { version: 1, kind: "external_fetch_attempt" };
+    }
+    if (isPasswordError(error)) {
+      return { version: 1, kind: "password_protected" };
+    }
+    return { version: 1, kind: "parse_error" };
+  } finally {
+    globalThis.fetch = originalFetch;
+    try {
+      await pdf?.destroy();
+    } catch {
+      // The extraction result is authoritative; teardown failures stay inside the worker.
+    }
+  }
+}
+
+const outputPort = parentPort;
+if (outputPort) {
+  void extract().then((result) => outputPort.postMessage(result));
+}

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,7 +350,7 @@ export const LITE_INSTANCE_INFO_TOOL: Tool = {
 export const LITE_READ_URL_TOOL: Tool = {
   name: "web_url_read",
   description:
-    "Fetch URL. Converts HTML to markdown; returns explicit JSON, plain text, YAML, TOML, and XML as readable markdown; binary/media/archive downloads are rejected. An operator-configured FlareSolverr or Byparr service can acquire browser sessions for challenge-protected URLs.",
+    "Fetch URL. Converts HTML to markdown; returns explicit JSON, plain text, YAML, TOML, and XML as readable markdown; supports bounded PDF text extraction; other binary/media/archive downloads are rejected. An operator-configured FlareSolverr or Byparr service can acquire browser sessions for challenge-protected URLs.",
   inputSchema: {
     type: "object",
     properties: { url: { type: "string", description: "URL to fetch." } },
@@ -363,7 +363,8 @@ export const READ_URL_TOOL: Tool = {
   description:
     "Fetches a URL and returns readable content as markdown. " +
     "Content-type aware: HTML is converted to markdown; JSON is pretty-printed; plain text, YAML, TOML, and XML are returned as fenced readable text. " +
-    "Binary, media, archive, PDF, and octet-stream downloads are intentionally rejected instead of being returned as raw bytes. " +
+    "PDF text extraction is supported with bounded input, output, page count, time, concurrency, and memory; OCR is not supported. " +
+    "Binary, media, archive, and octet-stream downloads other than PDFs are intentionally rejected instead of being returned as raw bytes. " +
     "When the operator configures FlareSolverr or Byparr, challenge-protected URLs are solved before the normal bounded URL-reader fetch. " +
     "Three modes: " +
     "(1) Full content — omit filtering params; use `startChar`/`maxLength` to paginate large pages. " +

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -743,6 +743,9 @@ export async function fetchAndConvertToMarkdown(
       try {
         bodyRead = await readResponseBytesWithLimit(response, effectivePdfLimit);
       } catch (error: any) {
+        if (error?.name === "AbortError") {
+          throw error;
+        }
         throw createContentError(
           `Failed to read PDF content: ${error.message || "Unknown error reading content"}`,
           url,

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -748,7 +748,7 @@ export async function fetchAndConvertToMarkdown(
       const extraction = await extractPdfText(bodyRead.bytes, effectivePdfLimit);
       switch (extraction.kind) {
         case "text":
-          markdownContent = extraction.text;
+          markdownContent = renderFencedMarkdown("text", extraction.text);
           break;
         case "no_text":
           return "No extractable text (likely a scanned/image PDF; OCR is not supported).";

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -775,7 +775,7 @@ export async function fetchAndConvertToMarkdown(
         case "parse_error":
           return "Unable to extract text from PDF.";
         case "too_many_pages":
-          return `PDF has too many pages to extract safely (limit: ${MAX_PDF_PAGES}).`;
+          return `PDF has too many pages to extract safely (observed: ${extraction.totalPages}; limit: ${MAX_PDF_PAGES}).`;
         case "text_too_large":
           return createPdfTextTooLargeMessage(extraction.bytes, effectivePdfLimit);
         case "timeout":

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -303,6 +303,20 @@ function createPdfTextTooLargeMessage(textBytes: number, maxBytes: number): stri
   );
 }
 
+function createPdfInputTooLargeMessage(
+  contentLength: number,
+  effectiveLimit: number,
+  configuredLimit: number,
+): string {
+  if (configuredLimit < MAX_PDF_BYTES) {
+    return createContentTooLargeMessage(contentLength, effectiveLimit);
+  }
+  return (
+    `Content too large: ${formatByteSize(contentLength)} exceeds the ${formatByteSize(effectiveLimit)} limit. ` +
+    `This is the fixed PDF input ceiling and cannot be raised with URL_READ_MAX_CONTENT_LENGTH_BYTES.`
+  );
+}
+
 function normalizeMediaType(contentType: string | null): string | null {
   if (!contentType) {
     return null;
@@ -735,7 +749,11 @@ export async function fetchAndConvertToMarkdown(
         );
       }
       if (bodyRead.exceeded) {
-        return createContentTooLargeMessage(bodyRead.bytesRead, effectivePdfLimit);
+        return createPdfInputTooLargeMessage(
+          bodyRead.bytesRead,
+          effectivePdfLimit,
+          maxContentLengthBytes,
+        );
       }
 
       // The network phase is complete. PDF parsing has its own independent,

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -13,6 +13,7 @@ import {
   resolveFlareSolverrConfig,
   type FlareSolverrSolution,
 } from "./flaresolverr.js";
+import { extractPdfText, MAX_PDF_BYTES, MAX_PDF_PAGES } from "./pdf-reader.js";
 import {
   createURLFormatError,
   createURLSecurityPolicyError,
@@ -38,6 +39,10 @@ type BoundedBodyReadResult =
   | { exceeded: false; text: string; bytesRead: number; hasNulInPrefix: boolean }
   | { exceeded: true; bytesRead: number };
 
+type BoundedByteReadResult =
+  | { exceeded: false; bytes: Uint8Array; bytesRead: number; hasNulInPrefix: boolean }
+  | { exceeded: true; bytesRead: number };
+
 const REDIRECT_STATUS_CODES = new Set([301, 302, 303, 307, 308]);
 const MAX_REDIRECTS = 5;
 export const DEFAULT_MAX_CONTENT_LENGTH_BYTES = 5 * 1024 * 1024;
@@ -47,6 +52,7 @@ const BINARY_SNIFF_PREFIX_BYTES = 1024;
 type ContentTypeClassification =
   | { kind: "html"; mediaType: string; language: "html" }
   | { kind: "json"; mediaType: string; language: "json" }
+  | { kind: "pdf"; mediaType: "application/pdf" }
   | { kind: "text"; mediaType: string; language: "text" | "yaml" | "toml" | "xml" }
   | { kind: "binary"; mediaType: string | null }
   | { kind: "generic"; mediaType: string | null };
@@ -55,6 +61,7 @@ const EXACT_READABLE_CONTENT_TYPES = new Map<string, (mediaType: string) => Cont
   ["text/html", (mediaType) => ({ kind: "html", mediaType, language: "html" })],
   ["application/xhtml+xml", (mediaType) => ({ kind: "html", mediaType, language: "html" })],
   ["application/json", (mediaType) => ({ kind: "json", mediaType, language: "json" })],
+  ["application/pdf", () => ({ kind: "pdf", mediaType: "application/pdf" })],
   ["application/xml", (mediaType) => ({ kind: "text", mediaType, language: "xml" })],
   ["text/xml", (mediaType) => ({ kind: "text", mediaType, language: "xml" })],
   ["application/yaml", (mediaType) => ({ kind: "text", mediaType, language: "yaml" })],
@@ -67,7 +74,6 @@ const EXACT_READABLE_CONTENT_TYPES = new Map<string, (mediaType: string) => Cont
 ]);
 
 const EXACT_BINARY_CONTENT_TYPES = new Set([
-  "application/pdf",
   "application/octet-stream",
   "binary/octet-stream",
   "application/zip",
@@ -290,6 +296,13 @@ function createContentTooLargeMessage(contentLength: number, maxBytes: number): 
   );
 }
 
+function createPdfTextTooLargeMessage(textBytes: number, maxBytes: number): string {
+  return (
+    `Extracted PDF text exceeds the safe byte limit: ${formatByteSize(textBytes)} ` +
+    `exceeds ${formatByteSize(maxBytes)}.`
+  );
+}
+
 function normalizeMediaType(contentType: string | null): string | null {
   if (!contentType) {
     return null;
@@ -341,7 +354,7 @@ function createUnsupportedContentTypeMessage(classification: ContentTypeClassifi
   const reasonText = reason ? ` ${reason}` : "";
   return (
     `Unsupported content type: ${contentType}.${reasonText} ` +
-    "Binary, media, archive, and PDF downloads are intentionally not read by web_url_read."
+    "Binary, media, and archive downloads are intentionally not read by web_url_read."
   );
 }
 
@@ -349,7 +362,7 @@ function createNulRejectedContentMessage(classification: ContentTypeClassificati
   if (classification.kind !== "generic" && classification.mediaType !== null) {
     return (
       `Body was declared ${classification.mediaType} but appears binary (NUL byte in first 1KB); not read. ` +
-      "Binary, media, archive, and PDF downloads are intentionally not read by web_url_read."
+      "Binary, media, and archive downloads are intentionally not read by web_url_read."
     );
   }
 
@@ -427,9 +440,9 @@ function evaluateChunkLimits(
   maxBytes: number,
   hasNulInPrefix: boolean,
   abortOnNulInPrefix: boolean,
-): BoundedBodyReadResult | null {
+): BoundedByteReadResult | null {
   if (hasNulInPrefix && abortOnNulInPrefix) {
-    return { exceeded: false, text: "", bytesRead, hasNulInPrefix };
+    return { exceeded: false, bytes: new Uint8Array(), bytesRead, hasNulInPrefix };
   }
   if (bytesRead > maxBytes) {
     return { exceeded: true, bytesRead };
@@ -437,13 +450,13 @@ function evaluateChunkLimits(
   return null;
 }
 
-async function readResponseBodyWithLimit(
+async function readResponseBytesWithLimit(
   response: Response,
   maxBytes: number,
   abortOnNulInPrefix: boolean = false,
-): Promise<BoundedBodyReadResult> {
+): Promise<BoundedByteReadResult> {
   if (response.body === null) {
-    return { exceeded: false, text: "", bytesRead: 0, hasNulInPrefix: false };
+    return { exceeded: false, bytes: new Uint8Array(), bytesRead: 0, hasNulInPrefix: false };
   }
 
   const reader = response.body.getReader();
@@ -479,8 +492,38 @@ async function readResponseBodyWithLimit(
     reader.releaseLock();
   }
 
-  const bodyBytes = concatenateChunks(chunks, bytesRead);
-  return { exceeded: false, text: new TextDecoder("utf-8").decode(bodyBytes), bytesRead, hasNulInPrefix };
+  return {
+    exceeded: false,
+    bytes: concatenateChunks(chunks, bytesRead),
+    bytesRead,
+    hasNulInPrefix,
+  };
+}
+
+async function readResponseBodyWithLimit(
+  response: Response,
+  maxBytes: number,
+  abortOnNulInPrefix: boolean = false,
+): Promise<BoundedBodyReadResult> {
+  const result = await readResponseBytesWithLimit(response, maxBytes, abortOnNulInPrefix);
+  if (result.exceeded) {
+    return result;
+  }
+  return {
+    exceeded: false,
+    text: new TextDecoder("utf-8").decode(result.bytes),
+    bytesRead: result.bytesRead,
+    hasNulInPrefix: result.hasNulInPrefix,
+  };
+}
+
+function hasPdfSignature(bytes: Uint8Array): boolean {
+  return bytes.byteLength >= 5
+    && bytes[0] === 0x25
+    && bytes[1] === 0x50
+    && bytes[2] === 0x44
+    && bytes[3] === 0x46
+    && bytes[4] === 0x2d;
 }
 
 export async function fetchAndConvertToMarkdown(
@@ -679,42 +722,89 @@ export async function fetchAndConvertToMarkdown(
       return createUnsupportedContentTypeMessage(contentType);
     }
 
-    // Retrieve readable content
-    let rawContent: string;
-    let hasNulInPrefix = false;
-    try {
-      const bodyRead = await readResponseBodyWithLimit(response, maxContentLengthBytes, true);
-      if (bodyRead.exceeded) {
-        return createContentTooLargeMessage(bodyRead.bytesRead, maxContentLengthBytes);
-      }
-      rawContent = bodyRead.text;
-      hasNulInPrefix = bodyRead.hasNulInPrefix;
-    } catch (error: any) {
-      throw createContentError(
-        `Failed to read website content: ${error.message || 'Unknown error reading content'}`,
-        url
-      );
-    }
-
-    if (hasNulInPrefix) {
-      return createNulRejectedContentMessage(contentType);
-    }
-
-    if (!rawContent || rawContent.trim().length === 0) {
-      throw createContentError("Website returned empty content.", url);
-    }
-
-    // Convert readable content to Markdown
     let markdownContent: string;
-    if (contentType.kind === "json") {
-      markdownContent = renderJsonMarkdown(rawContent);
-    } else if (contentType.kind === "text") {
-      markdownContent = renderFencedMarkdown(contentType.language, rawContent);
-    } else {
+    if (contentType.kind === "pdf") {
+      const effectivePdfLimit = Math.min(maxContentLengthBytes, MAX_PDF_BYTES);
+      let bodyRead: BoundedByteReadResult;
       try {
-        markdownContent = NodeHtmlMarkdown.translate(rawContent);
-      } catch {
-        throw createConversionError(url);
+        bodyRead = await readResponseBytesWithLimit(response, effectivePdfLimit);
+      } catch (error: any) {
+        throw createContentError(
+          `Failed to read PDF content: ${error.message || "Unknown error reading content"}`,
+          url,
+        );
+      }
+      if (bodyRead.exceeded) {
+        return createContentTooLargeMessage(bodyRead.bytesRead, effectivePdfLimit);
+      }
+
+      // The network phase is complete. PDF parsing has its own independent,
+      // bounded worker timeout rather than sharing the fetch budget.
+      clearTimeout(timeoutId);
+      if (!hasPdfSignature(bodyRead.bytes)) {
+        return "Response declared application/pdf but did not contain a PDF document.";
+      }
+
+      const extraction = await extractPdfText(bodyRead.bytes, effectivePdfLimit);
+      switch (extraction.kind) {
+        case "text":
+          markdownContent = extraction.text;
+          break;
+        case "no_text":
+          return "No extractable text (likely a scanned/image PDF; OCR is not supported).";
+        case "password_protected":
+          return "Password-protected PDF cannot be read.";
+        case "parse_error":
+          return "Unable to extract text from PDF.";
+        case "too_many_pages":
+          return `PDF has too many pages to extract safely (limit: ${MAX_PDF_PAGES}).`;
+        case "text_too_large":
+          return createPdfTextTooLargeMessage(extraction.bytes, effectivePdfLimit);
+        case "timeout":
+          return "PDF text extraction timed out.";
+        case "busy":
+          return "PDF text extraction is busy; try again later.";
+        case "external_fetch_attempt":
+          return "PDF attempted an external resource fetch and was blocked.";
+        case "worker_failure":
+          return "PDF text extraction worker failed.";
+      }
+    } else {
+      // Retrieve readable text content.
+      let rawContent: string;
+      let hasNulInPrefix = false;
+      try {
+        const bodyRead = await readResponseBodyWithLimit(response, maxContentLengthBytes, true);
+        if (bodyRead.exceeded) {
+          return createContentTooLargeMessage(bodyRead.bytesRead, maxContentLengthBytes);
+        }
+        rawContent = bodyRead.text;
+        hasNulInPrefix = bodyRead.hasNulInPrefix;
+      } catch (error: any) {
+        throw createContentError(
+          `Failed to read website content: ${error.message || "Unknown error reading content"}`,
+          url,
+        );
+      }
+
+      if (hasNulInPrefix) {
+        return createNulRejectedContentMessage(contentType);
+      }
+
+      if (!rawContent || rawContent.trim().length === 0) {
+        throw createContentError("Website returned empty content.", url);
+      }
+
+      if (contentType.kind === "json") {
+        markdownContent = renderJsonMarkdown(rawContent);
+      } else if (contentType.kind === "text") {
+        markdownContent = renderFencedMarkdown(contentType.language, rawContent);
+      } else {
+        try {
+          markdownContent = NodeHtmlMarkdown.translate(rawContent);
+        } catch {
+          throw createConversionError(url);
+        }
       }
     }
 


### PR DESCRIPTION
## Summary

- extract text from `application/pdf` responses in a resource-bounded worker
- enforce input, output, page, time, concurrency, memory, and network-egress limits
- preserve existing URL security, FlareSolverr replay, caching, and pagination behavior
- verify the shipped worker from an installed npm tarball

## Verification

- `npm run test:coverage` — 639/639 passed; 95.62% lines, 91.71% branches
- `npm run build`
- `npm run lint -- --no-cache`
- `npm run security` — 0 production vulnerabilities
- `npm run verify:packed-consumer`
- live full E2E — 13/13 passed, including FlareSolverr extraction of `https://eprint.iacr.org/2025/858.pdf` with the paper title and Abstract

Closes #167