### PR TITLE
feat(search): add configurable response default

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -60,7 +60,7 @@ Operator-level defaults applied when the caller omits the corresponding per-call
 |---|---|---|---|
 | `SEARXNG_DEFAULT_LANGUAGE` | No | `all` | Default language for all searches when `language` is not passed per call (e.g. `en`, `fr`, `de`). |
 | `SEARXNG_DEFAULT_SAFESEARCH` | No | — | Default safe-search level: `0` (off), `1` (moderate), `2` (strict). Invalid values are ignored with a warning. When unset, the SearXNG instance default applies. |
-| `SEARXNG_DEFAULT_RESPONSE_FORMAT` | No | `text` | Default response format when `response_format` is omitted. After trimming whitespace, accepted values are the exact lowercase `text` or `json`. Unset or blank values use `text` silently; invalid values warn once per server instance and use `text`. If omitted, `SEARXNG_DEFAULT_RESPONSE_FORMAT` applies; if unset or invalid, `text` is used. An explicit `response_format` always takes precedence. |
+| `SEARXNG_DEFAULT_RESPONSE_FORMAT` | No | `text` | After trimming whitespace, accepted values are the exact lowercase `text` or `json`. Unset or blank values use `text` silently; invalid values warn once per server instance and use `text`. If omitted, `SEARXNG_DEFAULT_RESPONSE_FORMAT` applies; if unset or invalid, `text` is used. An explicit `response_format` always takes precedence. |
 
 Clients that explicitly send or auto-inject `response_format=text` continue to override the operator default. If an omitted call still returns text after configuring JSON, inspect the tool arguments emitted by the MCP client.
 

--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -60,6 +60,11 @@ Operator-level defaults applied when the caller omits the corresponding per-call
 |---|---|---|---|
 | `SEARXNG_DEFAULT_LANGUAGE` | No | `all` | Default language for all searches when `language` is not passed per call (e.g. `en`, `fr`, `de`). |
 | `SEARXNG_DEFAULT_SAFESEARCH` | No | — | Default safe-search level: `0` (off), `1` (moderate), `2` (strict). Invalid values are ignored with a warning. When unset, the SearXNG instance default applies. |
+| `SEARXNG_DEFAULT_RESPONSE_FORMAT` | No | `text` | Default response format when `response_format` is omitted. After trimming whitespace, accepted values are the exact lowercase `text` or `json`. Unset or blank values use `text` silently; invalid values warn once per server instance and use `text`. If omitted, `SEARXNG_DEFAULT_RESPONSE_FORMAT` applies; if unset or invalid, `text` is used. An explicit `response_format` always takes precedence. |
+
+Clients that explicitly send or auto-inject `response_format=text` continue to override the operator default. If an omitted call still returns text after configuring JSON, inspect the tool arguments emitted by the MCP client.
+
+The response-format default also applies when `SEARXNG_LITE_TOOLS=true`. Lite schemas omit optional parameters, but callers that send `response_format` explicitly still override the configured default, consistent with the existing forwarding behavior for extra lite-tool arguments.
 
 ## Search Result Controls
 
@@ -410,6 +415,7 @@ This combined MCP client configuration shows the supported option groups in one 
         "SEARXNG_LITE_TOOLS": "false",
         "SEARXNG_DEFAULT_LANGUAGE": "en",
         "SEARXNG_DEFAULT_SAFESEARCH": "0",
+        "SEARXNG_DEFAULT_RESPONSE_FORMAT": "text",
         "SEARXNG_MAX_RESULTS": "10",
         "SEARXNG_MAX_RESULT_CHARS": "500",
         "SEARCH_CACHE_TTL_MS": "86400000",

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ For measured MCP-process CPU and memory starting points, see
 
 ## Features
 
-- **Web Search**: General, news, and article queries with pagination, time-range/language/safe-search filters, relevance filtering (`min_score`), and formatted-text or raw-JSON output (`response_format`).
+- **Web Search**: General, news, and article queries with pagination, time-range/language/safe-search filters, relevance filtering (`min_score`), and formatted-text or raw-JSON output selected per call (`response_format`) or with the operator default (`SEARXNG_DEFAULT_RESPONSE_FORMAT`).
 - **Instance Failover & Fan-out**: Configure interchangeable SearXNG replicas in `SEARXNG_URL`; searches fail over in order by default, or query all healthy replicas in parallel and merge results with `SEARXNG_FANOUT`.
 - **Direct Answers & Metadata**: Text results surface SearXNG answers, corrections, suggestions, and infoboxes before the result list.
 - **Search Suggestions**: Query autocomplete via SearXNG's `/autocompleter` endpoint.
