### PR TITLE
feat(url-reader): add browser solver failover

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ Versions follow [Semantic Versioning](https://semver.org/).
 
 ### Added
 
-- **Explicit FlareSolverr or Byparr URL reading:** Operators can select exactly one browser solver with `FLARESOLVERR_URL` or `BYPARR_URL`. FlareSolverr retains its millisecond timeout and concurrency variables; Byparr adds `BYPARR_TIMEOUT_SECONDS` and `BYPARR_MAX_CONCURRENT_REQUESTS`. Simultaneous endpoints fail closed, provider counters remain independent, MCP cancellation now reaches solver acquisition, replay, body streaming, and PDF workers, and transient failures retain the existing one-time uncached direct fallback. Verified with FlareSolverr 3.5.0 and Byparr 2.1.0 on 2026-07-30.
+- **FlareSolverr-primary failover to Byparr:** Operators can configure `FLARESOLVERR_URL`, `BYPARR_URL`, or both. Dual mode always tries FlareSolverr first, advances to Byparr only for busy or transient-unavailable acquisition, and uses one uncached direct fetch only after the final provider is unavailable. Persistent 4xx, cancellation, solution-integrity failures, and solved non-2xx target status stop the chain. Provider timeouts and concurrency remain independent, cache entries use the winning provider, and canonically duplicate endpoints fail closed. Verified provider versions remain FlareSolverr 3.5.0 and Byparr 2.1.0 from 2026-07-30.
 
   **Migration note:** Browser-solver endpoints are now validated during startup. A `FLARESOLVERR_URL` containing userinfo, a query, a fragment, or a non-HTTP(S) scheme now prevents startup instead of failing only when a URL read first uses it.
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -94,17 +94,18 @@ for trust, evaluation, and conservative-use guidance.
 | `URL_READ_MAX_CONTENT_LENGTH_BYTES` | No | `5242880` | Maximum decompressed response-body bytes `web_url_read` will read while streaming a page. A HEAD `Content-Length` preflight may reject oversized pages before GET, but the streaming cap is authoritative. PDF input and extracted text additionally have a fixed 16 MiB ceiling. Invalid values fall back to the default. |
 | `FLARESOLVERR_URL` | No | — | Base URL of a trusted FlareSolverr service, such as `http://flaresolverr:8191`. When set, `web_url_read` attempts to ask its `/v1` API for a browser session after an uncached URL passes URL validation and the HEAD size preflight. |
 | `FLARESOLVERR_TIMEOUT_MS` | No | `60000` | Maximum session-acquisition time in milliseconds, from `1` through `300000`. Invalid values use the default. This is separate from `FETCH_TIMEOUT_MS`, which starts when the target is replayed. |
-| `FLARESOLVERR_MAX_CONCURRENT_REQUESTS` | No | `2` | Maximum concurrent solver acquisitions per MCP process, from `1` through `16`. When all slots are occupied, the request uses the direct URL-reader path instead of waiting in a queue. |
-| `BYPARR_URL` | No | — | Base URL of a trusted Byparr service, such as `http://byparr:8191`. It is mutually exclusive with `FLARESOLVERR_URL`. |
+| `FLARESOLVERR_MAX_CONCURRENT_REQUESTS` | No | `2` | Maximum concurrent FlareSolverr acquisitions per MCP process, from `1` through `16`. In dual mode, a full primary limit advances to Byparr instead of waiting in a queue. |
+| `BYPARR_URL` | No | — | Base URL of a trusted Byparr service, such as `http://byparr:8191`. It may be configured alone or with `FLARESOLVERR_URL`; dual mode always tries FlareSolverr first. |
 | `BYPARR_TIMEOUT_SECONDS` | No | `60` | Maximum Byparr session-acquisition time in whole seconds, from `1` through `300`. Invalid values use the default. |
 | `BYPARR_MAX_CONCURRENT_REQUESTS` | No | `2` | Maximum concurrent Byparr acquisitions per MCP process, from `1` through `16`. It is independent from the FlareSolverr counter. |
 | `CACHE_TTL_MS` | No | `86400000` | URL cache TTL in milliseconds. Invalid or non-positive values fall back to the default (24 hours). |
 | `CACHE_MAX_ENTRIES` | No | `500` | Maximum number of cached URLs. When the cache exceeds this size, the least frequently used entry is evicted, with oldest entry used as the tie-breaker. Invalid or non-positive values fall back to the default. |
 
 FlareSolverr 3.5.0 and Byparr 2.1.0 were verified on 2026-07-30. Configure
-either provider or neither provider. If both endpoint variables are non-blank,
-startup fails closed. This release does not automatically fall back between
-providers.
+either provider, both providers, or neither provider. With both endpoints,
+FlareSolverr is always primary and Byparr is the secondary; ordering is not
+configurable and automatic reverse failover is not performed. Canonically
+identical endpoints fail startup without echoing either configured value.
 
 The verified `linux/amd64` images came from multi-architecture manifests
 `ghcr.io/flaresolverr/flaresolverr:v3.5.0@sha256:139dfee1c6f89249c8d665d1333a42e8ec74ec0a86bc6bb1c8461e10d3a66a47`
@@ -125,23 +126,26 @@ scheme now prevents startup until corrected.
 `BYPARR_TIMEOUT_SECONDS` is sent in seconds. The client permits up to 5
 additional seconds to receive and validate either solver response.
 
-With one browser-solver endpoint configured, `web_url_read` first performs its normal
+With at least one browser-solver endpoint configured, `web_url_read` first performs its normal
 target URL security and HEAD size preflight for every uncached read. It then
 requests a browser session and uses only its cookies and user-agent. Byparr
 2.1.0 also returns rendered content; that field is discarded after a bounded
 parse.
 When a solver slot is available, every uncached URL that passes URL validation
-and the HEAD size preflight is disclosed to the configured browser solver.
-Cache hits and reads made while the solver concurrency limit is full bypass
-solver acquisition. The actual target is fetched by `mcp-searxng`, so
+and the HEAD size preflight is disclosed to that provider. In dual mode the
+same original URL can therefore be disclosed first to FlareSolverr and then to
+Byparr after an allowed primary failure. The providers have independent
+concurrency counters. Cache hits bypass acquisition. The actual target is
+fetched by `mcp-searxng`, so
 redirect validation, URL-reader proxy selection, streaming size limits, and
 content-type handling remain authoritative.
 Replay starts again at the originally requested URL rather than trusting a
 same-host path returned by the solver.
 
 A transient solver connection, timeout, overload, HTTP 408/429/5xx response,
-malformed response, or oversized response falls back once to the direct
-URL-reader path. Invalid solver configuration, other HTTP 4xx responses, a
+malformed response, or oversized response advances to the next configured
+provider. If the final provider is busy or unavailable, one uncached direct
+URL-reader fetch runs. Invalid solver configuration, other HTTP 4xx responses, a
 solver result for a different hostname, and a non-success target status
 reported by the solver fail closed. A direct-fetch fallback result is not
 cached, so repeated reads re-fetch until solver acquisition succeeds.
@@ -149,6 +153,13 @@ Solver-backed cache entries are isolated by provider and from direct-fetch
 entries. Cancellation never falls back or writes a cache entry. When the
 replay response is `application/pdf`, the URL reader applies its bounded PDF
 text-extraction path.
+
+There is no shared solver timeout. At defaults, the additive maximum is 150
+seconds: up to 10 seconds for the initial HEAD preflight, 65 seconds for each
+provider including response grace, and 10 seconds for the final direct GET.
+MCP cancellation stops the chain immediately when the client propagates it.
+Repeated value-free `unavailable` warnings for one provider should be monitored
+as persistent degradation.
 
 Example with the official FlareSolverr image:
 
@@ -186,6 +197,32 @@ services:
       - BYPARR_MAX_CONCURRENT_REQUESTS=2
     depends_on:
       - byparr
+
+  byparr:
+    image: ghcr.io/thephaseless/byparr:2.1.0
+```
+
+For dual-provider mode, combine both services and set both endpoint variables:
+
+```yaml
+services:
+  mcp-searxng:
+    image: isokoliuk/mcp-searxng:latest
+    stdin_open: true
+    environment:
+      - SEARXNG_URL=${SEARXNG_URL:?Set SEARXNG_URL in the environment}
+      - FLARESOLVERR_URL=http://flaresolverr:8191
+      - BYPARR_URL=http://byparr:8191
+    depends_on:
+      - flaresolverr
+      - byparr
+
+  flaresolverr:
+    image: flaresolverr/flaresolverr:v3.5.0
+    environment:
+      - LOG_LEVEL=info
+      - LOG_HTML=false
+      - CAPTCHA_SOLVER=${CAPTCHA_SOLVER:-none}
 
   byparr:
     image: ghcr.io/thephaseless/byparr:2.1.0

--- a/README.md
+++ b/README.md
@@ -59,7 +59,7 @@ For measured MCP-process CPU and memory starting points, see
 - **Search Suggestions**: Query autocomplete via SearXNG's `/autocompleter` endpoint.
 - **Instance Capability Discovery**: Inspect configured categories, engines, defaults, locales, and plugins from `/config`.
 - **URL Content Reading**: Content-type-aware Markdown conversion, including bounded PDF text extraction, with pagination, section filtering, paragraph ranges, and heading extraction.
-- **Browser Solver Support**: For each uncached URL that passes URL validation and the HEAD size preflight, optionally acquire a browser session from either FlareSolverr or Byparr, then replay the returned user-agent and scoped cookies through the bounded URL reader. FlareSolverr 3.5.0 and Byparr 2.1.0 were verified on 2026-07-30. Configure exactly one provider; automatic cross-provider fallback is not enabled.
+- **Browser Solver Support**: For each uncached URL that passes static URL validation and the HEAD size preflight, optionally acquire a browser session from FlareSolverr, Byparr, or both, then replay the returned user-agent and scoped cookies through the bounded URL reader. In dual-provider mode FlareSolverr is always primary and Byparr is attempted only after a busy or transient-unavailable primary. FlareSolverr 3.5.0 and Byparr 2.1.0 were verified on 2026-07-30.
 - **Intelligent Caching**: Both search results and URL content are cached in memory with configurable TTL and least-frequently-used (LFU) eviction, reducing redundant requests.
 - **SSRF Protection**: `web_url_read` blocks private/internal URLs and redirects by default in all transport modes.
 - **HTTP Transport**: Optional Streamable HTTP mode with opt-in hardening — bearer-token auth, CORS allowlist, and rate limiting.
@@ -161,7 +161,8 @@ For SearXNG deployment, configuration, and troubleshooting, see
   - PDF parsing has a separate 30-second worker budget after the response body is downloaded. On the direct path, the network fetch and parse take at most the configured fetch budget plus 30 seconds; configured browser-solver preflight and acquisition time is additional.
   - At most two PDF extractions run concurrently per MCP process. There is no queue; additional concurrent reads return a busy message and may be retried.
   - Other binary, media, archive, and octet-stream downloads are intentionally rejected with a short hint instead of returning raw bytes
-  - When `FLARESOLVERR_URL` or `BYPARR_URL` is configured, an uncached URL is validated and checked by the HEAD size preflight before `mcp-searxng` attempts browser-session acquisition. Cache hits bypass acquisition; a full provider-specific concurrency limit and transient solver failures use an uncached direct-fetch fallback. When a solver slot is available, every uncached URL that passes URL validation and the HEAD size preflight is disclosed to the configured browser solver.
+  - When `FLARESOLVERR_URL` or `BYPARR_URL` is configured, an uncached URL is validated and checked by the HEAD size preflight before `mcp-searxng` attempts browser-session acquisition. With both set, FlareSolverr is attempted first and Byparr is attempted only after a busy slot, network/timeout failure, HTTP 408/429/5xx, or malformed/oversized response. Persistent provider 4xx, cancellation, solution-host validation failure, and solved non-2xx target status stop the chain. If every configured provider is busy or unavailable, one uncached direct fetch runs. Each attempted provider receives the original target URL; challenge success is not guaranteed.
+  - At default limits, dual-provider mode has an additive maximum of 150 seconds across the initial HEAD preflight, both solver attempts (including response grace), and the final direct fetch.
   - Inputs:
     - `url` (string): The URL to fetch and process
     - `startChar` (number, optional): Starting character position for content extraction (default: 0)
@@ -226,8 +227,9 @@ Image signatures can be verified with Cosign — see [SECURITY.md](SECURITY.md) 
 ```
 
 To pass additional env vars, add `-e VAR_NAME` to `args` and the variable to `env`.
-For browser-solver integration, pass either `FLARESOLVERR_URL` or `BYPARR_URL`
-and make that service reachable from this container. See
+For browser-solver integration, pass `FLARESOLVERR_URL`, `BYPARR_URL`, or both
+and make the configured services reachable from this container. Dual mode has
+a fixed FlareSolverr-first order and no automatic reverse failover. See
 [URL Reader Controls](CONFIGURATION.md#url-reader-controls) for the complete
 behavior and Docker Compose example.
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,8 +61,9 @@ To allow private URL reads and private DNS-resolved targets (e.g. for internal d
 
 Setting `FLARESOLVERR_URL` or `BYPARR_URL` delegates challenge-page navigation
 to a trusted browser service. FlareSolverr 3.5.0 and Byparr 2.1.0 were verified
-on 2026-07-30. Both endpoints may be configured; FlareSolverr is always primary
-and Byparr is the fallback only for busy or transient-unavailable acquisition.
+on 2026-07-30. When both endpoints are configured, this release uses
+FlareSolverr as the fixed primary and Byparr as the fallback only for busy or
+transient-unavailable acquisition.
 Canonical duplicate endpoints fail closed.
 
 The verified `linux/amd64` images came from multi-architecture manifests

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -61,8 +61,9 @@ To allow private URL reads and private DNS-resolved targets (e.g. for internal d
 
 Setting `FLARESOLVERR_URL` or `BYPARR_URL` delegates challenge-page navigation
 to a trusted browser service. FlareSolverr 3.5.0 and Byparr 2.1.0 were verified
-on 2026-07-30. Configure exactly one provider; simultaneous endpoints fail
-closed and automatic cross-provider fallback is not enabled.
+on 2026-07-30. Both endpoints may be configured; FlareSolverr is always primary
+and Byparr is the fallback only for busy or transient-unavailable acquisition.
+Canonical duplicate endpoints fail closed.
 
 The verified `linux/amd64` images came from multi-architecture manifests
 `ghcr.io/flaresolverr/flaresolverr:v3.5.0@sha256:139dfee1c6f89249c8d665d1333a42e8ec74ec0a86bc6bb1c8461e10d3a66a47`
@@ -72,12 +73,14 @@ Client cancellation stops local work promptly, but a remote browser may
 continue until its configured provider timeout after the HTTP client
 disconnects.
 
-Cache hits bypass solver acquisition. For uncached reads, `mcp-searxng`
-validates the requested target and performs the HEAD size preflight before
+Static URL policy runs before cache lookup, and cache hits bypass network
+preflight and solver acquisition. For uncached reads, `mcp-searxng` validates
+the requested target and performs the HEAD size preflight before
 attempting acquisition. When a solver slot is available, every uncached URL that
-passes URL validation and the HEAD size preflight is disclosed to the configured
-browser solver. Reads made while that provider's concurrency limit is full use
-the direct path without contacting it. `mcp-searxng` accepts a solution only for
+passes URL validation and the HEAD size preflight is disclosed to that provider.
+In dual mode an allowed primary failure discloses the same URL to Byparr.
+Independent concurrency limits prevent either provider from consuming the
+other's slots. `mcp-searxng` accepts a solution only for
 the same hostname, filters returned cookies by domain, path, secure flag, and
 expiry, rejects cookie names or values outside the HTTP cookie character set or
 above 4096 bytes per pair, and performs the final target fetch through the
@@ -95,15 +98,23 @@ challenge. Treat that service as part of the trusted deployment boundary:
   workload;
 - keep the solver image updated and review its own security guidance.
 
-Transient solver failures use the direct URL-reader path once. Cancellation
+Transient or busy primary outcomes advance to Byparr; the final busy or
+unavailable outcome uses the direct URL-reader path once. Persistent provider
+4xx, hostname divergence, and solved non-2xx target status stop the chain.
+Cancellation
 does not trigger fallback and is propagated through acquisition, replay, body
-streaming, and PDF extraction. Invalid solver
-configuration and hostname-divergent solutions fail closed. The solver API
+streaming, and PDF extraction. Invalid solver configuration fails closed. The solver API
 response is capped at 256 KiB for FlareSolverr and 5 MiB for Byparr. During
 2.1.0 verification, Byparr returned rendered content alongside cookies.
 Concurrent
 acquisitions are bounded independently by the selected provider's
 `*_MAX_CONCURRENT_REQUESTS` variable.
+
+Each provider keeps its full timeout. The default dual-provider worst case is
+150 seconds across preflight, both acquisitions, and one direct GET. Repeated
+value-free `unavailable` warnings for the same provider should trigger
+operational alerting; this feature does not retain a health score or silently
+reverse provider order.
 
 ### PDF Text Extraction
 

--- a/__tests__/e2e/browser-solver.e2e.ts
+++ b/__tests__/e2e/browser-solver.e2e.ts
@@ -73,6 +73,7 @@ async function runTests() {
   await testFunction('built MCP server replays a solved browser session', async () => {
     let replayUserAgent = '';
     let replayCookie = '';
+    let byparrRequests = 0;
     const target = await startServer((req, res) => {
       if (req.method === 'GET') {
         replayUserAgent = req.headers['user-agent'] ?? '';
@@ -108,6 +109,12 @@ async function runTests() {
         }));
       });
     });
+    const byparr = await startServer((req, res) => {
+      byparrRequests++;
+      req.resume();
+      res.writeHead(503);
+      res.end();
+    });
 
     try {
       const responses = await spawnWithMessagesAsync(
@@ -116,7 +123,7 @@ async function runTests() {
         15_000,
         {
           FLARESOLVERR_URL: solver.url,
-          BYPARR_URL: undefined,
+          BYPARR_URL: byparr.url,
           MCP_HTTP_ALLOW_PRIVATE_URLS: 'true',
           NO_PROXY: '127.0.0.1',
         },
@@ -127,7 +134,9 @@ async function runTests() {
       assert.ok(text.includes('Solver PDF E2E'), text);
       assert.equal(replayUserAgent, 'flaresolverr-e2e-agent');
       assert.equal(replayCookie, 'cf_clearance=e2e-token');
+      assert.equal(byparrRequests, 0);
     } finally {
+      await byparr.close();
       await solver.close();
       await target.close();
     }
@@ -190,7 +199,130 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('built MCP server fails over from FlareSolverr to Byparr', async () => {
+    const solverOrder: string[] = [];
+    let replayUserAgent = '';
+    const target = await startServer((req, res) => {
+      if (req.method === 'GET') {
+        replayUserAgent = req.headers['user-agent'] ?? '';
+      }
+      res.writeHead(req.method === 'HEAD' ? 403 : 200, {
+        'content-type': 'text/html',
+      });
+      res.end(req.method === 'HEAD' ? '' : '<main>Dual provider E2E</main>');
+    });
+    const flare = await startServer((req, res) => {
+      solverOrder.push('flaresolverr');
+      req.resume();
+      res.writeHead(503, { 'content-type': 'application/json' });
+      res.end(JSON.stringify({ status: 'error' }));
+    });
+    const byparr = await startServer((req, res) => {
+      solverOrder.push('byparr');
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => {
+        body += chunk;
+      });
+      req.on('end', () => {
+        const request = JSON.parse(body) as { url: string; maxTimeout: number };
+        assert.equal(request.maxTimeout, 60);
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          status: 'ok',
+          solution: {
+            url: request.url,
+            status: 200,
+            cookies: [],
+            userAgent: 'byparr-failover-e2e-agent',
+          },
+        }));
+      });
+    });
+    try {
+      const responses = await spawnWithMessagesAsync(
+        readUrlMessages(target.url),
+        'https://test-searx.example.com',
+        15_000,
+        {
+          FLARESOLVERR_URL: flare.url,
+          BYPARR_URL: byparr.url,
+          MCP_HTTP_ALLOW_PRIVATE_URLS: 'true',
+          NO_PROXY: '127.0.0.1',
+        },
+      );
+      const response = responses[2];
+      assert.ok(response && !response.error, JSON.stringify(response?.error));
+      const text: string = response.result?.content?.[0]?.text ?? '';
+      assert.ok(text.includes('Dual provider E2E'), text);
+      assert.deepEqual(solverOrder, ['flaresolverr', 'byparr']);
+      assert.equal(replayUserAgent, 'byparr-failover-e2e-agent');
+    } finally {
+      await byparr.close();
+      await flare.close();
+      await target.close();
+    }
+  }, results);
+
+  await testFunction('built MCP server performs one direct fetch after both providers fail', async () => {
+    const solverOrder: string[] = [];
+    let targetGets = 0;
+    const target = await startServer((req, res) => {
+      if (req.method === 'GET') {
+        targetGets++;
+      }
+      res.writeHead(req.method === 'HEAD' ? 403 : 200, {
+        'content-type': 'text/html',
+      });
+      res.end(req.method === 'HEAD' ? '' : '<main>Direct after dual failure</main>');
+    });
+    const flare = await startServer((req, res) => {
+      solverOrder.push('flaresolverr');
+      req.resume();
+      res.writeHead(503);
+      res.end();
+    });
+    const byparr = await startServer((req, res) => {
+      solverOrder.push('byparr');
+      req.resume();
+      res.writeHead(429);
+      res.end();
+    });
+
+    try {
+      const responses = await spawnWithMessagesAsync(
+        readUrlMessages(target.url),
+        'https://test-searx.example.com',
+        15_000,
+        {
+          FLARESOLVERR_URL: flare.url,
+          BYPARR_URL: byparr.url,
+          MCP_HTTP_ALLOW_PRIVATE_URLS: 'true',
+          NO_PROXY: '127.0.0.1',
+        },
+      );
+      const response = responses[2];
+      assert.ok(response && !response.error, JSON.stringify(response?.error));
+      const text: string = response.result?.content?.[0]?.text ?? '';
+      assert.ok(text.includes('Direct after dual failure'), text);
+      assert.deepEqual(solverOrder, ['flaresolverr', 'byparr']);
+      assert.equal(targetGets, 1);
+    } finally {
+      await byparr.close();
+      await flare.close();
+      await target.close();
+    }
+  }, results);
+
   const matrixRequested = process.env.BROWSER_SOLVER_REAL_MATRIX === 'true';
+  const failoverRequested = process.env.BROWSER_SOLVER_REAL_FAILOVER === 'true';
+  if (matrixRequested && failoverRequested) {
+    await testFunction('real browser-solver modes are unambiguous', () => {
+      assert.fail(
+        'BROWSER_SOLVER_REAL_MATRIX and BROWSER_SOLVER_REAL_FAILOVER cannot both be true',
+      );
+    }, results);
+  }
   const realProviders = matrixRequested
     ? [
         {
@@ -221,7 +353,60 @@ async function runTests() {
           : []),
       ];
 
-  if (matrixRequested && realProviders.some(({ endpoint }) => !endpoint)) {
+  if (failoverRequested) {
+    const flareEndpoint = process.env.VERIFY_FLARESOLVERR_URL;
+    const byparrEndpoint = process.env.VERIFY_BYPARR_URL;
+    if (!flareEndpoint || !byparrEndpoint) {
+      await testFunction('real browser-solver failover has both provider endpoints', () => {
+        assert.fail(
+          'BROWSER_SOLVER_REAL_FAILOVER=true requires VERIFY_FLARESOLVERR_URL and VERIFY_BYPARR_URL',
+        );
+      }, results);
+    } else {
+      await testFunction(
+        'real protected PDF fails over from unavailable FlareSolverr to Byparr',
+        async () => {
+          let primaryReachable = false;
+          try {
+            await fetch(new URL('/v1', flareEndpoint), {
+              method: 'GET',
+              signal: AbortSignal.timeout(1000),
+            });
+            primaryReachable = true;
+          } catch {
+            // The failover gate deliberately leaves the primary endpoint unavailable.
+          }
+          assert.equal(primaryReachable, false, 'FlareSolverr endpoint must be unavailable');
+
+          const challenge = await fetch(PROTECTED_PDF_URL, {
+            method: 'HEAD',
+            redirect: 'manual',
+            signal: AbortSignal.timeout(15_000),
+          });
+          assert.equal(challenge.status, 403);
+          assert.equal(challenge.headers.get('cf-mitigated'), 'challenge');
+
+          const responses = await spawnWithMessagesAsync(
+            readUrlMessages(PROTECTED_PDF_URL),
+            'https://test-searx.example.com',
+            90_000,
+            {
+              FLARESOLVERR_URL: flareEndpoint,
+              BYPARR_URL: byparrEndpoint,
+              FLARESOLVERR_TIMEOUT_MS: '1000',
+            },
+          );
+          const response = responses[2];
+          assert.ok(response && !response.error, JSON.stringify(response?.error));
+          const text: string = response.result?.content?.[0]?.text ?? '';
+          assert.ok(text.includes('Encrypted Matrix-Vector Products'), text);
+          assert.ok(text.includes('Abstract'), text);
+          assert.ok(!text.includes('Unsupported content type'), text);
+        },
+        results,
+      );
+    }
+  } else if (matrixRequested && realProviders.some(({ endpoint }) => !endpoint)) {
     await testFunction('real browser-solver matrix has both provider endpoints', () => {
       assert.fail(
         'BROWSER_SOLVER_REAL_MATRIX=true requires VERIFY_FLARESOLVERR_URL and VERIFY_BYPARR_URL',

--- a/__tests__/unit/browser-solver-state.test.ts
+++ b/__tests__/unit/browser-solver-state.test.ts
@@ -55,6 +55,21 @@ function jsonSolution(url: string, extra: Record<string, unknown> = {}) {
   };
 }
 
+function createProviderConfig(
+  provider: "flaresolverr" | "byparr",
+  endpoint: string,
+): BrowserSolverConfig {
+  const byparr = provider === "byparr";
+  return {
+    provider,
+    endpoint: new URL(`${endpoint}/v1`),
+    timeoutMs: 1000,
+    wireTimeout: byparr ? 1 : 1000,
+    maxConcurrentRequests: 1,
+    maxResponseBytes: byparr ? 5 * 1024 * 1024 : 256 * 1024,
+  };
+}
+
 async function waitForPending(
   pending: http.ServerResponse[],
   count: number,
@@ -217,14 +232,7 @@ async function runTests() {
       res.writeHead(200, { "content-type": "application/json" });
       res.end(JSON.stringify(jsonSolution(target.href)));
     });
-    const flareConfig: BrowserSolverConfig = {
-      provider: "flaresolverr",
-      endpoint: new URL(`${flare.url}/v1`),
-      timeoutMs: 1000,
-      wireTimeout: 1000,
-      maxConcurrentRequests: 1,
-      maxResponseBytes: 256 * 1024,
-    };
+    const flareConfig = createProviderConfig("flaresolverr", flare.url);
     const heldPrimary = acquireBrowserSolverSolution(
       createMockServer() as any,
       flareConfig,
@@ -236,14 +244,7 @@ async function runTests() {
         createMockServer() as any,
         [
           flareConfig,
-          {
-            provider: "byparr",
-            endpoint: new URL(`${byparr.url}/v1`),
-            timeoutMs: 1000,
-            wireTimeout: 1,
-            maxConcurrentRequests: 1,
-            maxResponseBytes: 5 * 1024 * 1024,
-          },
+          createProviderConfig("byparr", byparr.url),
         ],
         target,
       );

--- a/__tests__/unit/browser-solver-state.test.ts
+++ b/__tests__/unit/browser-solver-state.test.ts
@@ -6,9 +6,10 @@ import * as net from "node:net";
 import { fileURLToPath } from "node:url";
 import {
   acquireBrowserSolverSolution,
+  acquireBrowserSolverSolutionChain,
   buildBrowserSolverHeaders,
   createBrowserSolverCacheKey,
-  resolveBrowserSolverConfig,
+  resolveBrowserSolverConfigs,
   type BrowserSolverAcquisition,
   type BrowserSolverConfig,
 } from "../../src/browser-solver.js";
@@ -77,7 +78,7 @@ async function saturateFlareThenSwitch(
   process.env.FLARESOLVERR_URL = hanging.url;
   delete process.env.BYPARR_URL;
   process.env.FLARESOLVERR_MAX_CONCURRENT_REQUESTS = "1";
-  const flareConfig = resolveBrowserSolverConfig(createMockServer() as any)!;
+  const flareConfig = resolveBrowserSolverConfigs(createMockServer() as any)[0]!;
   const flarePending = acquireBrowserSolverSolution(
     createMockServer() as any,
     flareConfig,
@@ -92,7 +93,7 @@ async function saturateFlareThenSwitch(
   delete process.env.FLARESOLVERR_URL;
   process.env.BYPARR_URL = responding.url;
   process.env.BYPARR_MAX_CONCURRENT_REQUESTS = "1";
-  const byparrConfig = resolveBrowserSolverConfig(createMockServer() as any)!;
+  const byparrConfig = resolveBrowserSolverConfigs(createMockServer() as any)[0]!;
   assert.equal(
     (await acquireBrowserSolverSolution(
       createMockServer() as any,
@@ -168,6 +169,218 @@ async function runTests() {
     assertProviderCounterIsolation,
     results,
   );
+
+  await testFunction("ordered chain reaches Byparr only after a transient FlareSolverr result", async () => {
+    const target = new URL("https://example.com/paper");
+    let flareRequests = 0;
+    let byparrRequests = 0;
+    const flare = await startServer((_req, res) => {
+      flareRequests++;
+      res.writeHead(503);
+      res.end();
+    });
+    const byparr = await startServer((_req, res) => {
+      byparrRequests++;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(jsonSolution(target.href, { userAgent: "ByparrUA/1.0" })));
+    });
+    const configs: BrowserSolverConfig[] = [
+      { provider: "flaresolverr", endpoint: new URL(`${flare.url}/v1`), timeoutMs: 1000, wireTimeout: 1000, maxConcurrentRequests: 1, maxResponseBytes: 256 * 1024 },
+      { provider: "byparr", endpoint: new URL(`${byparr.url}/v1`), timeoutMs: 1000, wireTimeout: 1, maxConcurrentRequests: 1, maxResponseBytes: 5 * 1024 * 1024 },
+    ];
+    try {
+      const acquisition = await acquireBrowserSolverSolutionChain(
+        createMockServer() as any,
+        configs,
+        target,
+      );
+      assert.equal(acquisition.kind, "solved");
+      if (acquisition.kind === "solved") {
+        assert.equal(acquisition.provider, "byparr");
+        assert.equal(acquisition.solution.userAgent, "ByparrUA/1.0");
+      }
+      assert.equal(flareRequests, 1);
+      assert.equal(byparrRequests, 1);
+    } finally {
+      await byparr.close();
+      await flare.close();
+    }
+  }, results);
+
+  await testFunction("busy FlareSolverr advances immediately to Byparr and releases independently", async () => {
+    const target = new URL("https://example.com/paper");
+    const pending: http.ServerResponse[] = [];
+    let byparrRequests = 0;
+    const flare = await startServer((_req, res) => pending.push(res));
+    const byparr = await startServer((_req, res) => {
+      byparrRequests++;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(jsonSolution(target.href)));
+    });
+    const flareConfig: BrowserSolverConfig = {
+      provider: "flaresolverr",
+      endpoint: new URL(`${flare.url}/v1`),
+      timeoutMs: 1000,
+      wireTimeout: 1000,
+      maxConcurrentRequests: 1,
+      maxResponseBytes: 256 * 1024,
+    };
+    const heldPrimary = acquireBrowserSolverSolution(
+      createMockServer() as any,
+      flareConfig,
+      target,
+    );
+    try {
+      await waitForPending(pending, 1);
+      const acquisition = await acquireBrowserSolverSolutionChain(
+        createMockServer() as any,
+        [
+          flareConfig,
+          {
+            provider: "byparr",
+            endpoint: new URL(`${byparr.url}/v1`),
+            timeoutMs: 1000,
+            wireTimeout: 1,
+            maxConcurrentRequests: 1,
+            maxResponseBytes: 5 * 1024 * 1024,
+          },
+        ],
+        target,
+      );
+      assert.equal(acquisition.kind, "solved");
+      if (acquisition.kind === "solved") {
+        assert.equal(acquisition.provider, "byparr");
+      }
+      assert.equal(byparrRequests, 1);
+
+      pending[0].writeHead(200, { "content-type": "application/json" });
+      pending[0].end(JSON.stringify(jsonSolution(target.href)));
+      assert.equal((await heldPrimary).kind, "solved");
+    } finally {
+      for (const response of pending) {
+        if (!response.writableEnded) {
+          response.end();
+        }
+      }
+      await byparr.close();
+      await flare.close();
+    }
+  }, results);
+
+  await testFunction("primary success does not contact Byparr", async () => {
+    const target = new URL("https://example.com/paper");
+    let byparrRequests = 0;
+    const flare = await startServer((_req, res) => {
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(jsonSolution(target.href, { userAgent: "FlareUA/1.0" })));
+    });
+    const byparr = await startServer((_req, res) => {
+      byparrRequests++;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(jsonSolution(target.href)));
+    });
+    try {
+      const acquisition = await acquireBrowserSolverSolutionChain(
+        createMockServer() as any,
+        [
+          { provider: "flaresolverr", endpoint: new URL(`${flare.url}/v1`), timeoutMs: 1000, wireTimeout: 1000, maxConcurrentRequests: 1, maxResponseBytes: 256 * 1024 },
+          { provider: "byparr", endpoint: new URL(`${byparr.url}/v1`), timeoutMs: 1000, wireTimeout: 1, maxConcurrentRequests: 1, maxResponseBytes: 5 * 1024 * 1024 },
+        ],
+        target,
+      );
+      assert.equal(acquisition.kind, "solved");
+      if (acquisition.kind === "solved") {
+        assert.equal(acquisition.provider, "flaresolverr");
+        assert.equal(acquisition.solution.userAgent, "FlareUA/1.0");
+      }
+      assert.equal(byparrRequests, 0);
+    } finally {
+      await byparr.close();
+      await flare.close();
+    }
+  }, results);
+
+  await testFunction("caller cancellation during Byparr stops the chain and releases its slot", async () => {
+    const target = new URL("https://example.com/paper");
+    let byparrRequests = 0;
+    const pending: http.ServerResponse[] = [];
+    const flare = await startServer((_req, res) => {
+      res.writeHead(503);
+      res.end();
+    });
+    const byparr = await startServer((_req, res) => {
+      byparrRequests++;
+      if (byparrRequests === 1) {
+        pending.push(res);
+        return;
+      }
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(jsonSolution(target.href)));
+    });
+    const configs: BrowserSolverConfig[] = [
+      { provider: "flaresolverr", endpoint: new URL(`${flare.url}/v1`), timeoutMs: 1000, wireTimeout: 1000, maxConcurrentRequests: 1, maxResponseBytes: 256 * 1024 },
+      { provider: "byparr", endpoint: new URL(`${byparr.url}/v1`), timeoutMs: 1000, wireTimeout: 1, maxConcurrentRequests: 1, maxResponseBytes: 5 * 1024 * 1024 },
+    ];
+    const controller = new AbortController();
+    try {
+      const acquisition = acquireBrowserSolverSolutionChain(
+        createMockServer() as any,
+        configs,
+        target,
+        controller.signal,
+      );
+      await waitForPending(pending, 1);
+      controller.abort(new DOMException("cancelled", "AbortError"));
+      await assert.rejects(acquisition, /cancelled/iu);
+
+      const retry = await acquireBrowserSolverSolutionChain(
+        createMockServer() as any,
+        configs,
+        target,
+      );
+      assert.equal(retry.kind, "solved");
+      assert.equal(byparrRequests, 2);
+    } finally {
+      for (const response of pending) {
+        if (!response.writableEnded) {
+          response.end();
+        }
+      }
+      await byparr.close();
+      await flare.close();
+    }
+  }, results);
+
+  await testFunction("persistent primary 4xx stops the chain before Byparr", async () => {
+    const target = new URL("https://example.com/paper");
+    let byparrRequests = 0;
+    const flare = await startServer((_req, res) => {
+      res.writeHead(401);
+      res.end();
+    });
+    const byparr = await startServer((_req, res) => {
+      byparrRequests++;
+      res.writeHead(200, { "content-type": "application/json" });
+      res.end(JSON.stringify(jsonSolution(target.href)));
+    });
+    try {
+      await assert.rejects(
+        acquireBrowserSolverSolutionChain(
+          createMockServer() as any,
+          [
+            { provider: "flaresolverr", endpoint: new URL(`${flare.url}/v1`), timeoutMs: 1000, wireTimeout: 1000, maxConcurrentRequests: 1, maxResponseBytes: 256 * 1024 },
+            { provider: "byparr", endpoint: new URL(`${byparr.url}/v1`), timeoutMs: 1000, wireTimeout: 1, maxConcurrentRequests: 1, maxResponseBytes: 5 * 1024 * 1024 },
+          ],
+          target,
+        ),
+        /endpoint rejected/iu,
+      );
+      assert.equal(byparrRequests, 0);
+    } finally {
+      await byparr.close();
+      await flare.close();
+    }
+  }, results);
 
   await testFunction("solution validation never logs clearance-cookie values", async () => {
     const clearanceValue = ["clearance", "sensitive", "value"].join("-");

--- a/__tests__/unit/browser-solver.test.ts
+++ b/__tests__/unit/browser-solver.test.ts
@@ -6,13 +6,17 @@ import * as net from "node:net";
 import { fileURLToPath } from "node:url";
 import {
   acquireBrowserSolverSolution,
-  resolveBrowserSolverConfig,
+  resolveBrowserSolverConfigs,
   type BrowserSolverConfig,
 } from "../../src/browser-solver.js";
 import { createMockServer, createMockServerWithTracking } from "../helpers/mock-server.js";
 import { createTestResults, printTestSummary, testFunction } from "../helpers/test-utils.js";
 
 const results = createTestResults();
+
+function resolveFirstBrowserSolverConfig(mcpServer: any): BrowserSolverConfig | null {
+  return resolveBrowserSolverConfigs(mcpServer)[0] ?? null;
+}
 
 interface TestServer {
   url: string;
@@ -73,9 +77,9 @@ async function runTests() {
   await testFunction("unset and blank FLARESOLVERR_URL disable the solver", () => {
     const server = createMockServer();
     delete process.env.FLARESOLVERR_URL;
-    assert.equal(resolveBrowserSolverConfig(server as any), null);
+    assert.equal(resolveFirstBrowserSolverConfig(server as any), null);
     process.env.FLARESOLVERR_URL = "   ";
-    assert.equal(resolveBrowserSolverConfig(server as any), null);
+    assert.equal(resolveFirstBrowserSolverConfig(server as any), null);
   }, results);
 
   await testFunction("configuration normalizes a base path and bounded defaults", () => {
@@ -83,14 +87,14 @@ async function runTests() {
     delete process.env.FLARESOLVERR_TIMEOUT_MS;
     delete process.env.FLARESOLVERR_MAX_CONCURRENT_REQUESTS;
 
-    const config = resolveBrowserSolverConfig(createMockServer() as any);
+    const config = resolveFirstBrowserSolverConfig(createMockServer() as any);
     assert.equal(config?.endpoint.href, "http://solver.example/base/v1");
     assert.equal(config?.timeoutMs, 60000);
     assert.equal(config?.maxConcurrentRequests, 2);
 
     process.env.FLARESOLVERR_URL = "http://solver.example/base/v1/";
     assert.equal(
-      resolveBrowserSolverConfig(createMockServer() as any)?.endpoint.href,
+      resolveFirstBrowserSolverConfig(createMockServer() as any)?.endpoint.href,
       "http://solver.example/base/v1",
     );
   }, results);
@@ -101,7 +105,7 @@ async function runTests() {
     process.env.FLARESOLVERR_MAX_CONCURRENT_REQUESTS = "17";
     const { server, getLoggingCalls } = createMockServerWithTracking();
 
-    const config = resolveBrowserSolverConfig(server as any);
+    const config = resolveFirstBrowserSolverConfig(server as any);
     await new Promise((resolve) => setImmediate(resolve));
 
     assert.equal(config?.timeoutMs, 60000);
@@ -114,13 +118,13 @@ async function runTests() {
   await testFunction("invalid FLARESOLVERR_URL fails closed", () => {
     process.env.FLARESOLVERR_URL = "file:///tmp/solver";
     assert.throws(
-      () => resolveBrowserSolverConfig(createMockServer() as any),
+      () => resolveFirstBrowserSolverConfig(createMockServer() as any),
       /FLARESOLVERR_URL.*http.*https/iu,
     );
 
     process.env.FLARESOLVERR_URL = "http://solver.example/path?query=1";
     assert.throws(
-      () => resolveBrowserSolverConfig(createMockServer() as any),
+      () => resolveFirstBrowserSolverConfig(createMockServer() as any),
       /FLARESOLVERR_URL/u,
     );
   }, results);
@@ -131,7 +135,7 @@ async function runTests() {
     delete process.env.BYPARR_TIMEOUT_SECONDS;
     delete process.env.BYPARR_MAX_CONCURRENT_REQUESTS;
 
-    assert.deepEqual(resolveBrowserSolverConfig(createMockServer() as any), {
+    assert.deepEqual(resolveFirstBrowserSolverConfig(createMockServer() as any), {
       provider: "byparr",
       endpoint: new URL("http://byparr.example/api/v1"),
       timeoutMs: 60_000,
@@ -142,7 +146,7 @@ async function runTests() {
 
     process.env.BYPARR_TIMEOUT_SECONDS = "300";
     process.env.BYPARR_MAX_CONCURRENT_REQUESTS = "16";
-    const bounded = resolveBrowserSolverConfig(createMockServer() as any);
+    const bounded = resolveFirstBrowserSolverConfig(createMockServer() as any);
     assert.equal(bounded?.timeoutMs, 300_000);
     assert.equal(bounded?.wireTimeout, 300);
     assert.equal(bounded?.maxConcurrentRequests, 16);
@@ -155,7 +159,7 @@ async function runTests() {
     process.env.BYPARR_MAX_CONCURRENT_REQUESTS = "17";
     const { server, getLoggingCalls } = createMockServerWithTracking();
 
-    const config = resolveBrowserSolverConfig(server as any);
+    const config = resolveFirstBrowserSolverConfig(server as any);
     await new Promise((resolve) => setImmediate(resolve));
     assert.equal(config?.timeoutMs, 60_000);
     assert.equal(config?.maxConcurrentRequests, 2);
@@ -165,15 +169,25 @@ async function runTests() {
     assert.ok(!diagnostics.includes("1.5"));
   }, results);
 
-  await testFunction("both providers and credential-bearing endpoints fail closed without values", () => {
+  await testFunction("both providers resolve in fixed order and canonical duplicates fail closed", () => {
     process.env.FLARESOLVERR_URL = "http://flare-secret.example";
     process.env.BYPARR_URL = "http://byparr-secret.example";
+    const configs = resolveBrowserSolverConfigs(createMockServer() as any);
+    assert.deepEqual(
+      configs.map(({ provider, endpoint }) => ({ provider, endpoint: endpoint.href })),
+      [
+        { provider: "flaresolverr", endpoint: "http://flare-secret.example/v1" },
+        { provider: "byparr", endpoint: "http://byparr-secret.example/v1" },
+      ],
+    );
+
+    process.env.FLARESOLVERR_URL = "http://solver.example/base";
+    process.env.BYPARR_URL = "http://SOLVER.EXAMPLE:80/base/v1/";
     assert.throws(
-      () => resolveBrowserSolverConfig(createMockServer() as any),
+      () => resolveBrowserSolverConfigs(createMockServer() as any),
       (error: Error) => (
-        error.message.includes("Configure only one browser solver")
-        && !error.message.includes("flare-secret")
-        && !error.message.includes("byparr-secret")
+        error.message.includes("different services")
+        && !error.message.includes("solver.example")
       ),
     );
 
@@ -181,7 +195,7 @@ async function runTests() {
     const sensitiveUserinfo = ["operator", "credential-value"].join(":");
     process.env.BYPARR_URL = `http://${sensitiveUserinfo}@byparr-secret.example`;
     assert.throws(
-      () => resolveBrowserSolverConfig(createMockServer() as any),
+      () => resolveBrowserSolverConfigs(createMockServer() as any),
       (error: Error) => (
         error.message.includes("BYPARR_URL")
         && !error.message.includes(sensitiveUserinfo)

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -167,10 +167,14 @@ export async function runTests(): Promise<TestResult> {
       assert.ok(document.includes('disconnects'));
     }
     for (const document of [readme, configuration, security]) {
-      assert.ok(document.replace(/\s+/gu, ' ').includes(
-        'When a solver slot is available, every uncached URL that passes URL validation and the HEAD size preflight is disclosed to the configured browser solver.',
-      ));
+      const normalized = document.replace(/\s+/gu, ' ');
+      assert.ok(normalized.includes('FlareSolverr is always primary'));
+      assert.ok(normalized.includes('150 seconds'));
+      assert.ok(normalized.includes('unavailable'));
     }
+    assert.ok(readme.includes('no automatic reverse failover'));
+    assert.ok(configuration.includes('automatic reverse failover is not performed'));
+    assert.ok(security.includes('does not retain a health score'));
     for (const contract of [
       `\`FLARESOLVERR_TIMEOUT_MS\` | No | \`${DEFAULT_FLARESOLVERR_TIMEOUT_MS}\``,
       `from \`1\` through \`${MAX_FLARESOLVERR_TIMEOUT_MS}\``,
@@ -185,10 +189,9 @@ export async function runTests(): Promise<TestResult> {
     }
 
     for (const tool of [LITE_READ_URL_TOOL, READ_URL_TOOL]) {
-      assert.ok(tool.description.includes('attempts to acquire a browser session'));
-      assert.ok(tool.description.includes('after URL validation and a HEAD size preflight'));
+      assert.ok(tool.description.includes('FlareSolverr first'));
+      assert.ok(tool.description.includes('Byparr'));
       assert.ok(tool.description.includes('uncached direct'));
-      assert.ok(!tool.description.includes('FlareSolverr'));
     }
   }, results);
 

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -166,12 +166,16 @@ export async function runTests(): Promise<TestResult> {
       assert.ok(document.includes('HTTP client'));
       assert.ok(document.includes('disconnects'));
     }
-    for (const document of [readme, configuration, security]) {
+    for (const document of [readme, configuration]) {
       const normalized = document.replace(/\s+/gu, ' ');
       assert.ok(normalized.includes('FlareSolverr is always primary'));
       assert.ok(normalized.includes('150 seconds'));
       assert.ok(normalized.includes('unavailable'));
     }
+    const normalizedSecurity = security.replace(/\s+/gu, ' ');
+    assert.ok(normalizedSecurity.includes('FlareSolverr as the fixed primary'));
+    assert.ok(normalizedSecurity.includes('150 seconds'));
+    assert.ok(normalizedSecurity.includes('unavailable'));
     assert.ok(readme.includes('no automatic reverse failover'));
     assert.ok(configuration.includes('automatic reverse failover is not performed'));
     assert.ok(security.includes('does not retain a health score'));

--- a/__tests__/unit/error-handler.test.ts
+++ b/__tests__/unit/error-handler.test.ts
@@ -153,17 +153,25 @@ async function runTests() {
     envManager.restore();
   }, results);
 
-  await testFunction('validateEnvironment rejects simultaneous browser solver providers', () => {
+  await testFunction('validateEnvironment accepts distinct simultaneous browser solver providers', () => {
     envManager.set('SEARXNG_URL', 'https://valid-url.com');
     envManager.set('FLARESOLVERR_URL', 'http://flare-secret.example');
     envManager.set('BYPARR_URL', 'http://byparr-secret.example');
 
     const result = validateEnvironment();
-    assert.ok(result?.includes(
-      'Configure only one browser solver: FLARESOLVERR_URL or BYPARR_URL, not both.',
-    ));
-    assert.ok(!result?.includes('flare-secret'));
-    assert.ok(!result?.includes('byparr-secret'));
+    assert.equal(result, null);
+
+    envManager.restore();
+  }, results);
+
+  await testFunction('validateEnvironment rejects duplicate browser solver endpoints without values', () => {
+    envManager.set('SEARXNG_URL', 'https://valid-url.com');
+    envManager.set('FLARESOLVERR_URL', 'http://solver-secret.example/base');
+    envManager.set('BYPARR_URL', 'http://SOLVER-SECRET.EXAMPLE:80/base/v1/');
+
+    const result = validateEnvironment();
+    assert.ok(result?.includes('different services'));
+    assert.ok(!result?.includes('solver-secret'));
 
     envManager.restore();
   }, results);

--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -323,7 +323,8 @@ async function runTests() {
     assert.ok(LITE_READ_URL_TOOL.description.includes('text extraction'), LITE_READ_URL_TOOL.description);
     assert.ok(LITE_READ_URL_TOOL.description.includes('binary'), LITE_READ_URL_TOOL.description);
     assert.ok(LITE_READ_URL_TOOL.description.includes('rejected'), LITE_READ_URL_TOOL.description);
-    assert.ok(LITE_READ_URL_TOOL.description.includes('browser solver'), LITE_READ_URL_TOOL.description);
+    assert.ok(LITE_READ_URL_TOOL.description.includes('FlareSolverr first'), LITE_READ_URL_TOOL.description);
+    assert.ok(LITE_READ_URL_TOOL.description.includes('Byparr'), LITE_READ_URL_TOOL.description);
   }, results);
 
   await testFunction('Full WEB_SEARCH_TOOL schema has multiple properties including language', () => {
@@ -354,7 +355,8 @@ async function runTests() {
     assert.ok(READ_URL_TOOL.description.includes('Binary'), READ_URL_TOOL.description);
     assert.ok(READ_URL_TOOL.description.includes('media'), READ_URL_TOOL.description);
     assert.ok(READ_URL_TOOL.description.includes('rejected'), READ_URL_TOOL.description);
-    assert.ok(READ_URL_TOOL.description.includes('browser solver'), READ_URL_TOOL.description);
+    assert.ok(READ_URL_TOOL.description.includes('FlareSolverr first'), READ_URL_TOOL.description);
+    assert.ok(READ_URL_TOOL.description.includes('Byparr'), READ_URL_TOOL.description);
   }, results);
 
   await testFunction('isSearXNGSearchSuggestionsArgs accepts query and optional language', () => {

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -363,7 +363,7 @@ async function runTests() {
           targetGets++;
         }
         res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
-        res.end(req.method === 'HEAD' ? '' : `<h1>${scenario.name} direct</h1>`);
+        res.end(req.method === 'HEAD' ? '' : '<h1>Dual direct fallback</h1>');
       });
       const flare = await startHttpServer((_req, res) => {
         flarePosts++;
@@ -384,7 +384,7 @@ async function runTests() {
           createMockServer() as any,
           target.url,
         );
-        assert.ok(result.includes(`# ${scenario.name} direct`), scenario.name);
+        assert.ok(result.includes('# Dual direct fallback'), scenario.name);
         assert.equal(flarePosts, 1, scenario.name);
         assert.equal(byparrPosts, 1, scenario.name);
         assert.equal(targetGets, 1, scenario.name);

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -17,6 +17,10 @@ import { createRequire, syncBuiltinESMExports } from 'node:module';
 import { fileURLToPath } from 'node:url';
 import * as zlib from 'node:zlib';
 import { checkContentLength, fetchAndConvertToMarkdown } from '../../src/url-reader.js';
+import {
+  createBrowserSolverCacheKey,
+  MAX_BYPARR_RESPONSE_BYTES,
+} from '../../src/browser-solver.js';
 import { createUrlReaderLookup } from '../../src/proxy.js';
 import { urlCache } from '../../src/cache.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
@@ -336,6 +340,143 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('final malformed, top-level-error, and oversized responses direct-fetch once', async () => {
+    const scenarios = [
+      { name: 'malformed', body: '{"status":' },
+      { name: 'top-level-error', body: JSON.stringify({ status: 'error' }) },
+      {
+        name: 'oversized',
+        body: JSON.stringify({
+          status: 'error',
+          response: 'x'.repeat(MAX_BYPARR_RESPONSE_BYTES + 1024),
+        }),
+      },
+    ];
+
+    for (const scenario of scenarios) {
+      urlCache.clear();
+      let targetGets = 0;
+      let flarePosts = 0;
+      let byparrPosts = 0;
+      const target = await startHttpServer((req, res) => {
+        if (req.method === 'GET') {
+          targetGets++;
+        }
+        res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+        res.end(req.method === 'HEAD' ? '' : `<h1>${scenario.name} direct</h1>`);
+      });
+      const flare = await startHttpServer((_req, res) => {
+        flarePosts++;
+        res.writeHead(503);
+        res.end();
+      });
+      const byparr = await startHttpServer((_req, res) => {
+        byparrPosts++;
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(scenario.body);
+      });
+
+      try {
+        envManager.set('FLARESOLVERR_URL', flare.url);
+        envManager.set('BYPARR_URL', byparr.url);
+        envManager.set('NO_PROXY', '127.0.0.1');
+        const result = await fetchAndConvertToMarkdown(
+          createMockServer() as any,
+          target.url,
+        );
+        assert.ok(result.includes(`# ${scenario.name} direct`), scenario.name);
+        assert.equal(flarePosts, 1, scenario.name);
+        assert.equal(byparrPosts, 1, scenario.name);
+        assert.equal(targetGets, 1, scenario.name);
+        assert.equal(urlCache.getStats().size, 0, scenario.name);
+      } finally {
+        await byparr.close();
+        await flare.close();
+        await target.close();
+      }
+    }
+    envManager.restore();
+    urlCache.clear();
+  }, results);
+
+  await testFunction('dual-provider mode fails over to Byparr and caches only the winning provider', async () => {
+    urlCache.clear();
+    let targetHeadCount = 0;
+    let targetGetCount = 0;
+    let receivedUserAgent = '';
+    let receivedCookie = '';
+    const target = await startHttpServer((req, res) => {
+      if (req.method === 'HEAD') {
+        targetHeadCount++;
+        res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+        res.end();
+        return;
+      }
+      targetGetCount++;
+      receivedUserAgent = req.headers['user-agent'] ?? '';
+      receivedCookie = req.headers.cookie ?? '';
+      res.writeHead(200, { 'content-type': 'text/html; charset=utf-8' });
+      res.end('<html><body><h1>Byparr winner</h1></body></html>');
+    });
+    let flarePosts = 0;
+    const flare = await startHttpServer((_req, res) => {
+      flarePosts++;
+      res.writeHead(503);
+      res.end();
+    });
+    let byparrPosts = 0;
+    const byparr = await startHttpServer((req, res) => {
+      byparrPosts++;
+      let body = '';
+      req.setEncoding('utf8');
+      req.on('data', (chunk) => { body += chunk; });
+      req.on('end', () => {
+        const request = JSON.parse(body) as { url: string };
+        res.writeHead(200, { 'content-type': 'application/json' });
+        res.end(JSON.stringify({
+          status: 'ok',
+          solution: {
+            url: request.url,
+            status: 200,
+            cookies: [{ name: 'cf_clearance', value: 'byparr-cookie', domain: '127.0.0.1', path: '/' }],
+            userAgent: 'byparr-winner-agent',
+          },
+        }));
+      });
+    });
+
+    try {
+      envManager.set('FLARESOLVERR_URL', flare.url);
+      envManager.set('BYPARR_URL', byparr.url);
+      envManager.set('NO_PROXY', '127.0.0.1');
+      const first = await fetchAndConvertToMarkdown(createMockServer() as any, target.url);
+      const second = await fetchAndConvertToMarkdown(createMockServer() as any, target.url);
+
+      assert.ok(first.includes('# Byparr winner'));
+      assert.equal(second, first);
+      assert.equal(flarePosts, 1);
+      assert.equal(byparrPosts, 1);
+      assert.equal(targetHeadCount, 2);
+      assert.equal(targetGetCount, 1);
+      assert.equal(receivedUserAgent, 'byparr-winner-agent');
+      assert.equal(receivedCookie, 'cf_clearance=byparr-cookie');
+      assert.equal(
+        urlCache.get(createBrowserSolverCacheKey('flaresolverr', target.url)),
+        null,
+      );
+      assert.notEqual(
+        urlCache.get(createBrowserSolverCacheKey('byparr', target.url)),
+        null,
+      );
+    } finally {
+      envManager.restore();
+      urlCache.clear();
+      await byparr.close();
+      await flare.close();
+      await target.close();
+    }
+  }, results);
+
   await testFunction('cancellation discards a partial solver-backed body and writes no cache entry', async () => {
     urlCache.clear();
     let targetGetCount = 0;
@@ -469,18 +610,27 @@ async function runTests() {
         },
       }));
     });
+    let byparrPostCount = 0;
+    const byparr = await startHttpServer((_req, res) => {
+      byparrPostCount++;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end();
+    });
 
     try {
       envManager.set('FLARESOLVERR_URL', solver.url);
+      envManager.set('BYPARR_URL', byparr.url);
       envManager.set('NO_PROXY', '127.0.0.1');
       await assert.rejects(
         fetchAndConvertToMarkdown(createMockServer() as any, target.url),
         /403/u,
       );
       assert.equal(targetGetCount, 0);
+      assert.equal(byparrPostCount, 0);
     } finally {
       envManager.restore();
       urlCache.clear();
+      await byparr.close();
       await solver.close();
       await target.close();
     }
@@ -509,18 +659,27 @@ async function runTests() {
         },
       }));
     });
