### PR TITLE
security(deps): refresh vulnerable brace-expansion lockfile

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1371,9 +1371,9 @@
             "license": "ISC"
         },
         "node_modules/brace-expansion": {
-            "version": "5.0.8",
-            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.8.tgz",
-            "integrity": "sha512-JZyDyq3D4AUifKTPOB7DELf6XsB3WdPuNxCtob1vFXPsSXhdAiHBWJ/tJ8HAc9aH84BK+5JFZLNkJKx3G9kzQg==",
+            "version": "5.0.9",
+            "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-5.0.9.tgz",
+            "integrity": "sha512-ScQ4IuvIEF1TMlP7Zt+vjJ//9zlPb2SDcxWxM3bk8s6t6GGdJ7KO1dCcTidOPJKePW30LE/2cT7wCyPho9/Wxg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {


### PR DESCRIPTION
## Summary
- refresh the dev-only `brace-expansion` lock resolution from 5.0.8 to patched 5.0.9
- clear GHSA-rgw5-rvv9-x895 without adding a direct dependency or override
- retain the existing ESLint/minimatch parent versions and production dependency tree

## Verification
- `npm ci`
- default and production-only `npm audit --audit-level=moderate` — 0 vulnerabilities
- build and lint
- coverage — 692/692 tests, 94.69% lines, 91.63% branches
- local E2E — 24/24 runnable cases
- packed-consumer verification — audit 0, 4 tools