@@ -132,7 +132,8 @@ For SearXNG deployment, configuration, and troubleshooting, see
     - `num_results` (number, optional): Maximum number of results to return, from 1 to 20. `SEARXNG_MAX_RESULTS` applies as an operator ceiling.
     - `categories` (string, optional): Comma-separated SearXNG categories (e.g. `"news"`, `"it,science"`). Live `/config` capabilities are aggregated across reachable instances; prefer `searxng_instance_info` `categories.common` for consistent multi-instance results. Known values are trimmed and normalized case-insensitively; unknown values are forwarded trimmed so SearXNG can ignore or honor them. If `/config` is unavailable, values are forwarded as-is with a warning. If omitted, each instance uses its server-side default.
     - `engines` (string, optional): Comma-separated SearXNG engine names (e.g. `"google,bing,ddg"`, `"semantic scholar"`). Live `/config` capabilities are aggregated across reachable instances; prefer `searxng_instance_info` `engines.common.enabled` for consistent multi-instance results. Known values are trimmed and normalized case-insensitively, including engines disabled by default; unknown values are forwarded trimmed so SearXNG can ignore or honor them. If `/config` is unavailable, values are forwarded as-is with a warning. If omitted, each instance uses its server-side default.
-    - `response_format` (string, optional): Response format, either `"text"` for formatted agent-readable output or `"json"` for raw SearXNG JSON with filtered/sliced `results`. (default: `"text"`)
+    - `response_format` (string, optional): Response format, either `"text"` for formatted agent-readable output or `"json"` for raw SearXNG JSON with filtered/sliced `results`. If omitted, `SEARXNG_DEFAULT_RESPONSE_FORMAT` applies; if unset or invalid, `text` is used. An explicit `response_format` always takes precedence.
+    - Clients that explicitly send or auto-inject `response_format=text` continue to override the operator default. If omitted calls still return text after configuring JSON, inspect the arguments emitted by the MCP client.
 
 - **searxng_search_suggestions**
   - Get autocomplete suggestions for refining search queries
@@ -347,6 +348,8 @@ The server binds to `127.0.0.1` by default; set `MCP_HTTP_HOST=0.0.0.0` for remo
 ## Configuration
 
 `SEARXNG_URL` is the only required variable — set it to your SearXNG instance URL (or a semicolon-separated list of interchangeable replicas). Everything else is optional.
+
+Use `SEARXNG_DEFAULT_RESPONSE_FORMAT` to select `text` or `json` when search calls omit `response_format`; explicit per-call values still win.
 
 See **[CONFIGURATION.md](CONFIGURATION.md)** for the full environment variable reference, including authentication, failover/fan-out, caching, timeouts, proxies, TLS, HTTP transport, and hardening.
 

--- a/__tests__/e2e/search.e2e.ts
+++ b/__tests__/e2e/search.e2e.ts
@@ -21,6 +21,11 @@ import { testFunction, createTestResults, printTestSummary } from '../helpers/te
 
 const results = createTestResults();
 
+function getToolResponseText(response: any): string {
+  assert.ok(response && !response.error, `server error: ${JSON.stringify(response?.error)}`);
+  return response.result?.content?.[0]?.text ?? '';
+}
+
 async function runTests() {
   console.log('🌐 E2E Testing: searxng_web_search (live)\n');
 
@@ -169,14 +174,10 @@ async function runTests() {
       },
     ]);
 
-    const omitted = responses[2];
-    assert.ok(omitted && !omitted.error, `server error: ${JSON.stringify(omitted?.error)}`);
-    const payload = JSON.parse(omitted.result?.content?.[0]?.text ?? '');
+    const payload = JSON.parse(getToolResponseText(responses[2]));
     assert.ok(Array.isArray(payload.results), 'configured JSON default should return a results array');
 
-    const explicit = responses[3];
-    assert.ok(explicit && !explicit.error, `server error: ${JSON.stringify(explicit?.error)}`);
-    const text: string = explicit.result?.content?.[0]?.text ?? '';
+    const text = getToolResponseText(responses[3]);
     assert.ok(text.includes('Title:'), 'explicit text should return formatted results');
     assert.throws(() => JSON.parse(text));
   }, results);