+    let byparrPostCount = 0;
+    const byparr = await startHttpServer((_req, res) => {
+      byparrPostCount++;
+      res.writeHead(200, { 'content-type': 'application/json' });
+      res.end();
+    });
 
     try {
       envManager.set('FLARESOLVERR_URL', solver.url);
+      envManager.set('BYPARR_URL', byparr.url);
       envManager.set('NO_PROXY', '127.0.0.1,localhost');
       await assert.rejects(
         fetchAndConvertToMarkdown(createMockServer() as any, target.url),
         /different or unsupported hostname/iu,
       );
       assert.equal(targetGetCount, 0);
+      assert.equal(byparrPostCount, 0);
     } finally {
       envManager.restore();
       urlCache.clear();
+      await byparr.close();
       await solver.close();
       await target.close();
     }

--- a/docs/browser-solver-verification.md
+++ b/docs/browser-solver-verification.md
@@ -13,6 +13,12 @@ adapter and authoritative target replay. FlareSolverr returns a cookie-only
 response when requested. Byparr 2.1.0 ignores `returnOnlyCookies`, so the client
 accepts a bounded 5 MiB envelope and discards rendered content after parsing.
 
+When both providers are configured, FlareSolverr is always attempted first.
+Byparr is attempted only after a busy or transient-unavailable acquisition;
+persistent 4xx, cancellation, solution-integrity failure, and solved non-2xx
+target status stop the chain. There is no automatic reverse failover.
+Provider timeouts and concurrency remain independent.
+
 The real-container gate requires a directly observed anti-bot response no more
 than 30 minutes before each solved request. Record the UTC timestamp, public
 target, direct HTTP status or bounded anti-bot marker name, elapsed time,
