### PR TITLE
feat(http-server): add optional stateless mode

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -313,16 +313,23 @@ By default the server communicates over STDIO. Set `MCP_HTTP_PORT` to enable HTT
 | `MCP_HTTP_PORT` | No | — | Port number to enable HTTP transport (e.g. `3000`) |
 | `MCP_HTTP_HOST` | No | `127.0.0.1` | Interface address to bind to. Defaults to localhost-only for security. Set `0.0.0.0` for all interfaces (required for Docker and remote deployments), or a specific IP. Works in pair with `MCP_HTTP_PORT` only. **Breaking change from v1.2.1:** previous default was `0.0.0.0`. |
 | `MCP_HTTP_TRUST_PROXY` | No | `false` | Express `trust proxy` setting for deployments behind a trusted reverse proxy. Use `true`, a trusted hop count such as `1`, or a proxy subnet/preset such as `loopback` or `10.0.0.0/8`. Unset, `false`, or `0` disables it (the secure default). |
+| `MCP_HTTP_STATELESS` | No | `false` | Set to the exact value `true` to create an isolated MCP server and transport for every `POST /mcp`. `false`, blank, or unset disables it; any other nonblank value warns and uses `false`. Intended for deployments that cannot preserve process-local sessions. |
+| `MCP_HTTP_STATELESS_MAX_IN_FLIGHT` | No | `16` (range `1`-`256`) | Global maximum number of admitted stateless POST requests in flight. Invalid values use the default. |
+| `MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP` | No | `8` (range `1`-global cap) | Per-client-IP in-flight maximum. Values above the normalized global cap are reduced to that cap. |
+| `MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS` | No | `900000` (range `1000`-`2147483647`) | Maximum lifetime of an admitted stateless POST, including server construction, MCP handling, and an active response stream. |
 
 **HTTP endpoints (when HTTP mode is active):**
-- `POST/GET/DELETE /mcp` — MCP protocol
+- Stateful default: `POST/GET/DELETE /mcp` — session-based MCP protocol
+- With `MCP_HTTP_STATELESS=true`: `POST /mcp` only; GET and DELETE return HTTP 405 with `Allow: POST`
 - `GET /health` — health check
 
 HTTP sessions are stored in memory per process. A stale or unknown `mcp-session-id` on a non-initialize `POST /mcp` receives HTTP 404 with JSON-RPC error code `-32001` and message `"Session not found"`. Clients should recover by running `initialize` again; initialize requests are accepted even when they still carry a stale session header.
 
+In stateless mode, every POST creates a fresh MCP server and transport, ignores incoming `mcp-session-id` headers, and never emits a response session ID. A POST can return negotiated JSON or an SSE stream within that same POST. Cross-request sessions, resumable streams, standalone GET notification streams, and DELETE-based session termination are unavailable. This mode does not require an SDK 2.0 upgrade; it uses the stateless transport contract provided by the currently supported SDK.
+
 ## Rate Limiting (HTTP mode)
 
-Rate limiting is always active in HTTP mode to prevent resource exhaustion. Before the MCP handler runs, each request is counted by resolved client IP against exactly one limit: POST requests with a currently live session use the session limit, other POST requests use the initialization limit, and GET/DELETE requests always use the session limit.
+Rate limiting is always active in HTTP mode to prevent resource exhaustion. Before the MCP handler runs, each request is counted by resolved client IP against exactly one limit. In stateful mode, POST requests with a currently live session use the session limit, other POST requests use the initialization limit, and GET/DELETE requests always use the session limit. In stateless mode, only a single parsed request object recognized by the SDK as `initialize` uses the initialization limit; all other POST bodies, including notifications and batches, use the session limit, and GET/DELETE still use the session limit. Malformed or oversized JSON is rejected by parsing before rate limiting or MCP server construction.
 
 Each `MCP_RATE_*` value must be a positive decimal safe integer after JavaScript whitespace trimming. A leading `+` and leading zeros are accepted; fractions, suffixes, exponents, hexadecimal forms, non-positive values, and integers above `Number.MAX_SAFE_INTEGER` are rejected. An invalid value uses the documented default and emits one startup warning per variable without copying the raw value into diagnostics. Blank or unset variables use the default silently.
 
@@ -336,9 +343,13 @@ Before this correction, spellings such as `20requests`, `12.5`, or `1e3` could b
 
 Requests exceeding a limit receive HTTP 429 with a JSON-RPC error body (`code: -32029`). `/health` has a fixed limit of 60 requests per minute. Standard `RateLimit-*` headers are included on all responses.
 
+After a stateless request consumes its rate-limit token and passes authorization plus hardened Host/Origin checks, it must also acquire the per-IP and global in-flight capacity slots. Per-IP capacity is checked first. Saturation returns HTTP 503, `Retry-After: 1`, and JSON-RPC code `-32000` with message `Server busy`; these attempts still consume their selected rate-limit token. A request that exceeds its lifetime before response headers receives HTTP 504 and JSON-RPC code `-32000` with message `Stateless request timed out`. If an SSE response has already started, the connection is closed instead because its status can no longer be changed. Resource cleanup is bounded and capacity is reclaimed after completion, disconnect, failure, or timeout.
+
 The in-memory store is per-process; for horizontally scaled deployments replace it with a shared Redis store via `express-rate-limit`'s `store` option.
 
 When HTTP mode runs behind a trusted reverse proxy, set `MCP_HTTP_TRUST_PROXY` so Express can resolve the client IP from proxy headers before rate-limit keys and request logs are computed. For a single trusted proxy hop, use `MCP_HTTP_TRUST_PROXY=1`. Leave it unset for direct exposure; enabling it without a trusted proxy lets clients spoof `X-Forwarded-For`. This setting is distinct from outbound `HTTP_PROXY` / `HTTPS_PROXY`, which control this server's requests to SearXNG or URLs.
+
+Requests whose client IP cannot be resolved share one fail-closed capacity bucket. This prevents missing identity data from bypassing the per-IP cap, but such requests can receive HTTP 503 when another unresolved-IP request occupies that bucket.
 
 ## Hardened HTTP Mode
 
@@ -441,6 +452,10 @@ This combined MCP client configuration shows the supported option groups in one 
         "MCP_HTTP_PORT": "3000",
         "MCP_HTTP_HOST": "0.0.0.0",
         "MCP_HTTP_TRUST_PROXY": "1",
+        "MCP_HTTP_STATELESS": "false",
+        "MCP_HTTP_STATELESS_MAX_IN_FLIGHT": "16",
+        "MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP": "8",
+        "MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS": "900000",
         "MCP_RATE_WINDOW_MS": "60000",
         "MCP_RATE_INIT_MAX": "20",
         "MCP_RATE_SESSION_MAX": "300",

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ For measured MCP-process CPU and memory starting points, see
 - **Browser Solver Support**: For each uncached URL that passes static URL validation and the HEAD size preflight, optionally acquire a browser session from FlareSolverr, Byparr, or both, then replay the returned user-agent and scoped cookies through the bounded URL reader. In dual-provider mode FlareSolverr is always primary and Byparr is attempted only after a busy or transient-unavailable primary. FlareSolverr 3.5.0 and Byparr 2.1.0 were verified on 2026-07-30.
 - **Intelligent Caching**: Both search results and URL content are cached in memory with configurable TTL and least-frequently-used (LFU) eviction, reducing redundant requests.
 - **SSRF Protection**: `web_url_read` blocks private/internal URLs and redirects by default in all transport modes.
