### PR TITLE
feat(ci): test and publish on Node 24 LTS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,10 @@ jobs:
   test:
     name: Lint, Build, and Test
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '24']
 
     steps:
       - name: Checkout code
@@ -24,7 +28,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
 
       - name: Install dependencies

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -20,15 +20,15 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
 
       # ──────────────────────────────────────────────────────────────────────
       # ⚠️  DO NOT REMOVE / DO NOT "SIMPLIFY" THIS STEP. It is load-bearing.
       #
       # Tokenless OIDC "trusted publishing" (used below — `npm publish --provenance`
-      # with NO NODE_AUTH_TOKEN) requires npm >= 11.5.1, but the GitHub-hosted
-      # Node 20 runner ships npm ~10. Without this upgrade the publish fails with:
+      # with NO NODE_AUTH_TOKEN) requires npm >= 11.5.1.
+      # GitHub-hosted runner images may bundle a different npm version. Without this exact pin the publish fails with:
       #     npm error 404  'mcp-searxng@<version>' is not in this registry
       # This exact regression shipped in v1.6.0 — see SEC-015 in TODO-done.md.
       #
@@ -82,7 +82,7 @@ jobs:
       - name: Setup Node.js
         uses: actions/setup-node@820762786026740c76f36085b0efc47a31fe5020 # v7.0.0
         with:
-          node-version: '20'
+          node-version: '24'
           registry-url: 'https://registry.npmjs.org/'
 
       - name: Install and verify mcp-publisher


### PR DESCRIPTION
## Summary

- test the declared Node 20 minimum and maintained Node 24 LTS in CI with independent matrix results
- run both tag-triggered publishing jobs on Node 24
- preserve the exact npm 11.17.0 trusted-publishing pin and the Node 20 package floor

Reimplements the useful maintained-runtime scope from #175 against current main; the contributor branch was not modified.

## Testing

- Node 20.20.2 / npm 11.17.0: lint, build, 704/704 tests, 96.10% line and 92.00% branch coverage, 26/26 E2E, packed consumer
- Node 24.19.0 / npm 11.17.0: lint, build, 704/704 tests, 94.75% line and 91.98% branch coverage, 26/26 E2E, packed consumer
- exact workflow contract, diff check, conflict scan, and secret preflight