@@ -22,8 +28,8 @@ credentials, endpoint userinfo, or response bodies containing secrets.
 The E2E runner enforces the two-provider matrix in one invocation when
 `BROWSER_SOLVER_REAL_MATRIX=true`, `VERIFY_FLARESOLVERR_URL`, and
 `VERIFY_BYPARR_URL` are set. Missing either verification endpoint makes the
-matrix test fail; the runner starts two separate MCP child processes so the
-production mutual-exclusion rule remains intact.
+matrix test fail; the runner starts one provider-specific MCP child process per
+matrix row so each adapter is verified independently.
 
 Preferred deployment keeps the selected solver on the same private container
 network as `mcp-searxng` with no published host port. A loopback-only port may
@@ -49,3 +55,22 @@ container without a provider skip:
 
 The disposable diagnostic containers were removed after verification. No
 cookie, solver response body, credential, or endpoint userinfo was retained.
+
+## Dual-provider failover gate
+
+The real failover check starts both pinned images and confirms they are ready.
+It then stops the FlareSolverr container while leaving its loopback endpoint
+configured, producing a bounded connection-refused `unavailable` outcome. A
+single built-MCP request with both endpoints must extract the freshly
+challenge-confirmed PDF through Byparr with no provider skip. Disposable
+containers are removed afterward. The runner itself fails unless the configured
+FlareSolverr endpoint is unreachable and a fresh direct HEAD returns HTTP 403
+with `Cf-Mitigated: challenge` before the solved request.
+
+At `2026-07-30T22:00:41Z`, a direct `HEAD` request to the protected PDF
+returned HTTP 403 with `Cf-Mitigated: challenge`. The FlareSolverr 3.5.0
+container was then stopped while its loopback endpoint remained configured.
+The same built-MCP request contacted that unavailable primary, failed over to
+the pinned Byparr 2.1.0 container, and extracted `Encrypted Matrix-Vector
+Products` and `Abstract`. The E2E suite reported 16 passed and 0 failed, and
+both disposable containers were verified absent afterward.