-- **HTTP Transport**: Optional Streamable HTTP mode with opt-in hardening — bearer-token auth, CORS allowlist, and rate limiting.
+- **HTTP Transport**: Optional Streamable HTTP mode with opt-in hardening, rate limiting, and bounded stateless compatibility for serverless or horizontally scaled deployments.
 - **HTML Fallback**: Optionally parse results from the HTML page for public instances that reject `format=json`.
 - **Lite Tools Mode**: Minimal tool schemas for local models with small context windows.
 - **Proxy Support**: Global or per-tool HTTP/HTTPS proxies for search and URL-reader traffic.
@@ -333,7 +333,11 @@ The `--add-host` mapping lets the container reach a SearXNG instance on the host
 }
 ```
 
-**Endpoints:** `POST/GET/DELETE /mcp` (MCP protocol), `GET /health` (health check)
+**Endpoints:** `POST/GET/DELETE /mcp` (stateful MCP protocol), `GET /health` (health check)
+
+Stateful sessions remain the default. Set `MCP_HTTP_STATELESS=true` when a deployment cannot preserve in-memory sessions between requests. Every stateless POST creates a fresh MCP server and transport, ignores any incoming session ID, and returns negotiated JSON or an SSE stream within that same POST. Stateless mode is POST-only: `GET /mcp` and `DELETE /mcp` return HTTP 405 with `Allow: POST`, and no cross-request subscriptions, resumability, or server-to-client notifications are preserved.
+
+Stateless requests are bounded by global and per-client-IP in-flight limits plus a request lifetime. See [CONFIGURATION.md](CONFIGURATION.md#http-transport) for defaults, overload and timeout responses, proxy-aware fairness, and the complete compatibility contract.
 
 **Test it:**
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -33,7 +33,7 @@ The primary security surface areas are:
 | Area | Risk |
 |------|------|
 | `web_url_read` tool | SSRF — the server fetches user-supplied URLs on behalf of the AI |
-| HTTP transport | Unauthorized access, DNS rebinding, CORS misconfiguration |
+| HTTP transport | Unauthorized access, DNS rebinding, CORS misconfiguration, resource exhaustion, or unfair shared capacity |
 | Proxy credentials | Credential exposure in environment variables |
 | SearXNG credentials | Credentials in `SEARXNG_URL` userinfo or legacy `AUTH_PASSWORD` fallback |
 | Query forwarding | Search queries are forwarded verbatim to SearXNG |
@@ -158,6 +158,8 @@ Hardened mode protects the MCP protocol endpoint (`/mcp`) with:
 - **Origin allowlist** — `/mcp` requests from unlisted browser origins are rejected
 - **DNS rebinding protection** — the `Host` header is validated against `MCP_HTTP_ALLOWED_HOSTS`. The default allows loopback access on the configured port (`127.0.0.1`, `localhost`, `[::1]` and their `:PORT` forms). A custom list is matched exactly against `Host`: an entry matches only when it carries the same port the client or proxy sends (e.g. `app.example.com:8443`).
 
+With `MCP_HTTP_STATELESS=true`, bearer authorization and the hardened Host and Origin checks run before any per-request MCP server is constructed. Rate limiting also runs before construction, followed by the stateless capacity controls.
+
 `MCP_HTTP_HARDEN=true` will fail to start if `MCP_HTTP_AUTH_TOKEN` or `MCP_HTTP_ALLOWED_ORIGINS` are missing.
 
 `GET /health` intentionally remains unauthenticated so container orchestrators
@@ -179,6 +181,14 @@ MCP_HTTP_HOST=127.0.0.1
 ```
 
 The default bind address is `127.0.0.1` (loopback only); set `MCP_HTTP_HOST=0.0.0.0` to expose the port on all interfaces.
+
+Optional stateless mode isolates each POST in a fresh MCP server and transport. It does not preserve cross-request sessions, subscriptions, resumability, or standalone notification streams. Responses remain confined to negotiated JSON or an SSE stream within the initiating POST; GET and DELETE on `/mcp` are rejected with HTTP 405.
+
+Stateless mode uses global and per-client-IP in-flight caps plus a request lifetime so abandoned or expensive requests cannot occupy unbounded process resources. Saturation is rejected before server construction. These are process-local controls: horizontally scaled deployments enforce the global cap independently in each process.
+
+The per-IP cap uses Express's resolved request IP, just like rate limiting and request diagnostics. Configure `MCP_HTTP_TRUST_PROXY` only for a known proxy topology whose edge strips and sets forwarding headers. Otherwise clients can spoof `X-Forwarded-For`, evade fair per-IP allocation, and influence logs. Application capacity limits complement, but do not replace, reverse-proxy connection limits and infrastructure-level timeouts.
+
+Requests whose client IP cannot be resolved share one fail-closed capacity bucket. This avoids treating missing identity data as a new client on every request, at the cost of shared contention among those unusual connections.
 
 ### TLS and CA Certificates
 
@@ -211,6 +221,7 @@ Use the default STDIO transport. No additional configuration is needed beyond `S
 ```
 MCP_HTTP_HOST=127.0.0.1   # bind to loopback only
 MCP_HTTP_PORT=3000