--- a/__tests__/e2e/search.e2e.ts
+++ b/__tests__/e2e/search.e2e.ts
@@ -24,10 +24,34 @@ const results = createTestResults();
 async function runTests() {
   console.log('🌐 E2E Testing: searxng_web_search (live)\n');
 
+  const localSkip = checkSkipConditions(false);
+  if (localSkip) {
+    console.log(localSkip);
+    return { passed: 0, failed: 0, errors: [] };
+  }
+
+  await testFunction('built CLI exposes the environment-aware response_format schema', async () => {
+    const responses = spawnWithMessages([
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+      { jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} },
+    ], 'https://unused.invalid');
+
+    const r = responses[2];
+    assert.ok(r && !r.error, `server error: ${JSON.stringify(r?.error)}`);
+    const searchTool = r.result?.tools?.find((tool: any) => tool.name === 'searxng_web_search');
+    assert.ok(searchTool, 'tools/list should include searxng_web_search');
+    const responseFormat = searchTool.inputSchema?.properties?.response_format;
+    assert.deepEqual(responseFormat?.enum, ['text', 'json']);
+    assert.equal('default' in responseFormat, false);
+    assert.ok(responseFormat.description.includes('SEARXNG_DEFAULT_RESPONSE_FORMAT'));
+    assert.ok(responseFormat.description.includes('explicit response_format always takes precedence'));
+  }, results);
+
   const skip = checkSkipConditions();
   if (skip) {
     console.log(skip);
-    return { passed: 0, failed: 0, errors: [] };
+    printTestSummary(results, 'E2E: Web Search');
+    return results;
   }
 
   await testFunction('basic search returns results with title and URL', async () => {
@@ -119,6 +143,52 @@ async function runTests() {
     const payload = JSON.parse(text);
     assert.ok(Array.isArray(payload.results), 'JSON response should contain results array');
     assert.ok(payload.results.length <= 2, 'num_results should slice JSON results');
+  }, results);
+
+  await testFunction('configured JSON default applies when omitted and explicit text still wins', async () => {
+    const previousDefault = process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT;
+    process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT = 'json';
+
+    try {
+      const responses = spawnWithMessages([
+        { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+        {
+          jsonrpc: '2.0',
+          id: 2,
+          method: 'tools/call',
+          params: {
+            name: 'searxng_web_search',
+            arguments: { query: 'test', num_results: 2 },
+          },
+        },
+        {
+          jsonrpc: '2.0',
+          id: 3,
+          method: 'tools/call',
+          params: {
+            name: 'searxng_web_search',
+            arguments: { query: 'test', num_results: 2, response_format: 'text' },
+          },
+        },
+      ]);
+
+      const omitted = responses[2];
+      assert.ok(omitted && !omitted.error, `server error: ${JSON.stringify(omitted?.error)}`);
+      const payload = JSON.parse(omitted.result?.content?.[0]?.text ?? '');
+      assert.ok(Array.isArray(payload.results), 'configured JSON default should return a results array');
+
+      const explicit = responses[3];
+      assert.ok(explicit && !explicit.error, `server error: ${JSON.stringify(explicit?.error)}`);
+      const text: string = explicit.result?.content?.[0]?.text ?? '';
+      assert.ok(text.includes('Title:'), 'explicit text should return formatted results');
+      assert.throws(() => JSON.parse(text));
+    } finally {
+      if (previousDefault === undefined) {
+        delete process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT;
+      } else {
+        process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT = previousDefault;
+      }
+    }
   }, results);
 
   printTestSummary(results, 'E2E: Web Search');

--- a/__tests__/e2e/search.e2e.ts
+++ b/__tests__/e2e/search.e2e.ts
@@ -146,49 +146,39 @@ async function runTests() {
   }, results);
 
   await testFunction('configured JSON default applies when omitted and explicit text still wins', async () => {
-    const previousDefault = process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT;
     process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT = 'json';
-
-    try {
-      const responses = spawnWithMessages([
-        { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
-        {
-          jsonrpc: '2.0',
-          id: 2,
-          method: 'tools/call',
-          params: {
-            name: 'searxng_web_search',
-            arguments: { query: 'test', num_results: 2 },
-          },
+    const responses = spawnWithMessages([
+      { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+      {
+        jsonrpc: '2.0',
+        id: 2,
+        method: 'tools/call',
+        params: {
+          name: 'searxng_web_search',
+          arguments: { query: 'test', num_results: 2 },
         },
-        {
-          jsonrpc: '2.0',
-          id: 3,
-          method: 'tools/call',
-          params: {
-            name: 'searxng_web_search',
-            arguments: { query: 'test', num_results: 2, response_format: 'text' },
-          },
+      },
+      {
+        jsonrpc: '2.0',
+        id: 3,
+        method: 'tools/call',
+        params: {
+          name: 'searxng_web_search',
+          arguments: { query: 'test', num_results: 2, response_format: 'text' },
         },
-      ]);
+      },
+    ]);
 
-      const omitted = responses[2];
-      assert.ok(omitted && !omitted.error, `server error: ${JSON.stringify(omitted?.error)}`);
-      const payload = JSON.parse(omitted.result?.content?.[0]?.text ?? '');
-      assert.ok(Array.isArray(payload.results), 'configured JSON default should return a results array');
+    const omitted = responses[2];
+    assert.ok(omitted && !omitted.error, `server error: ${JSON.stringify(omitted?.error)}`);
+    const payload = JSON.parse(omitted.result?.content?.[0]?.text ?? '');
+    assert.ok(Array.isArray(payload.results), 'configured JSON default should return a results array');
 
-      const explicit = responses[3];
-      assert.ok(explicit && !explicit.error, `server error: ${JSON.stringify(explicit?.error)}`);
-      const text: string = explicit.result?.content?.[0]?.text ?? '';
-      assert.ok(text.includes('Title:'), 'explicit text should return formatted results');
-      assert.throws(() => JSON.parse(text));
-    } finally {
-      if (previousDefault === undefined) {
-        delete process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT;
-      } else {
-        process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT = previousDefault;
-      }
-    }
+    const explicit = responses[3];
+    assert.ok(explicit && !explicit.error, `server error: ${JSON.stringify(explicit?.error)}`);
+    const text: string = explicit.result?.content?.[0]?.text ?? '';
+    assert.ok(text.includes('Title:'), 'explicit text should return formatted results');
+    assert.throws(() => JSON.parse(text));
   }, results);
 
   printTestSummary(results, 'E2E: Web Search');

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -388,6 +388,50 @@ async function runTests() {
     await client.close();
   }, results);
 
+  await testFunction('tools/call in lite mode uses the configured response default and accepts an explicit override', async () => {
+    process.env.SEARXNG_URL = 'http://localhost:8080';
+    process.env.SEARXNG_LITE_TOOLS = 'true';
+    process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT = 'json';
+    fetchMocker.mock(createMockFetch({
+      body: JSON.stringify({
+        query: 'configured default',
+        number_of_results: 1,
+        results: [
+          {
+            title: 'Configured Default Result',
+            url: 'https://example.com/configured-default',
+            content: 'Configured default snippet',
+            score: 1.0,
+          },
+        ],
+      }),
+    }));
+    const { client } = await connect();
+
+    try {
+      const omitted = await client.callTool({
+        name: 'searxng_web_search',
+        arguments: { query: 'configured default omitted' },
+      });
+      const omittedPayload = JSON.parse((omitted.content[0] as { type: string; text: string }).text);
+      assert.equal(omittedPayload.results[0].title, 'Configured Default Result');
+
+      const explicit = await client.callTool({
+        name: 'searxng_web_search',
+        arguments: { query: 'configured default explicit', response_format: 'text' },
+      });
+      const explicitText = (explicit.content[0] as { type: string; text: string }).text;
+      assert.ok(explicitText.includes('Title: Configured Default Result'), explicitText);
+      assert.throws(() => JSON.parse(explicitText));
+    } finally {
+      fetchMocker.restore();
+      delete process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT;
+      delete process.env.SEARXNG_LITE_TOOLS;
+      delete process.env.SEARXNG_URL;
+      await client.close();
+    }
+  }, results);
+
   await testFunction('tools/call searxng_search_suggestions returns JSON suggestions', async () => {
     process.env.SEARXNG_URL = 'http://localhost:8080';
     fetchMocker.mock(createMockFetch({ body: JSON.stringify(['type', ['typescript', 'typescript tutorial']]) }));
@@ -449,24 +493,38 @@ async function runTests() {
   }, results);
 
   await testFunction('tools/call searxng_web_search with invalid args throws protocol error', async () => {
+    process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT = 'json';
     const { client } = await connect();
 
     try {
-      await client.callTool({
-        name: 'searxng_web_search',
-        arguments: { notQuery: 'oops' },
-      });
-      assert.fail('Expected error was not thrown');
-    } catch (error) {
-      assert.ok(error instanceof Error, 'should throw an Error');
-      assert.ok(
-        error.message.toLowerCase().includes('invalid') ||
-        error.message.toLowerCase().includes('argument'),
-        `unexpected message: ${error.message}`
-      );
-    }
+      try {
+        await client.callTool({
+          name: 'searxng_web_search',
+          arguments: { notQuery: 'oops' },
+        });
+        assert.fail('Expected error was not thrown');
+      } catch (error) {
+        assert.ok(error instanceof Error, 'should throw an Error');
+        assert.ok(
+          error.message.toLowerCase().includes('invalid') ||
+          error.message.toLowerCase().includes('argument'),
+          `unexpected message: ${error.message}`
+        );
+      }
 
-    await client.close();
+      try {
+        await client.callTool({
+          name: 'searxng_web_search',
+          arguments: { query: 'invalid format', response_format: 'xml' },
+        });
+        assert.fail('Expected invalid response_format error was not thrown');
+      } catch (error) {
+        assert.ok(error instanceof Error, 'should throw an Error for invalid response_format');
+      }
+    } finally {
+      delete process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT;
+      await client.close();
+    }
   }, results);
 
   await testFunction('tool errors and MCP logs never expose configured Basic Auth material', async () => {

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -464,6 +464,29 @@ export async function runTests(): Promise<TestResult> {
     assert.ok(normalizedGuide.includes('published port in `MCP_HTTP_ALLOWED_HOSTS`'));
   }, results);
 
+  await testFunction('public docs define the configurable search response default and precedence', () => {
+    const readme = readText(new URL('../../README.md', import.meta.url));
+    const configuration = readText(new URL('../../CONFIGURATION.md', import.meta.url));
+    const precedence = 'If omitted, `SEARXNG_DEFAULT_RESPONSE_FORMAT` applies; if unset or invalid, `text` is used. An explicit `response_format` always takes precedence.';
+
+    assert.ok(readme.includes('`SEARXNG_DEFAULT_RESPONSE_FORMAT`'));
+    assert.ok(readme.includes(precedence));
+    assert.ok(readme.includes('auto-inject `response_format=text`'));
+
+    const searchDefaultsStart = configuration.indexOf('## Search Defaults');
+    const resultControlsStart = configuration.indexOf('## Search Result Controls');
+    assert.ok(searchDefaultsStart >= 0);
+    assert.ok(resultControlsStart > searchDefaultsStart);
+    const searchDefaults = configuration.slice(searchDefaultsStart, resultControlsStart);
+    assert.ok(searchDefaults.includes('| `SEARXNG_DEFAULT_RESPONSE_FORMAT` |'));
+    assert.ok(searchDefaults.includes('`text` or `json`'));
+    assert.ok(searchDefaults.includes(precedence));
+    assert.ok(searchDefaults.includes('auto-inject `response_format=text`'));
+    assert.ok(configuration.includes('also applies when `SEARXNG_LITE_TOOLS=true`'));
+    assert.ok(configuration.includes('callers that send `response_format` explicitly still override'));
+    assert.ok(configuration.includes('"SEARXNG_DEFAULT_RESPONSE_FORMAT": "text"'));
+  }, results);
+
   await testFunction('public documentation states current security, privacy, and configuration contracts', () => {
     const readme = readText(new URL('../../README.md', import.meta.url));
     const configuration = readText(new URL('../../CONFIGURATION.md', import.meta.url));

--- a/__tests__/unit/resources.test.ts
+++ b/__tests__/unit/resources.test.ts
@@ -98,6 +98,10 @@ async function runTests() {
     assert.ok(help.includes('`num_results`'), 'missing num_results parameter');
     assert.ok(help.includes('`categories`'), 'missing categories parameter');
     assert.ok(help.includes('`response_format`'), 'missing response_format parameter');
+    assert.ok(help.includes('`SEARXNG_DEFAULT_RESPONSE_FORMAT`'), 'missing response-format environment default');
+    assert.ok(help.includes('`text` or `json`'), 'missing accepted response-format values');
+    assert.ok(help.includes('if unset or invalid, text is used'), 'missing text fallback');
+    assert.ok(help.includes('explicit `response_format` always takes precedence'), 'missing explicit precedence');
     assert.ok(help.includes('metadata sections'), 'missing metadata/direct-answer output note');
     assert.ok(help.includes('### 2. searxng_search_suggestions'), 'missing suggestions tool section');
     assert.ok(help.includes('### 3. searxng_instance_info'), 'missing instance info tool section');

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -2286,6 +2286,178 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('omitted response_format honors SEARXNG_DEFAULT_RESPONSE_FORMAT=json', async () => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARXNG_DEFAULT_RESPONSE_FORMAT', '  json  ');
+
+    const mockServer = createMockServer();
+    fetchMocker.mock(createMockFetch({
+      json: {
+        query: 'environment json query',
+        number_of_results: 1,
+        results: [
+          {
+            title: 'Environment JSON Result',
+            content: 'Structured result content',
+            url: 'https://example.com/environment-json',
+            score: 1,
+          },
+        ],
+      },
+    }));
+
+    try {
+      const result = await performWebSearch(mockServer as any, 'environment json query');
+      const payload = JSON.parse(result);
+      assert.equal(payload.query, 'environment json query');
+      assert.equal(payload.results[0].title, 'Environment JSON Result');
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+    }
+  }, results);
+
+  await testFunction('unset, blank, and text response defaults stay formatted and silent', async () => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.delete('SEARXNG_DEFAULT_RESPONSE_FORMAT');
+    const { server, getLoggingCalls } = createMockServerWithTracking();
+    fetchMocker.mock(createMockFetch({
+      json: {
+        query: 'text default',
+        number_of_results: 1,
+        results: [{ title: 'Text Default', content: 'Body', url: 'https://example.com/text-default', score: 1 }],
+      },
+    }));
+
+    try {
+      const unset = await performWebSearch(server as any, 'unset default');
+      envManager.set('SEARXNG_DEFAULT_RESPONSE_FORMAT', '   ');
+      const blank = await performWebSearch(server as any, 'blank default');
+      envManager.set('SEARXNG_DEFAULT_RESPONSE_FORMAT', ' text ');
+      const configuredText = await performWebSearch(server as any, 'text default');
+
+      for (const output of [unset, blank, configuredText]) {
+        assert.ok(output.includes('Title: Text Default'), output);
+        assert.throws(() => JSON.parse(output));
+      }
+      assert.equal(getLoggingCalls().filter((call) => call.level === 'warning').length, 0);
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+    }
+  }, results);
+
+  await testFunction('invalid configured format warns once per server without echoing the value', async () => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    const invalidValue = 'sensitive-invalid-sentinel-7f3a';
+    envManager.set('SEARXNG_DEFAULT_RESPONSE_FORMAT', invalidValue);
+    const first = createMockServerWithTracking();
+    const second = createMockServerWithTracking();
+    fetchMocker.mock(createMockFetch({
+      json: {
+        query: 'invalid default',
+        number_of_results: 1,
+        results: [{ title: 'Fallback Text', content: 'Body', url: 'https://example.com/fallback', score: 1 }],
+      },
+    }));
+
+    try {
+      const firstCall = await performWebSearch(first.server as any, 'invalid default one');
+      const repeatedCall = await performWebSearch(first.server as any, 'invalid default two');
+      envManager.set('SEARXNG_DEFAULT_RESPONSE_FORMAT', 'JSON');
+      const secondServerCall = await performWebSearch(second.server as any, 'invalid default three');
+
+      for (const output of [firstCall, repeatedCall, secondServerCall]) {
+        assert.ok(output.includes('Title: Fallback Text'), output);
+      }
+      for (const calls of [first.getLoggingCalls(), second.getLoggingCalls()]) {
+        const warnings = calls.filter((call) => call.level === 'warning');
+        assert.equal(warnings.length, 1);
+        const message = String(warnings[0].data?.message ?? '');
+        assert.ok(message.includes('SEARXNG_DEFAULT_RESPONSE_FORMAT'), message);
+        assert.ok(message.includes('text or json'), message);
+      }
+      const firstWarning = String(first.getLoggingCalls().find((call) => call.level === 'warning')?.data?.message ?? '');
+      const secondWarning = String(second.getLoggingCalls().find((call) => call.level === 'warning')?.data?.message ?? '');
+      assert.ok(!firstWarning.toLowerCase().includes(invalidValue.toLowerCase()), firstWarning);
+      assert.ok(!secondWarning.includes('JSON'), secondWarning);
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+    }
+  }, results);
+
+  await testFunction('explicit response_format overrides the environment without resolving an invalid default', async () => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARXNG_DEFAULT_RESPONSE_FORMAT', 'invalid-explicit-override');
+    const { server, getLoggingCalls } = createMockServerWithTracking();
+    fetchMocker.mock(createMockFetch({
+      json: {
+        query: 'explicit override',
+        number_of_results: 1,
+        results: [{ title: 'Explicit Result', content: 'Body', url: 'https://example.com/explicit', score: 1 }],
+      },
+    }));
+
+    try {
+      const text = await performWebSearch(server as any, 'explicit text', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'text');
+      const json = await performWebSearch(server as any, 'explicit json', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
+
+      assert.ok(text.includes('Title: Explicit Result'), text);
+      assert.equal(JSON.parse(json).results[0].title, 'Explicit Result');
+      assert.equal(getLoggingCalls().filter((call) => call.level === 'warning').length, 0);
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+    }
+  }, results);
+
+  await testFunction('effective response format isolates cache entries and annotations', async () => {
+    searchCache.clear();
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    envManager.set('SEARXNG_DEFAULT_RESPONSE_FORMAT', 'text');
+    const mockServer = createMockServer();
+    let fetchCount = 0;
+    fetchMocker.mock(async (url, options) => {
+      fetchCount++;
+      return createMockFetch({
+        json: {
+          query: 'format cache',
+          number_of_results: 1,
+          results: [{ title: 'Format Cache', content: 'Body', url: 'https://example.com/cache-format', score: 1 }],
+        },
+      })(url, options);
+    });
+
+    try {
+      const firstText = await performWebSearch(mockServer as any, 'format cache');
+      envManager.set('SEARXNG_DEFAULT_RESPONSE_FORMAT', 'json');
+      const firstJson = await performWebSearch(mockServer as any, 'format cache');
+      envManager.set('SEARXNG_DEFAULT_RESPONSE_FORMAT', 'text');
+      const cachedText = await performWebSearch(mockServer as any, 'format cache');
+      envManager.set('SEARXNG_DEFAULT_RESPONSE_FORMAT', 'json');
+      const cachedJson = await performWebSearch(mockServer as any, 'format cache');
+
+      assert.equal(fetchCount, 2);
+      assert.ok(!firstText.endsWith('_Cached result_'), firstText);
+      assert.equal(JSON.parse(firstJson).cached, undefined);
+      assert.ok(cachedText.endsWith('\n\n_Cached result_'), cachedText);
+      assert.equal(JSON.parse(cachedJson).cached, true);
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+    }
+  }, results);
+
   await testFunction('response_format=json returns parseable SearXNG JSON with raw metadata', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
 
@@ -2381,6 +2553,7 @@ async function runTests() {
     const result = await performWebSearch(mockServer as any, 'empty query', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
     const payload = JSON.parse(result);
     assert.equal(payload.query, 'empty query');
+    assert.equal(payload.number_of_results, 0);
     assert.deepEqual(payload.results, []);
     assert.deepEqual(payload.suggestions, ['broader query']);
     assert.ok(!result.includes('No results found'), result);

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -60,6 +60,15 @@ function makeConfigWithEngines() {
   };
 }
 
+function getSingleResponseFormatWarning(calls: any[]): string {
+  const warnings = calls.filter((call) => call.level === 'warning');
+  assert.equal(warnings.length, 1);
+  const message = String(warnings[0].data?.message ?? '');
+  assert.ok(message.includes('SEARXNG_DEFAULT_RESPONSE_FORMAT'), message);
+  assert.ok(message.includes('text or json'), message);
+  return message;
+}
+
 async function runTests() {
   console.log('🧪 Testing: search.ts\n');
 
@@ -2375,15 +2384,8 @@ async function runTests() {
       for (const output of [firstCall, repeatedCall, secondServerCall]) {
         assert.ok(output.includes('Title: Fallback Text'), output);
       }
-      for (const calls of [first.getLoggingCalls(), second.getLoggingCalls()]) {
-        const warnings = calls.filter((call) => call.level === 'warning');
-        assert.equal(warnings.length, 1);
-        const message = String(warnings[0].data?.message ?? '');
-        assert.ok(message.includes('SEARXNG_DEFAULT_RESPONSE_FORMAT'), message);
-        assert.ok(message.includes('text or json'), message);
-      }
-      const firstWarning = String(first.getLoggingCalls().find((call) => call.level === 'warning')?.data?.message ?? '');
-      const secondWarning = String(second.getLoggingCalls().find((call) => call.level === 'warning')?.data?.message ?? '');
+      const firstWarning = getSingleResponseFormatWarning(first.getLoggingCalls());
+      const secondWarning = getSingleResponseFormatWarning(second.getLoggingCalls());
       assert.ok(!firstWarning.toLowerCase().includes(invalidValue.toLowerCase()), firstWarning);
       assert.ok(!secondWarning.includes('JSON'), secondWarning);
     } finally {

--- a/__tests__/unit/types.test.ts
+++ b/__tests__/unit/types.test.ts
@@ -247,6 +247,7 @@ async function runTests() {
   }, results);
 
   await testFunction('isSearXNGWebSearchArgs accepts response_format text or json', () => {
+    assert.equal(isSearXNGWebSearchArgs({ query: 'test' }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', response_format: 'text' }), true);
     assert.equal(isSearXNGWebSearchArgs({ query: 'test', response_format: 'json' }), true);
   }, results);
@@ -295,6 +296,16 @@ async function runTests() {
     assert.ok(properties.response_format, 'WEB_SEARCH_TOOL must expose response_format parameter');
     assert.equal(properties.response_format.type, 'string');
     assert.deepEqual(properties.response_format.enum, ['text', 'json']);
+    assert.equal('default' in properties.response_format, false);
+    assert.ok(!(WEB_SEARCH_TOOL.inputSchema.required as string[]).includes('response_format'));
+    assert.ok(
+      properties.response_format.description.includes('SEARXNG_DEFAULT_RESPONSE_FORMAT'),
+      properties.response_format.description,
+    );
+    assert.ok(
+      properties.response_format.description.includes('explicit response_format always takes precedence'),
+      properties.response_format.description,
+    );
   }, results);
 
   await testFunction('LITE_WEB_SEARCH_TOOL schema has only query property', () => {

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -135,7 +135,7 @@ Performs web searches using the configured SearXNG instance or replica list, wit
 - \`num_results\` (optional): Maximum result count from 1 to 20
 - \`categories\` (optional): Comma-separated SearXNG categories such as "news" or "it,science"; live \`/config\` values are aggregated across reachable instances and normalized case-insensitively when available
 - \`engines\` (optional): Comma-separated SearXNG engine names such as "google,bing,ddg" or "semantic scholar"; live \`/config\` values are aggregated across reachable instances and normalized case-insensitively when available
-- \`response_format\` (optional): "text" for formatted output or "json" for raw SearXNG-shaped JSON (may include a \`warnings\` array for non-fatal issues)
+- \`response_format\` (optional): Response format, either \`text\` or \`json\`. Text is formatted for agents; JSON preserves the SearXNG shape and may include a \`warnings\` array for non-fatal issues. If omitted, \`SEARXNG_DEFAULT_RESPONSE_FORMAT\` applies; if unset or invalid, text is used. An explicit \`response_format\` always takes precedence.
 
 Text output can include metadata sections for direct answers, spelling corrections, suggestions, and infoboxes before the result list. JSON output preserves the SearXNG response shape with filtered and sliced \`results\`, and may include a \`warnings\` array for non-fatal issues. Use \`searxng_instance_info\` and prefer \`common\` categories/engines for consistent multi-instance results; \`available\`-only filters are best-effort. Unknown categories or engines are forwarded trimmed so SearXNG can ignore or honor them; if \`/config\` is unavailable, the search proceeds with the supplied values and emits a warning.
 
@@ -175,6 +175,7 @@ ${REQUIRED_CONFIGURATION_GUIDANCE}
 ### Optional Environment Variables
 ${OPTIONAL_CONFIGURATION_GUIDANCE}
 Common ones are listed below (failover/fan-out, caching, timeouts, result limits, per-tool proxies, TLS, HTTP transport, and hardening).
+- \`SEARXNG_DEFAULT_RESPONSE_FORMAT\`: Default omitted search responses to \`text\` or \`json\`; an explicit \`response_format\` takes precedence
 - \`AUTH_USERNAME\` & \`AUTH_PASSWORD\`: Legacy global Basic Auth fallback when \`SEARXNG_URL\` has no userinfo
 - \`HTTP_PROXY\` / \`HTTPS_PROXY\`: Proxy server configuration
 - \`NO_PROXY\` / \`no_proxy\`: Comma-separated list of hosts to bypass proxy

--- a/src/search.ts
+++ b/src/search.ts
@@ -295,6 +295,9 @@ type FailedInstanceResult = {
   error: unknown;
 };
 
+type ResponseFormat = "text" | "json";
+const warnedInvalidDefaultResponseFormat = new WeakSet<McpServer>();
+
 async function normalizeSearchFilters(
   mcpServer: McpServer,
   categories?: string,
@@ -391,6 +394,29 @@ function formatSearchMetadata(data: SearXNGWeb): string {
 
 function getDefaultLanguage(): string {
   return process.env.SEARXNG_DEFAULT_LANGUAGE ?? "all";
+}
+
+function getDefaultResponseFormat(mcpServer: McpServer): ResponseFormat {
+  const rawValue = process.env.SEARXNG_DEFAULT_RESPONSE_FORMAT;
+  if (rawValue === undefined || rawValue.trim() === "") {
+    return "text";
+  }
+
+  const value = rawValue.trim();
+  if (value === "text" || value === "json") {
+    return value;
+  }
+
+  if (!warnedInvalidDefaultResponseFormat.has(mcpServer)) {
+    warnedInvalidDefaultResponseFormat.add(mcpServer);
+    logMessage(
+      mcpServer,
+      "warning",
+      "Ignoring invalid SEARXNG_DEFAULT_RESPONSE_FORMAT. Expected text or json. Using text.",
+    );
+  }
+
+  return "text";
 }
 
 function getDefaultSafesearch(mcpServer: McpServer): number | undefined {
@@ -699,9 +725,10 @@ export async function performWebSearch(
   num_results?: number,
   categories?: string,
   engines?: string,
-  response_format: "text" | "json" = "text",
+  response_format?: ResponseFormat,
 ) {
   const startTime = Date.now();
+  const effectiveResponseFormat = response_format ?? getDefaultResponseFormat(mcpServer);
   const operatorMax = getOperatorMaxResults(mcpServer);
   const effectiveMax = operatorMax !== undefined
     ? (num_results !== undefined ? Math.min(num_results, operatorMax) : operatorMax)
@@ -756,13 +783,13 @@ export async function performWebSearch(
     min_score,
     effectiveMax,
     maxResultChars,
-    response_format,
+    response_format: effectiveResponseFormat,
     instances,
     searxngFanout: fanoutEnabled,
   };
   const cachedResult = searchCache.get("searxng_web_search", cacheArgs);
   if (cachedResult !== null) {
-    return formatCachedSearchResult(cachedResult, response_format);
+    return formatCachedSearchResult(cachedResult, effectiveResponseFormat);
   }
 
   let data: SearXNGWeb;
@@ -786,7 +813,7 @@ export async function performWebSearch(
     ? results.slice(0, effectiveMax)
     : results;
 
-  if (response_format === "json") {
+  if (effectiveResponseFormat === "json") {
     const result = JSON.stringify({
       ...data,
       results: slicedResults,

--- a/src/types.ts
+++ b/src/types.ts
@@ -247,9 +247,8 @@ export const WEB_SEARCH_TOOL: Tool = {
       },
       response_format: {
         type: "string",
-        description: "Response format: formatted text for agents or raw JSON for programmatic clients. Default: text.",
+        description: "Response format: formatted text for agents or raw JSON for programmatic clients. If omitted, SEARXNG_DEFAULT_RESPONSE_FORMAT applies; if unset or invalid, text is used. An explicit response_format always takes precedence.",
         enum: ["text", "json"],
-        default: "text",
       },
     },
     required: ["query"],


### PR DESCRIPTION
## Summary

Adds an operator-level `SEARXNG_DEFAULT_RESPONSE_FORMAT` setting for `searxng_web_search`. Explicit per-call `response_format` values continue to take precedence, while existing installations keep the `text` default when the setting is unset, blank, or invalid.

## Changes

- Resolve the effective `text` or `json` response format per search and isolate cache entries by that effective format.
- Warn once per server for invalid configured values without echoing the value.
- Remove the hard-coded schema default so clients can omit the argument and allow the operator setting to apply.
- Document full- and lite-tool behavior, compatibility, accepted values, fallback, and precedence.
- Add unit, integration, documentation, built-CLI, and live end-to-end coverage.

## Testing

- `npm run test:coverage` — 673 passed, 0 failed; 94.47% lines and 91.73% branches.
- `npm run build` — passed.
- `npm run lint` — passed with zero warnings.
- `npm run test:e2e` — 17 passed, 0 failed, including the live configured-default and explicit-override case.
- `git diff --check` — passed.

## Checklist

- [x] Tests added or updated to cover the change
- [x] Documentation updated — `README.md` and `CONFIGURATION.md` reflect the new behavior
- [x] Branch is based on the current `main`
- [x] PR title and description are in English
- [x] No personal branding, badges, or identity changes included

Related to #187