--- a/docs/deployment-profiles.md
+++ b/docs/deployment-profiles.md
@@ -23,7 +23,8 @@ cannot be independently rerun from repository artifacts alone. Treat it as
 historical starting evidence and measure the current image with your own
 representative workload before enforcing limits.
 
-The snapshot did not exercise FlareSolverr acquisition or PDF text extraction.
+The snapshot did not exercise browser-solver acquisition, dual-provider
+failover, or PDF text extraction.
 PDF reads can use two PDF extractions concurrently per MCP process. Each parse
 accepts at most 16 MiB of input, rejects documents above 500 pages, has a
 separate 30-second budget, and runs with a 192 MiB V8 old-generation ceiling
@@ -69,7 +70,7 @@ limit is too low, not as an application retry condition.
 
 The optional 256 MiB balanced container overlay is a measured non-PDF starting
 point. It may be insufficient when representative traffic can reach the
-two-worker PDF concurrency limit. Measure PDF and FlareSolverr-enabled traffic
+two-worker PDF concurrency limit. Measure PDF and browser-solver-enabled traffic
 before enforcing a memory ceiling.
 
 ## Apply a profile

--- a/src/browser-solver-config.ts
+++ b/src/browser-solver-config.ts
@@ -1,5 +1,5 @@
-export const BROWSER_SOLVER_MUTUAL_EXCLUSION_ERROR =
-  "Configure only one browser solver: FLARESOLVERR_URL or BYPARR_URL, not both.";
+export const BROWSER_SOLVER_DUPLICATE_ENDPOINT_ERROR =
+  "FLARESOLVERR_URL and BYPARR_URL must identify different services.";
 
 export class BrowserSolverConfigurationIssue extends Error {
   constructor(message: string) {
@@ -56,31 +56,34 @@ function normalizeEndpoint(name: "FLARESOLVERR_URL" | "BYPARR_URL", value: strin
   return endpoint;
 }
 
-export function resolveBrowserSolverEndpoint(): BrowserSolverEndpointSelection | null {
+export function resolveBrowserSolverEndpoints(): BrowserSolverEndpointSelection[] {
   const flareSolverrUrl = configuredValue("FLARESOLVERR_URL");
   const byparrUrl = configuredValue("BYPARR_URL");
-
-  if (flareSolverrUrl && byparrUrl) {
-    throw new BrowserSolverConfigurationIssue(BROWSER_SOLVER_MUTUAL_EXCLUSION_ERROR);
-  }
+  const selections: BrowserSolverEndpointSelection[] = [];
   if (flareSolverrUrl) {
-    return {
+    selections.push({
       provider: "flaresolverr",
       endpoint: normalizeEndpoint("FLARESOLVERR_URL", flareSolverrUrl),
-    };
+    });
   }
   if (byparrUrl) {
-    return {
+    selections.push({
       provider: "byparr",
       endpoint: normalizeEndpoint("BYPARR_URL", byparrUrl),
-    };
+    });
   }
-  return null;
+  if (
+    selections.length === 2
+    && selections[0].endpoint.href === selections[1].endpoint.href
+  ) {
+    throw new BrowserSolverConfigurationIssue(BROWSER_SOLVER_DUPLICATE_ENDPOINT_ERROR);
+  }
+  return selections;
 }
 
 export function validateBrowserSolverEnvironment(): string | null {
   try {
-    resolveBrowserSolverEndpoint();
+    resolveBrowserSolverEndpoints();
     return null;
   } catch (error) {
     return error instanceof Error ? error.message : "Invalid browser solver configuration.";

--- a/src/browser-solver.ts
+++ b/src/browser-solver.ts
@@ -3,7 +3,7 @@ import { fetch as undiciFetch } from "undici";
 import { createConfigurationError, createContentError } from "./error-handler.js";
 import {
   BrowserSolverConfigurationIssue,
-  resolveBrowserSolverEndpoint,
+  resolveBrowserSolverEndpoints,
   type BrowserSolverProvider,
 } from "./browser-solver-config.js";
 import { parseStrictInteger } from "./env-int.js";
@@ -52,6 +52,10 @@ export type BrowserSolverAcquisition =
   | { kind: "solved"; solution: BrowserSolverSolution }
   | { kind: "fallback"; reason: "busy" | "unavailable" };
 
+export type BrowserSolverChainAcquisition =
+  | { kind: "solved"; provider: BrowserSolverProvider; solution: BrowserSolverSolution }
+  | { kind: "fallback"; reason: "busy" | "unavailable" };
+
 const activeSolverRequests: Record<BrowserSolverProvider, number> = {
   flaresolverr: 0,
   byparr: 0,
@@ -85,9 +89,9 @@ function resolveBoundedInteger(
   return parsed;
 }
 
-function readEndpointSelection() {
+function readEndpointSelections() {
   try {
-    return resolveBrowserSolverEndpoint();
+    return resolveBrowserSolverEndpoints();
   } catch (error) {
     if (error instanceof BrowserSolverConfigurationIssue) {
       throw createConfigurationError(error.message);
@@ -146,16 +150,14 @@ function resolveFlareSolverrConfig(
   };
 }
 
-export function resolveBrowserSolverConfig(
+export function resolveBrowserSolverConfigs(
   mcpServer: McpServer,
-): BrowserSolverConfig | null {
-  const selection = readEndpointSelection();
-  if (!selection) {
-    return null;
-  }
-  return selection.provider === "byparr"
-    ? resolveByparrConfig(mcpServer, selection.endpoint)
-    : resolveFlareSolverrConfig(mcpServer, selection.endpoint);
+): BrowserSolverConfig[] {
+  return readEndpointSelections().map((selection) => (
+    selection.provider === "byparr"
+      ? resolveByparrConfig(mcpServer, selection.endpoint)
+      : resolveFlareSolverrConfig(mcpServer, selection.endpoint)
+  ));
 }
 
 async function readBoundedResponse(
@@ -362,29 +364,21 @@ function throwIfAborted(signal?: AbortSignal): void {
 }
 
 function tryReserveProviderSlot(
-  mcpServer: McpServer,
   config: BrowserSolverConfig,
 ): boolean {
   if (activeSolverRequests[config.provider] < config.maxConcurrentRequests) {
     activeSolverRequests[config.provider]++;
     return true;
   }
-  logMessage(
-    mcpServer,
-    "warning",
-    "Browser solver concurrency limit reached; using the direct URL fetch path.",
-  );
   return false;
 }
 
 function classifyAcquisition(
-  mcpServer: McpServer,
   responseText: string | null,
   requestedUrl: URL,
 ): BrowserSolverAcquisition {
   const solution = decodeSolution(responseText);
   if (!solution) {
-    logDirectFallback(mcpServer);
     return { kind: "fallback", reason: "unavailable" };
   }
   validateSolutionUrl(solution, requestedUrl);
@@ -396,19 +390,70 @@ export async function acquireBrowserSolverSolution(
   config: BrowserSolverConfig,
   requestedUrl: URL,
   signal?: AbortSignal,
+  logFallback: boolean = true,
 ): Promise<BrowserSolverAcquisition> {
   throwIfAborted(signal);
-  if (!tryReserveProviderSlot(mcpServer, config)) {
+  if (!tryReserveProviderSlot(config)) {
+    if (logFallback) {
+      logDirectFallback(mcpServer);
+    }
     return { kind: "fallback", reason: "busy" };
   }
 
   try {
     const responseText = await requestBrowserSolverSession(config, requestedUrl, signal);
     throwIfAborted(signal);
-    return classifyAcquisition(mcpServer, responseText, requestedUrl);
+    const acquisition = classifyAcquisition(responseText, requestedUrl);
+    if (logFallback && acquisition.kind === "fallback") {
+      logDirectFallback(mcpServer);
+    }
+    return acquisition;
   } finally {
     activeSolverRequests[config.provider]--;
   }
+}
+
+function logProviderOutcome(
+  mcpServer: McpServer,
+  provider: BrowserSolverProvider,
+  reason: "busy" | "unavailable",
+): void {
+  logMessage(
+    mcpServer,
+    "warning",
+    "Browser solver provider did not produce a session.",
+    { provider, classification: reason },
+  );
+}
+
+export async function acquireBrowserSolverSolutionChain(
+  mcpServer: McpServer,
+  configs: readonly BrowserSolverConfig[],
+  requestedUrl: URL,
+  signal?: AbortSignal,
+): Promise<BrowserSolverChainAcquisition> {
+  let finalReason: "busy" | "unavailable" = "unavailable";
+  for (const config of configs) {
+    throwIfAborted(signal);
+    const acquisition = await acquireBrowserSolverSolution(
+      mcpServer,
+      config,
+      requestedUrl,
+      signal,
+      false,
+    );
+    if (acquisition.kind === "solved") {
+      return {
+        kind: "solved",
+        provider: config.provider,
+        solution: acquisition.solution,
+      };
+    }
+    finalReason = acquisition.reason;
+    logProviderOutcome(mcpServer, config.provider, acquisition.reason);
+  }
+  logDirectFallback(mcpServer);
+  return { kind: "fallback", reason: finalReason };
 }
 
 function cookiePath(cookie: BrowserSolverCookie): string {

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,7 +350,7 @@ export const LITE_INSTANCE_INFO_TOOL: Tool = {
 export const LITE_READ_URL_TOOL: Tool = {
   name: "web_url_read",
   description:
-    "Fetch URL. Converts HTML to markdown; returns explicit JSON, plain text, YAML, TOML, and XML as readable markdown; supports bounded PDF text extraction; other binary/media/archive downloads are rejected. When browser solvers are configured, mcp-searxng attempts FlareSolverr first and then Byparr only after a busy or transient-unavailable acquisition; after the final unavailable provider it uses one uncached direct read.",
+    "Fetch URL. Converts HTML to markdown; returns explicit JSON, plain text, YAML, TOML, and XML as readable markdown; supports bounded PDF text extraction; other binary/media/archive downloads are rejected. When browser solvers are configured, mcp-searxng attempts FlareSolverr first and then Byparr only after a busy or transient-unavailable acquisition; after a final busy or unavailable provider it uses one uncached direct read.",
   inputSchema: {
     type: "object",
     properties: { url: { type: "string", description: "URL to fetch." } },
@@ -365,7 +365,7 @@ export const READ_URL_TOOL: Tool = {
     "Content-type aware: HTML is converted to markdown; JSON is pretty-printed; plain text, YAML, TOML, and XML are returned as fenced readable text. " +
     "PDF text extraction is supported with bounded input, output, page count, time, concurrency, and memory; OCR is not supported. " +
     "Binary, media, archive, and octet-stream downloads other than PDFs are intentionally rejected instead of being returned as raw bytes. " +
-    "When the operator configures browser solvers, mcp-searxng attempts FlareSolverr first and then Byparr only after a busy or transient-unavailable acquisition; cache hits bypass acquisition and the final unavailable provider uses one uncached direct-fetch fallback. " +
+    "When the operator configures browser solvers, mcp-searxng attempts FlareSolverr first and then Byparr only after a busy or transient-unavailable acquisition; cache hits bypass acquisition and a final busy or unavailable provider uses one uncached direct-fetch fallback. " +
     "Three modes: " +
     "(1) Full content — omit filtering params; use `startChar`/`maxLength` to paginate large pages. " +
     "(2) Section extraction — set `section` to return content under a specific heading. " +

--- a/src/types.ts
+++ b/src/types.ts
@@ -350,7 +350,7 @@ export const LITE_INSTANCE_INFO_TOOL: Tool = {
 export const LITE_READ_URL_TOOL: Tool = {
   name: "web_url_read",
   description:
-    "Fetch URL. Converts HTML to markdown; returns explicit JSON, plain text, YAML, TOML, and XML as readable markdown; supports bounded PDF text extraction; other binary/media/archive downloads are rejected. When a browser solver is configured, mcp-searxng attempts to acquire a browser session after URL validation and a HEAD size preflight for each uncached URL read; busy or unavailable attempts fall back to an uncached direct read.",
+    "Fetch URL. Converts HTML to markdown; returns explicit JSON, plain text, YAML, TOML, and XML as readable markdown; supports bounded PDF text extraction; other binary/media/archive downloads are rejected. When browser solvers are configured, mcp-searxng attempts FlareSolverr first and then Byparr only after a busy or transient-unavailable acquisition; after the final unavailable provider it uses one uncached direct read.",
   inputSchema: {
     type: "object",
     properties: { url: { type: "string", description: "URL to fetch." } },
@@ -365,7 +365,7 @@ export const READ_URL_TOOL: Tool = {
     "Content-type aware: HTML is converted to markdown; JSON is pretty-printed; plain text, YAML, TOML, and XML are returned as fenced readable text. " +
     "PDF text extraction is supported with bounded input, output, page count, time, concurrency, and memory; OCR is not supported. " +
     "Binary, media, archive, and octet-stream downloads other than PDFs are intentionally rejected instead of being returned as raw bytes. " +
-    "When the operator configures a browser solver, mcp-searxng attempts to acquire a browser session after URL validation and a HEAD size preflight for each uncached URL read; cache hits bypass acquisition and busy or unavailable attempts use an uncached direct-fetch fallback. " +
+    "When the operator configures browser solvers, mcp-searxng attempts FlareSolverr first and then Byparr only after a busy or transient-unavailable acquisition; cache hits bypass acquisition and the final unavailable provider uses one uncached direct-fetch fallback. " +
     "Three modes: " +
     "(1) Full content — omit filtering params; use `startChar`/`maxLength` to paginate large pages. " +
     "(2) Section extraction — set `section` to return content under a specific heading. " +

--- a/src/url-reader.ts
+++ b/src/url-reader.ts
@@ -7,10 +7,10 @@ import { urlCache } from "./cache.js";
 import { assertUrlAllowed, isUrlSecurityPolicyDnsError } from "./url-security.js";
 import { parseStrictInteger } from "./env-int.js";
 import {
-  acquireBrowserSolverSolution,
+  acquireBrowserSolverSolutionChain,
   buildBrowserSolverHeaders,
   createBrowserSolverCacheKey,
-  resolveBrowserSolverConfig,
+  resolveBrowserSolverConfigs,
   type BrowserSolverSolution,
 } from "./browser-solver.js";
 import { extractPdfText, MAX_PDF_BYTES, MAX_PDF_PAGES } from "./pdf-reader.js";
@@ -557,21 +557,6 @@ export async function fetchAndConvertToMarkdown(
   const startTime = Date.now();
   logMessage(mcpServer, "info", `Fetching URL: ${url}`);
 
-  const browserSolverConfig = resolveBrowserSolverConfig(mcpServer);
-  const configuredCacheKey = browserSolverConfig
-    ? createBrowserSolverCacheKey(browserSolverConfig.provider, url)
-    : url;
-
-  // Check cache first
-  const cachedEntry = urlCache.get(configuredCacheKey);
-  if (cachedEntry) {
-    logMessage(mcpServer, "info", `Using cached content for URL: ${url}`);
-    const result = applyPaginationOptions(cachedEntry.markdownContent, paginationOptions);
-    const duration = Date.now() - startTime;
-    logMessage(mcpServer, "info", `Processed cached URL: ${url} (${result.length} chars in ${duration}ms)`);
-    return result;
-  }
-  
   // Validate URL format
   let parsedUrl: URL;
   try {
@@ -582,13 +567,29 @@ export async function fetchAndConvertToMarkdown(
   }
 
   assertUrlAllowed(parsedUrl);
+  const browserSolverConfigs = resolveBrowserSolverConfigs(mcpServer);
+  const configuredCacheKeys = browserSolverConfigs.length > 0
+    ? browserSolverConfigs.map(({ provider }) => createBrowserSolverCacheKey(provider, url))
+    : [url];
+
+  for (const configuredCacheKey of configuredCacheKeys) {
+    const cachedEntry = urlCache.get(configuredCacheKey);
+    if (cachedEntry) {
+      logMessage(mcpServer, "info", `Using cached content for URL: ${url}`);
+      const result = applyPaginationOptions(cachedEntry.markdownContent, paginationOptions);
+      const duration = Date.now() - startTime;
+      logMessage(mcpServer, "info", `Processed cached URL: ${url} (${result.length} chars in ${duration}ms)`);
+      return result;
+    }
+  }
+
   const maxContentLengthBytes = getMaxContentLengthBytes(mcpServer);
 
   let browserSolverSolution: BrowserSolverSolution | null = null;
   let cacheKey = url;
   let shouldCacheResult = true;
   let skipInitialReplayHead = false;
-  if (browserSolverConfig) {
+  if (browserSolverConfigs.length > 0) {
     const preflightProxyAgent = createProxyAgent(parsedUrl.toString(), ProxyType.URL_READER);
     const preflightDispatcher = preflightProxyAgent ?? createUrlReaderAgent();
     const preflightHeaders: Record<string, string> = {};
@@ -611,9 +612,9 @@ export async function fetchAndConvertToMarkdown(
       return createContentTooLargeMessage(contentLength, maxContentLengthBytes);
     }
 
-    const acquisition = await acquireBrowserSolverSolution(
+    const acquisition = await acquireBrowserSolverSolutionChain(
       mcpServer,
-      browserSolverConfig,
+      browserSolverConfigs,
       parsedUrl,
       signal,
     );
@@ -627,7 +628,7 @@ export async function fetchAndConvertToMarkdown(
           { url },
         );
       }
-      cacheKey = configuredCacheKey;
+      cacheKey = createBrowserSolverCacheKey(acquisition.provider, url);
     } else {
       skipInitialReplayHead = true;
       shouldCacheResult = false;


### PR DESCRIPTION
## Summary
- allow FlareSolverr and Byparr to be configured together in a fixed FlareSolverr-first order
- fail over only for busy or transient-unavailable acquisition outcomes while preserving fail-closed security and configuration errors
- keep provider-specific timeouts, concurrency, cache keys, diagnostics, and document the additive latency bound
- add deterministic and pinned-container failover coverage

## Testing
- npm run lint
- npm run test:coverage (665/665; 94.44% lines, 91.64% branches)
- npm run build
- npm run test:e2e (16/16 with fresh Cloudflare challenge and unavailable FlareSolverr primary)
- npm run audit:deps
- docker compose config for all browser-solver examples
- git diff --check