+# Optional for serverless/process-local isolation: MCP_HTTP_STATELESS=true
 ```
 
 ### Public / Internet-Facing (HTTP)

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -44,6 +44,18 @@ function createTestMcpServer(): McpServer {
   );
 }
 
+function postStatelessMcp(
+  app: Awaited<ReturnType<typeof createHttpServer>>,
+  body: unknown,
+  clientIp?: string,
+) {
+  const pending = request(app).post('/mcp')
+    .set('Content-Type', 'application/json')
+    .set('Accept', 'application/json, text/event-stream');
+  if (clientIp) pending.set('X-Forwarded-For', clientIp);
+  return pending.send(body);
+}
+
 async function captureConsoleOutput(action: () => Promise<void>): Promise<string[]> {
   const originalError = console.error;
   const originalWarn = console.warn;
@@ -433,19 +445,11 @@ async function runTests() {
       const waitForStart = () => new Promise<void>((resolve) => startedResolvers.push(resolve));
 
       const firstStarted = waitForStart();
-      const first = request(app).post('/mcp')
-        .set('X-Forwarded-For', '198.51.100.10')
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json, text/event-stream')
-        .send(callBody);
+      const first = postStatelessMcp(app, callBody, '198.51.100.10');
       const firstResult = first.then(response => response);
       await firstStarted;
 
-      const sameIp = await request(app).post('/mcp')
-        .set('X-Forwarded-For', '198.51.100.10')
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json, text/event-stream')
-        .send(callBody)
+      const sameIp = await postStatelessMcp(app, callBody, '198.51.100.10')
         .timeout({ deadline: 500 });
       assert.equal(sameIp.status, 503);
       assert.equal(sameIp.headers['retry-after'], '1');
@@ -454,19 +458,11 @@ async function runTests() {
       assert.equal(constructions, 1);
 
       const secondStarted = waitForStart();
-      const second = request(app).post('/mcp')
-        .set('X-Forwarded-For', '198.51.100.11')
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json, text/event-stream')
-        .send({ ...callBody, id: 2 });
+      const second = postStatelessMcp(app, { ...callBody, id: 2 }, '198.51.100.11');
       const secondResult = second.then(response => response);
       await secondStarted;
 
-      const global = await request(app).post('/mcp')
-        .set('X-Forwarded-For', '198.51.100.12')
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json, text/event-stream')
-        .send({ ...callBody, id: 3 });
+      const global = await postStatelessMcp(app, { ...callBody, id: 3 }, '198.51.100.12');
       assert.equal(global.status, 503);
       assert.equal(global.headers['retry-after'], '1');
       assert.equal(constructions, 2);
@@ -477,11 +473,11 @@ async function runTests() {
       await new Promise(resolve => setImmediate(resolve));
       assert.equal(closes, 2);
 
-      const afterCleanup = await request(app).post('/mcp')
-        .set('X-Forwarded-For', '198.51.100.10')
-        .set('Content-Type', 'application/json')
-        .set('Accept', 'application/json, text/event-stream')
-        .send({ jsonrpc: '2.0', id: 4, method: 'tools/list', params: {} });
+      const afterCleanup = await postStatelessMcp(
+        app,
+        { jsonrpc: '2.0', id: 4, method: 'tools/list', params: {} },
+        '198.51.100.10',
+      );
       assert.equal(afterCleanup.status, 200);
       assert.equal(constructions, 3);
     } finally {

--- a/__tests__/integration/http-server.test.ts
+++ b/__tests__/integration/http-server.test.ts
@@ -10,7 +10,15 @@ import { strict as assert } from 'node:assert';
 import { fileURLToPath } from 'node:url';
 import request from 'supertest';
 import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
-import { createHttpServer } from '../../src/http-server.js';
+import { CallToolRequestSchema } from '@modelcontextprotocol/sdk/types.js';
+import {
+  DEFAULT_STATELESS_MAX_IN_FLIGHT,
+  DEFAULT_STATELESS_MAX_IN_FLIGHT_PER_IP,
+  DEFAULT_STATELESS_REQUEST_TIMEOUT_MS,
+  MAX_STATELESS_MAX_IN_FLIGHT,
+  createHttpServer,
+  resolveStatelessHttpConfig,
+} from '../../src/http-server.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 import { EnvManager } from '../helpers/env-utils.js';
 import {
@@ -20,6 +28,14 @@ import {
 
 const results = createTestResults();
 const envManager = new EnvManager();
+
+function createDeferred() {
+  let resolve!: () => void;
+  const promise = new Promise<void>((done) => {
+    resolve = done;
+  });
+  return { promise, resolve };
+}
 
 function createTestMcpServer(): McpServer {
   return new McpServer(
@@ -62,6 +78,96 @@ async function captureConsoleOutput(action: () => Promise<void>): Promise<string
 
 async function runTests() {
   console.log('🧪 Integration Testing: http-server.ts\n');
+
+  await testFunction('stateless HTTP configuration defaults are disabled and bounded', async () => {
+    envManager.delete('MCP_HTTP_STATELESS');
+    envManager.delete('MCP_HTTP_STATELESS_MAX_IN_FLIGHT');
+    envManager.delete('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP');
+    envManager.delete('MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS');
+
+    try {
+      assert.deepEqual(resolveStatelessHttpConfig(), {
+        enabled: false,
+        maxInFlight: DEFAULT_STATELESS_MAX_IN_FLIGHT,
+        maxInFlightPerIp: DEFAULT_STATELESS_MAX_IN_FLIGHT_PER_IP,
+        requestTimeoutMs: DEFAULT_STATELESS_REQUEST_TIMEOUT_MS,
+      });
+      assert.equal(DEFAULT_STATELESS_MAX_IN_FLIGHT, 16);
+      assert.equal(DEFAULT_STATELESS_MAX_IN_FLIGHT_PER_IP, 8);
+      assert.equal(DEFAULT_STATELESS_REQUEST_TIMEOUT_MS, 900000);
+      assert.equal(MAX_STATELESS_MAX_IN_FLIGHT, 256);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless HTTP configuration normalizes explicit boundaries in dependency order', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '4');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '8');
+    envManager.set('MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS', '1000');
+
+    try {
+      const output = await captureConsoleOutput(async () => {
+        assert.deepEqual(resolveStatelessHttpConfig(), {
+          enabled: true,
+          maxInFlight: 4,
+          maxInFlightPerIp: 4,
+          requestTimeoutMs: 1000,
+        });
+      });
+      assert.equal(output.filter(line => line.includes('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP')).length, 1);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless HTTP configuration rejects unsafe values without echoing them', async () => {
+    const unsafeGlobal = '999999999999999999999';
+    const unsafeTimeout = 'timeout-secret-value';
+    envManager.set('MCP_HTTP_STATELESS', 'TRUE');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', unsafeGlobal);
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '0');
+    envManager.set('MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS', unsafeTimeout);
+
+    try {
+      const output = await captureConsoleOutput(async () => {
+        assert.deepEqual(resolveStatelessHttpConfig(), {
+          enabled: false,
+          maxInFlight: DEFAULT_STATELESS_MAX_IN_FLIGHT,
+          maxInFlightPerIp: DEFAULT_STATELESS_MAX_IN_FLIGHT_PER_IP,
+          requestTimeoutMs: DEFAULT_STATELESS_REQUEST_TIMEOUT_MS,
+        });
+      });
+      const combined = output.join('\n');
+      assert.equal(output.filter(line => line.includes('Ignoring invalid MCP_HTTP_STATELESS')).length, 4);
+      assert.ok(!combined.includes(unsafeGlobal));
+      assert.ok(!combined.includes(unsafeTimeout));
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless HTTP configuration rejects exact out-of-range boundaries', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '257');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '257');
+    envManager.set('MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS', '999');
+
+    try {
+      const output = await captureConsoleOutput(async () => {
+        assert.deepEqual(resolveStatelessHttpConfig(), {
+          enabled: true,
+          maxInFlight: DEFAULT_STATELESS_MAX_IN_FLIGHT,
+          maxInFlightPerIp: DEFAULT_STATELESS_MAX_IN_FLIGHT_PER_IP,
+          requestTimeoutMs: DEFAULT_STATELESS_REQUEST_TIMEOUT_MS,
+        });
+      });
+      assert.equal(output.filter(line => line.includes('Ignoring invalid MCP_HTTP_STATELESS_')).length, 3);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
 
   await testFunction('default trust proxy setting remains disabled', async () => {
     envManager.delete('MCP_HTTP_TRUST_PROXY');
@@ -179,6 +285,634 @@ async function runTests() {
         allowHeaders.includes(header),
         `Expected '${header}' in Access-Control-Allow-Headers, got: ${allowHeaders}`
       );
+    }
+  }, results);
+
+  await testFunction('stateless POST limiter selection uses the request body and ignores session headers', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_RATE_INIT_MAX', '7');
+    envManager.set('MCP_RATE_SESSION_MAX', '11');
+    envManager.set('MCP_RATE_WINDOW_MS', '60000');
+
+    try {
+      const app = await createHttpServer(() => createTestMcpServer());
+      const initRes = await request(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .set('mcp-session-id', 'stale-session')
+        .send({
+          jsonrpc: '2.0', id: 1, method: 'initialize',
+          params: { protocolVersion: '2024-11-05', capabilities: {},
+            clientInfo: { name: 'stateless-client', version: '1.0.0' } }
+        });
+      assert.equal(initRes.status, 200);
+      assert.equal(initRes.headers['ratelimit-limit'], '7');
+      assert.equal(initRes.headers['mcp-session-id'], undefined);
+
+      const listRes = await request(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .set('mcp-session-id', 'stale-session')
+        .send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+      assert.equal(listRes.status, 200);
+      assert.equal(listRes.headers['ratelimit-limit'], '11');
+
+      const batchRes = await request(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send([{ jsonrpc: '2.0', id: 3, method: 'initialize', params: {} }]);
+      assert.equal(batchRes.headers['ratelimit-limit'], '11');
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless hardened Host and Origin checks reject before server construction', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_HARDEN', 'true');
+    envManager.set('MCP_HTTP_AUTH_TOKEN', 'secret-token');
+    envManager.set('MCP_HTTP_ALLOWED_ORIGINS', 'https://allowed.example.com');
+    envManager.set('MCP_HTTP_ALLOWED_HOSTS', 'allowed.example.com');
+    let constructions = 0;
+
+    try {
+      const app = await createHttpServer(() => {
+        constructions += 1;
+        return createTestMcpServer();
+      });
+      const body = {
+        jsonrpc: '2.0', id: 1, method: 'initialize',
+        params: { protocolVersion: '2024-11-05', capabilities: {},
+          clientInfo: { name: 'security-client', version: '1.0.0' } }
+      };
+
+      const hostRes = await request(app)
+        .post('/mcp')
+        .set('Host', 'blocked.example.com')
+        .set('Origin', 'https://allowed.example.com')
+        .set('Authorization', 'Bearer secret-token')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send(body);
+      assert.equal(hostRes.status, 403);
+      assert.equal(constructions, 0);
+
+      const originRes = await request(app)
+        .post('/mcp')
+        .set('Host', 'allowed.example.com')
+        .set('Origin', 'https://blocked.example.com')
+        .set('Authorization', 'Bearer secret-token')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send(body);
+      assert.equal(originRes.status, 403);
+      assert.equal(constructions, 0);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless malformed and oversized JSON stop before server construction', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    let constructions = 0;
+
+    try {
+      const app = await createHttpServer(() => {
+        constructions += 1;
+        return createTestMcpServer();
+      });
+      const malformed = await request(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .send('{"jsonrpc":"2.0"');
+      assert.ok(malformed.status >= 400);
+      assert.equal(constructions, 0);
+
+      const oversized = await request(app)
+        .post('/mcp')
+        .set('Content-Type', 'application/json')
+        .send({ payload: 'x'.repeat(101 * 1024) });
+      assert.ok(oversized.status >= 400);
+      assert.equal(constructions, 0);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless capacity enforces per-IP and global bounds without constructing rejected requests', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '2');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '1');
+    envManager.set('MCP_HTTP_TRUST_PROXY', '1');
+    envManager.set('MCP_RATE_SESSION_MAX', '20');
+    const release = createDeferred();
+    const startedResolvers: Array<() => void> = [];
+    let constructions = 0;
+    let closes = 0;
+
+    try {
+      const app = await createHttpServer(() => {
+        constructions += 1;
+        const server = createTestMcpServer();
+        const originalClose = server.close.bind(server);
+        server.close = async () => {
+          closes += 1;
+          await originalClose();
+        };
+        server.server.setRequestHandler(CallToolRequestSchema, async () => {
+          startedResolvers.shift()?.();
+          await release.promise;
+          return { content: [{ type: 'text', text: 'released' }] };
+        });
+        return server;
+      });
+      const callBody = { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'hold', arguments: {} } };
+      const waitForStart = () => new Promise<void>((resolve) => startedResolvers.push(resolve));
+
+      const firstStarted = waitForStart();
+      const first = request(app).post('/mcp')
+        .set('X-Forwarded-For', '198.51.100.10')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send(callBody);
+      const firstResult = first.then(response => response);
+      await firstStarted;
+
+      const sameIp = await request(app).post('/mcp')
+        .set('X-Forwarded-For', '198.51.100.10')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send(callBody)
+        .timeout({ deadline: 500 });
+      assert.equal(sameIp.status, 503);
+      assert.equal(sameIp.headers['retry-after'], '1');
+      assert.equal(sameIp.body.error.code, -32000);
+      assert.equal(sameIp.body.error.message, 'Server busy');
+      assert.equal(constructions, 1);
+
+      const secondStarted = waitForStart();
+      const second = request(app).post('/mcp')
+        .set('X-Forwarded-For', '198.51.100.11')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ ...callBody, id: 2 });
+      const secondResult = second.then(response => response);
+      await secondStarted;
+
+      const global = await request(app).post('/mcp')
+        .set('X-Forwarded-For', '198.51.100.12')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ ...callBody, id: 3 });
+      assert.equal(global.status, 503);
+      assert.equal(global.headers['retry-after'], '1');
+      assert.equal(constructions, 2);
+
+      release.resolve();
+      assert.equal((await firstResult).status, 200);
+      assert.equal((await secondResult).status, 200);
+      await new Promise(resolve => setImmediate(resolve));
+      assert.equal(closes, 2);
+
+      const afterCleanup = await request(app).post('/mcp')
+        .set('X-Forwarded-For', '198.51.100.10')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 4, method: 'tools/list', params: {} });
+      assert.equal(afterCleanup.status, 200);
+      assert.equal(constructions, 3);
+    } finally {
+      release.resolve();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless capacity rejections consume the selected rate-limit bucket', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '1');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '1');
+    envManager.set('MCP_RATE_SESSION_MAX', '2');
+    const release = createDeferred();
+    const started = createDeferred();
+
+    try {
+      const app = await createHttpServer(() => {
+        const server = createTestMcpServer();
+        server.server.setRequestHandler(CallToolRequestSchema, async () => {
+          started.resolve();
+          await release.promise;
+          return { content: [{ type: 'text', text: 'released' }] };
+        });
+        return server;
+      });
+      const body = { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'hold', arguments: {} } };
+      const firstResult = request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send(body)
+        .then(response => response);
+      await started.promise;
+
+      const busy = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ ...body, id: 2 });
+      assert.equal(busy.status, 503);
+
+      const rateLimited = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ ...body, id: 3 });
+      assert.equal(rateLimited.status, 429);
+      assert.equal(rateLimited.body.error.code, -32029);
+
+      release.resolve();
+      assert.equal((await firstResult).status, 200);
+    } finally {
+      release.resolve();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless capacity warnings aggregate to one per minute per process', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '1');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '1');
+    envManager.set('MCP_RATE_SESSION_MAX', '10');
+    const release = createDeferred();
+    const started = createDeferred();
+
+    try {
+      const app = await createHttpServer(() => {
+        const server = createTestMcpServer();
+        server.server.setRequestHandler(CallToolRequestSchema, async () => {
+          started.resolve();
+          await release.promise;
+          return { content: [{ type: 'text', text: 'released' }] };
+        });
+        return server;
+      });
+      const body = { jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'hold', arguments: {} } };
+      const firstResult = request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send(body)
+        .then(response => response);
+      await started.promise;
+
+      const output = await captureConsoleOutput(async () => {
+        for (let id = 2; id <= 4; id += 1) {
+          const busy = await request(app).post('/mcp')
+            .set('Content-Type', 'application/json')
+            .set('Accept', 'application/json, text/event-stream')
+            .send({ ...body, id });
+          assert.equal(busy.status, 503);
+        }
+      });
+      assert.equal(output.filter(line => line.includes('Stateless HTTP capacity exhausted')).length, 1);
+
+      release.resolve();
+      assert.equal((await firstResult).status, 200);
+    } finally {
+      release.resolve();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless request timeout returns the exact 504 contract and restores capacity', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '1');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '1');
+    envManager.set('MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS', '1000');
+    const never = new Promise<void>(() => undefined);
+    let constructions = 0;
+
+    try {
+      const app = await createHttpServer(() => {
+        constructions += 1;
+        const server = createTestMcpServer();
+        if (constructions === 1) {
+          server.connect = async () => {
+            await never;
+          };
+        }
+        return server;
+      });
+      const timedOut = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'hold', arguments: {} } })
+        .timeout({ deadline: 2000 });
+      assert.equal(timedOut.status, 504);
+      assert.equal(timedOut.headers['retry-after'], undefined);
+      assert.deepEqual(timedOut.body, {
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Stateless request timed out' },
+        id: null,
+      });
+
+      const afterTimeout = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+      assert.equal(afterTimeout.status, 200);
+      assert.equal(constructions, 2);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless lifetime includes synchronous server construction time', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '1');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '1');
+    envManager.set('MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS', '1000');
+    let constructions = 0;
+
+    try {
+      const app = await createHttpServer(() => {
+        constructions += 1;
+        if (constructions === 1) {
+          Atomics.wait(new Int32Array(new SharedArrayBuffer(4)), 0, 0, 1050);
+        }
+        return createTestMcpServer();
+      });
+      const timedOut = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+      assert.equal(timedOut.status, 504);
+      assert.equal(timedOut.body.error.message, 'Stateless request timed out');
+
+      const recovered = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+      assert.equal(recovered.status, 200);
+      assert.equal(constructions, 2);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless timeout closes an already-started POST stream and restores capacity', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '1');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '1');
+    envManager.set('MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS', '1000');
+    let constructions = 0;
+    let abortObserved = false;
+    let closes = 0;
+
+    try {
+      const app = await createHttpServer(() => {
+        constructions += 1;
+        const server = createTestMcpServer();
+        if (constructions === 1) {
+          const originalClose = server.close.bind(server);
+          server.close = async () => {
+            closes += 1;
+            await originalClose();
+          };
+          server.server.setRequestHandler(CallToolRequestSchema, async (_request, extra) => {
+            await new Promise<void>((resolve) => {
+              if (extra.signal.aborted) {
+                abortObserved = true;
+                resolve();
+                return;
+              }
+              extra.signal.addEventListener('abort', () => {
+                abortObserved = true;
+                resolve();
+              }, { once: true });
+            });
+            return { content: [{ type: 'text', text: 'aborted' }] };
+          });
+        }
+        return server;
+      });
+      let streamError = '';
+      try {
+        await request(app).post('/mcp')
+          .set('Content-Type', 'application/json')
+          .set('Accept', 'application/json, text/event-stream')
+          .send({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'hold', arguments: {} } })
+          .timeout({ deadline: 2000 });
+      } catch (error) {
+        streamError = error instanceof Error ? error.message : String(error);
+      }
+      assert.match(streamError, /aborted|socket hang up/i);
+      await new Promise(resolve => setTimeout(resolve, 50));
+      assert.equal(abortObserved, true);
+      assert.equal(closes, 1);
+
+      const afterTimeout = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+      assert.equal(afterTimeout.status, 200);
+      assert.equal(constructions, 2);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless construction failures restore capacity', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '1');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '1');
+    let constructions = 0;
+
+    try {
+      const app = await createHttpServer(() => {
+        constructions += 1;
+        if (constructions === 1) throw new Error('controlled construction failure');
+        return createTestMcpServer();
+      });
+      const failed = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+      assert.equal(failed.status, 500);
+
+      const recovered = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+      assert.equal(recovered.status, 200);
+      assert.equal(constructions, 2);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless cleanup wait is bounded and reclaims capacity exactly once', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '1');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '1');
+    envManager.set('MCP_RATE_SESSION_MAX', '20');
+    const closeStarted = createDeferred();
+    const never = new Promise<void>(() => undefined);
+    let constructions = 0;
+    let closeAttempts = 0;
+
+    try {
+      const app = await createHttpServer(() => {
+        constructions += 1;
+        const server = createTestMcpServer();
+        if (constructions === 1) {
+          server.close = async () => {
+            closeAttempts += 1;
+            closeStarted.resolve();
+            await never;
+          };
+        }
+        return server;
+      });
+      const first = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 1, method: 'tools/list', params: {} });
+      assert.equal(first.status, 200);
+      await closeStarted.promise;
+
+      const busy = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+      assert.equal(busy.status, 503);
+      await new Promise(resolve => setTimeout(resolve, 5300));
+
+      const recovered = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 3, method: 'tools/list', params: {} });
+      assert.equal(recovered.status, 200);
+      assert.equal(constructions, 2);
+      assert.equal(closeAttempts, 1);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless client disconnect aborts handler work and restores capacity', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT', '1');
+    envManager.set('MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP', '1');
+    const handlerStarted = createDeferred();
+    const handlerAborted = createDeferred();
+    let constructions = 0;
+    let closes = 0;
+
+    try {
+      const app = await createHttpServer(() => {
+        constructions += 1;
+        const server = createTestMcpServer();
+        if (constructions === 1) {
+          const originalClose = server.close.bind(server);
+          server.close = async () => {
+            closes += 1;
+            await originalClose();
+          };
+          server.server.setRequestHandler(CallToolRequestSchema, async (_request, extra) => {
+            handlerStarted.resolve();
+            await new Promise<void>((resolve) => {
+              extra.signal.addEventListener('abort', () => {
+                handlerAborted.resolve();
+                resolve();
+              }, { once: true });
+            });
+            return { content: [{ type: 'text', text: 'aborted' }] };
+          });
+        }
+        return server;
+      });
+      const pending = request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 1, method: 'tools/call', params: { name: 'hold', arguments: {} } });
+      const pendingResult = pending.then(
+        response => response,
+        error => error,
+      );
+      await handlerStarted.promise;
+      pending.abort();
+      await handlerAborted.promise;
+      await pendingResult;
+      await new Promise(resolve => setTimeout(resolve, 50));
+
+      const recovered = await request(app).post('/mcp')
+        .set('Content-Type', 'application/json')
+        .set('Accept', 'application/json, text/event-stream')
+        .send({ jsonrpc: '2.0', id: 2, method: 'tools/list', params: {} });
+      assert.equal(recovered.status, 200);
+      assert.equal(constructions, 2);
+      assert.equal(closes, 1);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless GET and DELETE keep the session limiter and return the exact 405 contract', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_RATE_SESSION_MAX', '2');
+    envManager.set('MCP_RATE_WINDOW_MS', '60000');
+
+    try {
+      const app = await createHttpServer(() => createTestMcpServer());
+      for (const method of ['get', 'delete'] as const) {
+        const res = await request(app)[method]('/mcp');
+        assert.equal(res.status, 405);
+        assert.equal(res.headers.allow, 'POST');
+        assert.equal(res.headers['ratelimit-limit'], '2');
+        assert.deepEqual(res.body, {
+          jsonrpc: '2.0',
+          error: { code: -32000, message: 'Method not allowed' },
+          id: null,
+        });
+      }
+
+      const blocked = await request(app).get('/mcp');
+      assert.equal(blocked.status, 429);
+      assert.equal(blocked.body.error.code, -32029);
+    } finally {
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('stateless GET rejects unauthorized and invalid hardened headers before 405', async () => {
+    envManager.set('MCP_HTTP_STATELESS', 'true');
+    envManager.set('MCP_HTTP_HARDEN', 'true');
+    envManager.set('MCP_HTTP_AUTH_TOKEN', 'secret-token');
+    envManager.set('MCP_HTTP_ALLOWED_ORIGINS', 'https://allowed.example.com');
+    envManager.set('MCP_HTTP_ALLOWED_HOSTS', 'allowed.example.com');
+
+    try {
+      const app = await createHttpServer(() => createTestMcpServer());
+      const unauthorized = await request(app)
+        .get('/mcp')
+        .set('Host', 'allowed.example.com')
+        .set('Origin', 'https://allowed.example.com');
+      assert.equal(unauthorized.status, 401);
+
+      const invalidHost = await request(app)
+        .get('/mcp')
+        .set('Host', 'blocked.example.com')
+        .set('Origin', 'https://allowed.example.com')
+        .set('Authorization', 'Bearer secret-token');
+      assert.equal(invalidHost.status, 403);
+
+      const invalidOrigin = await request(app)
+        .delete('/mcp')
+        .set('Host', 'allowed.example.com')
+        .set('Origin', 'https://blocked.example.com')
+        .set('Authorization', 'Bearer secret-token');
+      assert.equal(invalidOrigin.status, 403);
+    } finally {
+      envManager.restore();
     }
   }, results);
 

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -27,6 +27,12 @@ import {
   MAX_FLARESOLVERR_TIMEOUT_MS,
 } from '../../src/browser-solver.js';
 import { LITE_READ_URL_TOOL, READ_URL_TOOL } from '../../src/types.js';
+import {
+  DEFAULT_STATELESS_MAX_IN_FLIGHT,
+  DEFAULT_STATELESS_MAX_IN_FLIGHT_PER_IP,
+  DEFAULT_STATELESS_REQUEST_TIMEOUT_MS,
+  MAX_STATELESS_MAX_IN_FLIGHT,
+} from '../../src/http-server.js';
 import { createTestResults, printTestSummary, TestResult, testFunction } from '../helpers/test-utils.js';
 
 const results = createTestResults();
@@ -485,6 +491,45 @@ export async function runTests(): Promise<TestResult> {
     assert.ok(configuration.includes('also applies when `SEARXNG_LITE_TOOLS=true`'));
     assert.ok(configuration.includes('callers that send `response_format` explicitly still override'));
     assert.ok(configuration.includes('"SEARXNG_DEFAULT_RESPONSE_FORMAT": "text"'));
+  }, results);
+
+  await testFunction('public docs define the optional stateless HTTP contract and fixed defaults', () => {
+    const readme = readText(new URL('../../README.md', import.meta.url));
+    const configuration = readText(new URL('../../CONFIGURATION.md', import.meta.url));
+    const security = readText(new URL('../../SECURITY.md', import.meta.url));
+
+    assert.equal(DEFAULT_STATELESS_MAX_IN_FLIGHT, 16);
+    assert.equal(DEFAULT_STATELESS_MAX_IN_FLIGHT_PER_IP, 8);
+    assert.equal(DEFAULT_STATELESS_REQUEST_TIMEOUT_MS, 900000);
+    assert.equal(MAX_STATELESS_MAX_IN_FLIGHT, 256);
+
+    for (const document of [readme, configuration, security]) {
+      assert.ok(document.includes('`MCP_HTTP_STATELESS=true`'));
+    }
+    assert.ok(readme.includes('Stateless mode is POST-only'));
+    assert.ok(readme.includes('Every stateless POST creates a fresh MCP server and transport'));
+
+    for (const variable of [
+      'MCP_HTTP_STATELESS',
+      'MCP_HTTP_STATELESS_MAX_IN_FLIGHT',
+      'MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP',
+      'MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS',
+    ]) {
+      assert.ok(configuration.includes(`\`${variable}\``), `configuration must define ${variable}`);
+      assert.ok(configuration.includes(`"${variable}"`), `combined example must include ${variable}`);
+    }
+    assert.ok(configuration.includes('`16` (range `1`-`256`)'));
+    assert.ok(configuration.includes('`8` (range `1`-global cap)'));
+    assert.ok(configuration.includes('`900000` (range `1000`-`2147483647`)'));
+    assert.ok(configuration.includes('HTTP 503'));
+    assert.ok(configuration.includes('HTTP 504'));
+    assert.ok(configuration.includes('negotiated JSON or an SSE stream within that same POST'));
+    assert.ok(configuration.includes('Requests whose client IP cannot be resolved share one fail-closed capacity bucket'));
+
+    assert.ok(security.includes('does not preserve cross-request sessions'));
+    assert.ok(security.includes('global and per-client-IP in-flight caps'));
+    assert.ok(security.includes('clients can spoof `X-Forwarded-For`'));
+    assert.ok(security.includes('Requests whose client IP cannot be resolved share one fail-closed capacity bucket'));
   }, results);
 
   await testFunction('public documentation states current security, privacy, and configuration contracts', () => {

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -26,6 +26,22 @@ interface Session {
   mcpServer: McpServer;
 }
 
+export const DEFAULT_STATELESS_MAX_IN_FLIGHT = 16;
+export const DEFAULT_STATELESS_MAX_IN_FLIGHT_PER_IP = 8;
+export const DEFAULT_STATELESS_REQUEST_TIMEOUT_MS = 900000;
+export const MAX_STATELESS_MAX_IN_FLIGHT = 256;
+const MIN_STATELESS_REQUEST_TIMEOUT_MS = 1000;
+const MAX_STATELESS_REQUEST_TIMEOUT_MS = 2147483647;
+const STATELESS_CLEANUP_DEADLINE_MS = 5000;
+const STATELESS_WARNING_INTERVAL_MS = 60000;
+
+export interface StatelessHttpConfig {
+  enabled: boolean;
+  maxInFlight: number;
+  maxInFlightPerIp: number;
+  requestTimeoutMs: number;
+}
+
 function warnDiagnostic(message: string, data?: unknown): void {
   if (data === undefined) {
     writeDiagnostic("warn", sanitizeDiagnosticText(message));
@@ -73,6 +89,71 @@ export function parseRateLimitEnv(name: string, fallback: number): number {
   return parsed;
 }
 
+function parseBoundedStatelessEnv(
+  name: string,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): number {
+  const raw = process.env[name];
+  if (raw === undefined || raw.trim() === "") {
+    return fallback;
+  }
+  const parsed = parseStrictInteger(raw);
+  if (parsed === undefined || parsed < minimum || parsed > maximum) {
+    warnDiagnostic(
+      `⚠️  Ignoring invalid ${name}. Expected an integer from ${minimum} through ${maximum}. Using default ${fallback}.`,
+    );
+    return fallback;
+  }
+  return parsed;
+}
+
+function resolveStatelessEnabled(): boolean {
+  const raw = process.env.MCP_HTTP_STATELESS;
+  const value = raw?.trim();
+  if (!value || value === "false") return false;
+  if (value === "true") return true;
+  warnDiagnostic(
+    "⚠️  Ignoring invalid MCP_HTTP_STATELESS. Expected true or false. Using false.",
+  );
+  return false;
+}
+
+export function resolveStatelessHttpConfig(): StatelessHttpConfig {
+  const maxInFlight = parseBoundedStatelessEnv(
+    "MCP_HTTP_STATELESS_MAX_IN_FLIGHT",
+    DEFAULT_STATELESS_MAX_IN_FLIGHT,
+    1,
+    MAX_STATELESS_MAX_IN_FLIGHT,
+  );
+  const requestedPerIp = parseBoundedStatelessEnv(
+    "MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP",
+    DEFAULT_STATELESS_MAX_IN_FLIGHT_PER_IP,
+    1,
+    MAX_STATELESS_MAX_IN_FLIGHT,
+  );
+  const maxInFlightPerIp = Math.min(requestedPerIp, maxInFlight);
+  if (requestedPerIp > maxInFlight) {
+    warnDiagnostic(
+      `⚠️  Ignoring invalid MCP_HTTP_STATELESS_MAX_IN_FLIGHT_PER_IP. Expected a value no greater than MCP_HTTP_STATELESS_MAX_IN_FLIGHT. Using ${maxInFlight}.`,
+    );
+  }
+  const requestTimeoutMs = parseBoundedStatelessEnv(
+    "MCP_HTTP_STATELESS_REQUEST_TIMEOUT_MS",
+    DEFAULT_STATELESS_REQUEST_TIMEOUT_MS,
+    MIN_STATELESS_REQUEST_TIMEOUT_MS,
+    MAX_STATELESS_REQUEST_TIMEOUT_MS,
+  );
+
+  return {
+    enabled: resolveStatelessEnabled(),
+    maxInFlight,
+    maxInFlightPerIp,
+    requestTimeoutMs,
+  };
+}
+
 function makeRateLimiters() {
   const windowMs = parseRateLimitEnv("MCP_RATE_WINDOW_MS", 60000);
 
@@ -116,6 +197,7 @@ export async function createHttpServer(
 ): Promise<express.Application> {
   const app = express();
   const security = getHttpSecurityConfig(port);
+  const stateless = resolveStatelessHttpConfig();
   validateHttpSecurityConfig(security);
   if (security.trustProxy !== false) {
     app.set('trust proxy', security.trustProxy);
@@ -145,6 +227,34 @@ export async function createHttpServer(
       },
       id: null,
     });
+  }
+
+  function rejectInvalidStatelessHeaders(
+    req: express.Request,
+    res: express.Response,
+  ): boolean {
+    if (!security.enableDnsRebindingProtection) {
+      return false;
+    }
+    const host = req.headers.host;
+    if (security.allowedHosts.length > 0 && (!host || !security.allowedHosts.includes(host))) {
+      res.status(403).json({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: `Invalid Host header: ${host}` },
+        id: null,
+      });
+      return true;
+    }
+    const origin = req.headers.origin;
+    if (origin && !isOriginAllowed(origin, security)) {
+      res.status(403).json({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: `Invalid Origin header: ${origin}` },
+        id: null,
+      });
+      return true;
+    }
+    return false;
   }
 
   function rejectInvalidPost(
@@ -196,8 +306,73 @@ export async function createHttpServer(
 
   // Map to store sessions by session ID
   const sessions = new Map<string, Session>();
+  let statelessInFlight = 0;
+  const statelessInFlightByIp = new Map<string, number>();
+  let lastCapacityWarningAt = 0;
+  let suppressedCapacityWarnings = 0;
+
+  function resolvedClientIp(req: express.Request): string {
+    return req.ip || req.socket.remoteAddress || "unknown";
+  }
+
+  function warnStatelessCapacity(reason: "per-ip" | "global"): void {
+    const now = Date.now();
+    if (now - lastCapacityWarningAt < STATELESS_WARNING_INTERVAL_MS) {
+      suppressedCapacityWarnings += 1;
+      return;
+    }
+    warnDiagnostic("⚠️  Stateless HTTP capacity exhausted.", {
+      reason,
+      inFlight: statelessInFlight,
+      maxInFlight: stateless.maxInFlight,
+      suppressedSinceLastWarning: suppressedCapacityWarnings,
+    });
+    lastCapacityWarningAt = now;
+    suppressedCapacityWarnings = 0;
+  }
+
+  function admitStatelessRequest(
+    req: express.Request,
+    res: express.Response,
+  ): (() => void) | undefined {
+    const clientIp = resolvedClientIp(req);
+    const clientInFlight = statelessInFlightByIp.get(clientIp) ?? 0;
+    const reason = clientInFlight >= stateless.maxInFlightPerIp
+      ? "per-ip"
+      : statelessInFlight >= stateless.maxInFlight
+        ? "global"
+        : undefined;
+    if (reason) {
+      warnStatelessCapacity(reason);
+      res.set("Retry-After", "1").status(503).json({
+        jsonrpc: "2.0",
+        error: { code: -32000, message: "Server busy" },
+        id: null,
+      });
+      return undefined;
+    }
+
+    statelessInFlight += 1;
+    statelessInFlightByIp.set(clientIp, clientInFlight + 1);
+    let released = false;
+    return () => {
+      if (released) return;
+      released = true;
+      statelessInFlight -= 1;
+      const remaining = (statelessInFlightByIp.get(clientIp) ?? 1) - 1;
+      if (remaining <= 0) statelessInFlightByIp.delete(clientIp);
+      else statelessInFlightByIp.set(clientIp, remaining);
+    };
+  }
 
   const postRateLimiter: express.RequestHandler = (req, res, next) => {
+    if (stateless.enabled) {
+      const selectedLimiter = isInitializeRequest(req.body)
+        ? initLimiter
+        : sessionLimiter;
+      selectedLimiter(req, res, next);
+      return;
+    }
     const sessionId = req.headers['mcp-session-id'];
     // Node comma-joins duplicate custom headers. Only one exact live session ID
     // selects the generous bucket; every other value stays initialization-limited.
@@ -211,6 +386,103 @@ export async function createHttpServer(
   app.post('/mcp', postRateLimiter, async (req, res) => {
     if (!isRequestAuthorized(req.headers.authorization as string | undefined, security)) {
       rejectUnauthorized(res);
+      return;
+    }
+
+    if (stateless.enabled) {
+      if (rejectInvalidStatelessHeaders(req, res)) {
+        return;
+      }
+      const releaseCapacity = admitStatelessRequest(req, res);
+      if (!releaseCapacity) return;
+
+      let mcpServer: McpServer | undefined;
+      let transport: StreamableHTTPServerTransport | undefined;
+      let requestTimer: NodeJS.Timeout | undefined;
+      let cleanupPromise: Promise<void> | undefined;
+      let requestTimedOut = false;
+      const requestDeadline = Date.now() + stateless.requestTimeoutMs;
+      const cleanup = (): Promise<void> => {
+        if (cleanupPromise) return cleanupPromise;
+        cleanupPromise = (async () => {
+          if (requestTimer) clearTimeout(requestTimer);
+          const closeResources = async () => {
+            const errors: unknown[] = [];
+            try {
+              await transport?.close();
+            } catch (error) {
+              errors.push(error);
+            }
+            try {
+              await mcpServer?.close();
+            } catch (error) {
+              errors.push(error);
+            }
+            if (errors.length) throw new AggregateError(errors, "Stateless resource cleanup failed");
+          };
+          let cleanupDeadline: NodeJS.Timeout | undefined;
+          try {
+            await Promise.race([
+              closeResources(),
+              new Promise<never>((_resolve, reject) => {
+                cleanupDeadline = setTimeout(
+                  () => reject(new Error("Stateless resource cleanup timed out")),
+                  STATELESS_CLEANUP_DEADLINE_MS,
+                );
+                cleanupDeadline.unref();
+              }),
+            ]);
+          } catch (error) {
+            warnDiagnostic("⚠️  Stateless HTTP cleanup did not complete normally.", error);
+          } finally {
+            if (cleanupDeadline) clearTimeout(cleanupDeadline);
+            releaseCapacity();
+          }
+        })();
+        return cleanupPromise;
+      };
+      const handleStatelessTimeout = (): void => {
+        if (requestTimedOut) return;
+        requestTimedOut = true;
+        warnDiagnostic("⚠️  Stateless HTTP request reached its lifetime limit.", {
+          timeoutMs: stateless.requestTimeoutMs,
+        });
+        if (!res.headersSent && !res.destroyed) {
+          res.status(504).json({
+            jsonrpc: "2.0",
+            error: { code: -32000, message: "Stateless request timed out" },
+            id: null,
+          });
+        } else if (!res.destroyed) {
+          res.destroy();
+        }
+        void cleanup();
+      };
+      res.once('close', () => {
+        void cleanup();
+      });
+      requestTimer = setTimeout(handleStatelessTimeout, stateless.requestTimeoutMs);
+      requestTimer.unref();
+      try {
+        mcpServer = createMcpServer();
+        transport = new StreamableHTTPServerTransport({
+          sessionIdGenerator: undefined,
+          enableDnsRebindingProtection: security.enableDnsRebindingProtection,
+          allowedHosts: security.allowedHosts,
+          allowedOrigins: security.allowedOrigins,
+        });
+        if (Date.now() >= requestDeadline) {
+          handleStatelessTimeout();
+          await cleanup();
+          return;
+        }
+        await mcpServer.connect(transport);
+        await handleTransportRequest(transport, req, res);
+      } catch (error) {
+        await cleanup();
+        if (requestTimedOut) return;
+        throw error;
+      }
       return;
     }
 
@@ -263,6 +535,18 @@ export async function createHttpServer(
       return;
     }
 
+    if (stateless.enabled) {
+      if (rejectInvalidStatelessHeaders(req, res)) {
+        return;
+      }
+      res.set('Allow', 'POST').status(405).json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Method not allowed' },
+        id: null,
+      });
+      return;
+    }
+
     const sessionId = req.headers['mcp-session-id'] as string | undefined;
     if (!sessionId || !sessions.has(sessionId)) {
       warnDiagnostic(`⚠️  GET request rejected - missing or invalid session ID:`, {
@@ -291,6 +575,18 @@ export async function createHttpServer(
   app.delete('/mcp', sessionLimiter, async (req, res) => {
     if (!isRequestAuthorized(req.headers.authorization as string | undefined, security)) {
       rejectUnauthorized(res);
+      return;
+    }
+
+    if (stateless.enabled) {
+      if (rejectInvalidStatelessHeaders(req, res)) {
+        return;
+      }
+      res.set('Allow', 'POST').status(405).json({
+        jsonrpc: '2.0',
+        error: { code: -32000, message: 'Method not allowed' },
+        id: null,
+      });
       return;
     }
 

--- a/src/http-server.ts
+++ b/src/http-server.ts
@@ -458,9 +458,11 @@ export async function createHttpServer(
         }
         void cleanup();
       };
-      res.once('close', () => {
+      const cleanupAfterResponse = () => {
         void cleanup();
-      });
+      };
+      res.once('finish', cleanupAfterResponse);
+      res.once('close', cleanupAfterResponse);
       requestTimer = setTimeout(handleStatelessTimeout, stateless.requestTimeoutMs);
       requestTimer.unref();
       try {


### PR DESCRIPTION
## Summary
- add opt-in `MCP_HTTP_STATELESS=true` Streamable HTTP handling with one isolated MCP server and transport per POST
- bound admitted requests with validated global/per-IP capacity and request-lifetime controls while preserving hardened checks and rate-limit ordering
- keep stateful HTTP as the default, return POST-only method contracts in stateless mode, and document configuration, security, overload, timeout, and session limitations

## Testing
- `npm run test:coverage` — 692 passed, 0 failed; 94.68% lines, 91.63% branches (Node 24.18.0)
- `npm run lint`
- `npm run build`
- `npm run test:e2e` — 17 passed, 0 failed
- `npm run audit:deps` — 0 vulnerabilities
- `git diff --check`

Related to #173