### PR TITLE
feat(search): bound SearXNG response bodies

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -43,8 +43,13 @@ Percent-encode special characters in usernames or passwords before placing them 
 
 | Variable | Required | Default | Description |
 |---|---|---|---|
-| `SEARXNG_TIMEOUT_MS` | No | `10000` | Maximum time in milliseconds to wait for a SearXNG search response. The request is aborted and a network error is returned if the server does not respond within this window. Invalid, non-positive, or out-of-range values (above `2147483647`) fall back to the default. |
+| `SEARXNG_TIMEOUT_MS` | No | `10000` | Maximum time in milliseconds for each SearXNG search attempt, covering response headers, body streaming, decoding, and parsing. The request is aborted and a network error is returned if the server does not complete within this window. Invalid, non-positive, or out-of-range values (above `2147483647`) fall back to the default. |
 | `FETCH_TIMEOUT_MS` | No | `10000` | Maximum time in milliseconds to wait for a `web_url_read` fetch. The request is aborted and an error is returned if the server does not respond within this window. |
+| `SEARXNG_MAX_RESPONSE_BYTES` | No | `5242880` | Maximum retained bytes read from each SearXNG response: successful search JSON, HTML fallback, `/config`, and `/autocompleter`. It is a per-response admission limit, not an aggregate or concurrency cap. |
+
+`SEARXNG_MAX_RESPONSE_BYTES` accepts only a strict integer after surrounding JavaScript whitespace is trimmed. A leading `+` and leading zeros are accepted; `-0`, other non-positive values, fractions, exponents, suffixes, unsafe integers, and values outside the inclusive `1` through `16777216` range are invalid. Unset or blank uses `5242880` silently. An invalid value uses that default and emits one value-free warning per MCP server.
+
+Search JSON and HTML fallback each receive their own full `SEARXNG_TIMEOUT_MS` deadline, so the fallback deadline is separate and additive; replica failover remains per instance and additive as well. `/config` and `/autocompleter` retain their fixed 5-second deadlines through body consumption. Oversized, stalled, partial, malformed, or read-failed responses do not populate successful caches or health state and follow the existing failure, negative-cache, or empty-array path.
 
 ## Tool Schema
 
@@ -426,6 +431,7 @@ This combined MCP client configuration shows the supported option groups in one 
         "AUTH_PASSWORD": "legacy-fallback-password",
         "SEARXNG_FANOUT": "false",
         "SEARXNG_TIMEOUT_MS": "10000",
+        "SEARXNG_MAX_RESPONSE_BYTES": "5242880",
         "FETCH_TIMEOUT_MS": "10000",
         "SEARXNG_LITE_TOOLS": "false",
         "SEARXNG_DEFAULT_LANGUAGE": "en",

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -41,6 +41,28 @@ The primary security surface areas are:
 
 ## Security Features
 
+### SearXNG Response-Body Limits
+
+`SEARXNG_MAX_RESPONSE_BYTES` bounds the bytes this MCP client retains from each
+successful SearXNG search JSON response, HTML fallback, `/config`, and
+`/autocompleter` response. It defaults to 5 MiB and accepts only strict
+integers from 1 through 16 MiB; an invalid value falls back to the default with
+one value-free warning per MCP server. This is a per-response retained-byte
+admission limit, not an aggregate or concurrency limit, and it does not change,
+deploy, restart, reconfigure, or impose settings on the SearXNG service.
+
+For non-success search responses, the client retains at most the lower of the
+configured limit and 64 KiB for a credential-sanitized diagnostic preview,
+preserves the HTTP status, and appends the fixed `[Response body truncated]`
+marker when that preview is cut short. Non-success `/config` and
+`/autocompleter` bodies are canceled rather than disclosed. Search deadlines
+cover headers, body streaming, decoding, and parsing; JSON and HTML fallback
+deadlines are separate and additive, as are per-instance failover attempts.
+The fixed 5-second `/config` and `/autocompleter` deadlines include body
+consumption. Oversize, stalled, partial, malformed, and read failures do not
+populate successful caches or health state and use the existing failure,
+negative-cache, or empty-array behavior.
+
 ### SSRF Protection (`web_url_read`)
 
 Private and internal URLs are **blocked by default** in all transport modes. The following are rejected:

--- a/__tests__/e2e/timeout.e2e.ts
+++ b/__tests__/e2e/timeout.e2e.ts
@@ -13,10 +13,12 @@
 
 import { strict as assert } from 'node:assert';
 import http from 'node:http';
+import type { Socket } from 'node:net';
 import { fileURLToPath } from 'node:url';
 import {
   checkSkipConditions,
   INIT_PARAMS,
+  spawnWithMessagesAsync,
   spawnWithMessages,
 } from './helpers/spawn-server.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
@@ -39,10 +41,71 @@ async function startHangingServer(): Promise<{ url: string; close: () => Promise
   });
 }
 
+/**
+ * Serves response headers without completing the body. The socket tracking is
+ * deliberate: a failing RED test must still leave no listener or connection.
+ */
+async function startHeadersThenStallServer(
+  handleRequest: (request: http.IncomingMessage, response: http.ServerResponse) => void,
+): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const sockets = new Set<Socket>();
+    const server = http.createServer(handleRequest);
+    server.on('connection', (socket) => {
+      sockets.add(socket);
+      socket.once('close', () => sockets.delete(socket));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as { port: number };
+      resolve({
+        url: `http://127.0.0.1:${address.port}`,
+        close: () => new Promise((done) => {
+          for (const socket of sockets) socket.destroy();
+          server.close(() => done());
+        }),
+      });
+    });
+  });
+}
+
 // Default fetch timeout in src/search.ts and src/url-reader.ts
 const FETCH_TIMEOUT_MS = 10000;
 // Allow 3s extra for process startup, JSON parsing, etc.
 const TEST_TIMEOUT_MS = FETCH_TIMEOUT_MS + 3000;
+const BODY_TIMEOUT_MS = 150;
+const BODY_TEST_TIMEOUT_MS = 1500;
+
+function hasToolError(response: any): boolean {
+  return Boolean(
+    response?.error
+    || response?.result?.isError
+    || (response?.result?.content?.[0]?.text ?? '').toLowerCase().includes('error'),
+  );
+}
+
+async function expectBodyDeadline(
+  start: number,
+  run: () => Promise<Record<number, any>>,
+  description: string,
+): Promise<void> {
+  let responses: Record<number, any>;
+  try {
+    responses = await run();
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(
+      `${description}: response headers arrived, but the built client did not apply `
+      + `SEARXNG_TIMEOUT_MS=${BODY_TIMEOUT_MS} while consuming the body (${detail})`,
+    );
+  }
+
+  assert.ok(responses[2], `${description}: expected the tool to return a timeout error response`);
+  assert.ok(hasToolError(responses[2]), `${description}: expected a timeout error response`);
+  assert.ok(
+    Date.now() - start < BODY_TEST_TIMEOUT_MS,
+    `${description}: expected completion before the outer test deadline`,
+  );
+}
 
 async function runTests() {
   console.log('⏱  E2E Testing: AbortController timeout (local hanging server)\n');
@@ -129,6 +192,77 @@ async function runTests() {
       assert.ok(hasError, `expected error response, got: ${JSON.stringify(r)}`);
 
       assert.ok(elapsed < TEST_TIMEOUT_MS, `took ${elapsed}ms — should be under ${TEST_TIMEOUT_MS}ms`);
+    } finally {
+      await close();
+    }
+  }, results);
+
+  await testFunction('searxng_web_search keeps its timeout while a JSON body stalls after headers', async () => {
+    const { url, close } = await startHeadersThenStallServer((_request, response) => {
+      response.writeHead(200, { 'content-type': 'application/json' });
+      response.flushHeaders();
+    });
+
+    try {
+      const start = Date.now();
+      await expectBodyDeadline(
+        start,
+        () => spawnWithMessagesAsync(
+          [
+            { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+            {
+              jsonrpc: '2.0',
+              id: 2,
+              method: 'tools/call',
+              params: { name: 'searxng_web_search', arguments: { query: 'headers-first-json' } },
+            },
+          ],
+          url,
+          BODY_TEST_TIMEOUT_MS,
+          { SEARXNG_TIMEOUT_MS: String(BODY_TIMEOUT_MS) },
+        ),
+        'JSON response body deadline',
+      );
+    } finally {
+      await close();
+    }
+  }, results);
+
+  await testFunction('searxng_web_search gives its HTML fallback a fresh body deadline', async () => {
+    const { url, close } = await startHeadersThenStallServer((request, response) => {
+      const requestUrl = new URL(request.url ?? '/', 'http://127.0.0.1');
+      if (requestUrl.searchParams.get('format') === 'json') {
+        response.writeHead(403, { 'content-type': 'text/plain' });
+        response.end('fallback');
+        return;
+      }
+      response.writeHead(200, { 'content-type': 'text/html' });
+      response.flushHeaders();
+    });
+
+    try {
+      const start = Date.now();
+      await expectBodyDeadline(
+        start,
+        () => spawnWithMessagesAsync(
+          [
+            { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+            {
+              jsonrpc: '2.0',
+              id: 2,
+              method: 'tools/call',
+              params: { name: 'searxng_web_search', arguments: { query: 'headers-first-html' } },
+            },
+          ],
+          url,
+          BODY_TEST_TIMEOUT_MS,
+          {
+            SEARXNG_TIMEOUT_MS: String(BODY_TIMEOUT_MS),
+            SEARXNG_HTML_FALLBACK: 'true',
+          },
+        ),
+        'HTML fallback response body deadline',
+      );
     } finally {
       await close();
     }

--- a/__tests__/helpers/mock-fetch.ts
+++ b/__tests__/helpers/mock-fetch.ts
@@ -34,22 +34,15 @@ export function createMockFetch(options: FetchMockOptions = {}) {
       throw throwError;
     }
 
-    return {
-      ok,
+    // Give consumers a real, readable body stream. Preserve the helper's
+    // historical json override for callers that deliberately pass both forms.
+    const response = new Response(body || (json !== null ? JSON.stringify(json) : ''), {
       status,
       statusText,
-      // text() and json() come from one body on a real Response — mirror json
-      // into text when only json is given so a text-first reader stays consistent.
-      text: async () => {
-        if (body) {
-          return body;
-        }
-        if (json !== null) {
-          return JSON.stringify(json);
-        }
-        return '';
-      },
-      json: async () => {
+    });
+    Object.defineProperty(response, 'ok', { value: ok });
+    Object.defineProperty(response, 'json', {
+      value: async () => {
         if (json !== null) {
           return json;
         }
@@ -57,8 +50,9 @@ export function createMockFetch(options: FetchMockOptions = {}) {
           return JSON.parse(body);
         }
         throw new Error('No JSON content');
-      }
-    } as Response;
+      },
+    });
+    return response;
   };
 }
 
@@ -73,13 +67,10 @@ export function createCapturingMockFetch() {
     capturedUrl = url.toString();
     capturedOptions = options;
     
-    return {
-      ok: true,
+    return new Response(JSON.stringify({ results: [] }), {
       status: 200,
       statusText: 'OK',
-      text: async () => JSON.stringify({ results: [] }),
-      json: async () => ({ results: [] })
-    } as Response;
+    });
   };
 
   return {

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -213,7 +213,10 @@ async function runTests() {
     fetchMocker.mock(async (url, _opts) => {
       capturedUrl = url as string;
       const body = JSON.stringify({ results: [{ title: 'R', url: 'https://x.com', content: 'c', score: 1 }] });
-      return { ok: true, json: async () => JSON.parse(body), text: async () => body } as any;
+      return new Response(body, {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      });
     });
     const { client } = await connect();
 

--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -35,6 +35,7 @@ import { runTests as runVersionTests } from './unit/version.test.js';
 import { runTests as runHttpSecurityTests } from './unit/http-security.test.js';
 import { runTests as runPackedConsumerTests } from './unit/packed-consumer.test.js';
 import { runTests as runDocumentationTests } from './unit/documentation.test.js';
+import { runTests as runSearxngResponseTests } from './unit/searxng-response.test.js';
 import { runTests as runFuzzTests } from './fuzz/search-params.fuzz.js';
 import { runTests as runHttpServerTests } from './integration/http-server.test.js';
 import { runTests as runIndexTests } from './integration/index.test.js';
@@ -76,6 +77,7 @@ const testSuites: TestSuite[] = [
   { name: 'HTTP Security', category: 'unit', run: runHttpSecurityTests },
   { name: 'Packed Consumer Verification', category: 'unit', run: runPackedConsumerTests },
   { name: 'Documentation', category: 'unit', run: runDocumentationTests },
+  { name: 'SearXNG Response', category: 'unit', run: runSearxngResponseTests },
   { name: 'Fuzz Properties', category: 'unit', run: runFuzzTests },
 
   // Integration Tests

--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -74,6 +74,22 @@ function makeSecondaryConfig() {
   };
 }
 
+function configResponse(body: string, init: ResponseInit = {}): Response {
+  return new Response(body, { status: 200, ...init });
+}
+
+function streamedConfigResponse(chunks: Uint8Array[]): Response {
+  const body = new ReadableStream<Uint8Array>({
+    start(controller) {
+      for (const chunk of chunks) {
+        controller.enqueue(chunk);
+      }
+      controller.close();
+    },
+  });
+  return new Response(body, { status: 200 });
+}
+
 async function runTests() {
   console.log('🧪 Testing: instance-info.ts\n');
 
@@ -581,6 +597,188 @@ async function runTests() {
 
     fetchMocker.restore();
     envManager.restore();
+  }, results);
+
+  await testFunction('accepts a /config response exactly at the configured byte limit', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://exact-limit.example.com');
+    const mockServer = createMockServer();
+    const body = JSON.stringify(makeConfig());
+    envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(body)));
+    fetchMocker.mock(async () => configResponse(body));
+
+    const payload = JSON.parse(await fetchInstanceInfo(mockServer as any));
+
+    assert.equal(payload.available, true);
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('returns sanitized unavailable payload and negative-caches a /config response one byte over its limit', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://over-limit.example.com');
+    const mockServer = createMockServer();
+    const body = JSON.stringify(makeConfig());
+    envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(body) - 1));
+    let attempts = 0;
+    fetchMocker.mock(async () => {
+      attempts++;
+      return streamedConfigResponse([Buffer.from(body)]);
+    });
+
+    const first = JSON.parse(await fetchInstanceInfo(mockServer as any));
+    const second = JSON.parse(await fetchInstanceInfo(mockServer as any));
+
+    assert.equal(first.available, false);
+    assert.equal(first.instancesUnreachable[0].sourceUrl, 'https://over-limit.example.com');
+    assert.ok(!JSON.stringify(first).includes(body.slice(0, 16)));
+    assert.equal(second.available, false);
+    assert.equal(attempts, 1, 'failed oversized response should use the negative cache');
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('treats partial and malformed streamed /config JSON as unavailable without populating the success cache', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://malformed-config.example.com');
+    const mockServer = createMockServer();
+    let attempts = 0;
+    fetchMocker.mock(async () => {
+      attempts++;
+      return streamedConfigResponse([Buffer.from('{"categories":')]);
+    });
+
+    const first = JSON.parse(await fetchInstanceInfo(mockServer as any));
+    const second = JSON.parse(await fetchInstanceInfo(mockServer as any));
+
+    assert.equal(first.available, false);
+    assert.equal(second.available, false);
+    assert.equal(attempts, 1);
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('cancels non-success /config response bodies and preserves the HTTP unavailable result when cancellation rejects', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://forbidden-config.example.com');
+    const mockServer = createMockServer();
+    let cancelAttempts = 0;
+    const response = configResponse('not disclosed', { status: 403, statusText: 'Forbidden' });
+    Object.defineProperty(response, 'body', {
+      value: {
+        cancel: async () => {
+          cancelAttempts++;
+          throw new Error('cleanup failed');
+        },
+      },
+    });
+    fetchMocker.mock(async () => response);
+
+    const payload = JSON.parse(await fetchInstanceInfo(mockServer as any));
+
+    assert.equal(cancelAttempts, 1);
+    assert.deepEqual(payload.instancesUnreachable, [{
+      sourceUrl: 'https://forbidden-config.example.com',
+      message: 'SearXNG /config is unavailable: HTTP 403 Forbidden',
+      status: 403,
+    }]);
+    assert.ok(!JSON.stringify(payload).includes('not disclosed'));
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('resolves one response limit for all configured instances before fanout begins', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://first-limit.example.com;https://second-limit.example.com');
+    const mockServer = createMockServer();
+    const body = JSON.stringify(makeConfig());
+    envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(body) - 1));
+    let attempts = 0;
+    fetchMocker.mock(async () => {
+      attempts++;
+      if (attempts === 1) {
+        envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(body) + 1));
+      }
+      return streamedConfigResponse([Buffer.from(body)]);
+    });
+
+    const payload = JSON.parse(await fetchInstanceInfo(mockServer as any));
+
+    assert.equal(payload.available, false);
+    assert.equal(attempts, 2);
+    fetchMocker.restore();
+    envManager.restore();
+  }, results);
+
+  await testFunction('keeps the fixed request timeout active while a headers-first /config body stalls', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://stalled-config.example.com');
+    const mockServer = createMockServer();
+    const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
+    let observedSignal: AbortSignal | undefined;
+    fetchMocker.mock(async (_url, options) => {
+      observedSignal = options?.signal ?? undefined;
+      let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
+      const response = new Response(new ReadableStream<Uint8Array>({
+        start(streamController) {
+          controller = streamController;
+        },
+      }), { status: 200 });
+      observedSignal?.addEventListener('abort', () => controller?.error(observedSignal?.reason), { once: true });
+      return response;
+    });
+    Object.defineProperty(AbortSignal, 'timeout', {
+      configurable: true,
+      value: () => {
+        const controller = new AbortController();
+        setTimeout(() => controller.abort(new Error('bounded test timeout')), 5);
+        return controller.signal;
+      },
+    });
+
+    try {
+      const payload = JSON.parse(await fetchInstanceInfo(mockServer as any));
+      assert.ok(observedSignal, 'expected the /config request signal');
+      assert.equal(observedSignal.aborted, true);
+      assert.equal(payload.available, false);
+    } finally {
+      if (timeoutDescriptor) {
+        Object.defineProperty(AbortSignal, 'timeout', timeoutDescriptor);
+      }
+      fetchMocker.restore();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('does not log malformed /config response bytes when JSON parsing fails', async () => {
+    clearInstanceInfoCacheForTests();
+    envManager.set('SEARXNG_URL', 'https://log-user:log-pass@malformed-log.example.com/opaque?trace=UNSAFE_QUERY_SENTINEL');
+    const { server, getLoggingCalls } = createMockServerWithTracking();
+    const malformedBodySentinel = 'UNSAFE_CONFIG_BODY_SENTINEL_4c2f';
+    const originalJsonParse = JSON.parse;
+    fetchMocker.mock(async () => configResponse(`{"broken":"${malformedBodySentinel}"`));
+    JSON.parse = ((text: string) => {
+      if (text.includes(malformedBodySentinel)) {
+        throw new Error(`Unable to parse ${malformedBodySentinel}`);
+      }
+      return originalJsonParse(text);
+    }) as typeof JSON.parse;
+
+    try {
+      const payload = await fetchInstanceInfo(server as any);
+      const serializedLogs = JSON.stringify(getLoggingCalls());
+
+      assert.equal(JSON.parse(payload).available, false);
+      assert.ok(!payload.includes(malformedBodySentinel));
+      assert.ok(!serializedLogs.includes(malformedBodySentinel), serializedLogs);
+      assert.ok(!serializedLogs.includes('log-user'), serializedLogs);
+      assert.ok(!serializedLogs.includes('log-pass'), serializedLogs);
+      assert.ok(!serializedLogs.includes('UNSAFE_QUERY_SENTINEL'), serializedLogs);
+    } finally {
+      JSON.parse = originalJsonParse;
+      fetchMocker.restore();
+      envManager.restore();
+    }
   }, results);
 
   printTestSummary(results, 'Instance Info Module');

--- a/__tests__/unit/instance-info.test.ts
+++ b/__tests__/unit/instance-info.test.ts
@@ -716,31 +716,44 @@ async function runTests() {
     const mockServer = createMockServer();
     const timeoutDescriptor = Object.getOwnPropertyDescriptor(AbortSignal, 'timeout');
     let observedSignal: AbortSignal | undefined;
+    let attempts = 0;
+    const timeoutReason = new Error('bounded test timeout');
+    const cancellationReasons: unknown[] = [];
+    let responseBody: ReadableStream<Uint8Array> | undefined;
     fetchMocker.mock(async (_url, options) => {
+      attempts++;
       observedSignal = options?.signal ?? undefined;
-      let controller: ReadableStreamDefaultController<Uint8Array> | undefined;
-      const response = new Response(new ReadableStream<Uint8Array>({
-        start(streamController) {
-          controller = streamController;
+      responseBody = new ReadableStream<Uint8Array>({
+        cancel(reason) {
+          cancellationReasons.push(reason);
         },
-      }), { status: 200 });
-      observedSignal?.addEventListener('abort', () => controller?.error(observedSignal?.reason), { once: true });
-      return response;
+      });
+      return new Response(responseBody, { status: 200 });
     });
     Object.defineProperty(AbortSignal, 'timeout', {
       configurable: true,
       value: () => {
         const controller = new AbortController();
-        setTimeout(() => controller.abort(new Error('bounded test timeout')), 5);
+        setTimeout(() => controller.abort(timeoutReason), 5);
         return controller.signal;
       },
     });
 
     try {
-      const payload = JSON.parse(await fetchInstanceInfo(mockServer as any));
+      const payload = JSON.parse(await Promise.race([
+        fetchInstanceInfo(mockServer as any),
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(() => reject(new Error('stalled /config response did not become unavailable promptly')), 250);
+        }),
+      ]));
+      const cachedPayload = JSON.parse(await fetchInstanceInfo(mockServer as any));
       assert.ok(observedSignal, 'expected the /config request signal');
       assert.equal(observedSignal.aborted, true);
       assert.equal(payload.available, false);
+      assert.equal(cachedPayload.available, false);
+      assert.equal(attempts, 1, 'a timed-out response must not populate the successful cache');
+      assert.deepEqual(cancellationReasons, [timeoutReason]);
+      assert.equal(responseBody?.locked, false, 'the shared reader must release its body lock after cancellation');
     } finally {
       if (timeoutDescriptor) {
         Object.defineProperty(AbortSignal, 'timeout', timeoutDescriptor);

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -3311,6 +3311,56 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('HTML fallback accepts an exact response-body limit and rejects the next byte without caching or recording success', async () => {
+    searchCache.clear();
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://fallback-bounded.example.com');
+    envManager.set('SEARXNG_HTML_FALLBACK', 'true');
+    const exactBody = searxngHtmlFixture;
+    envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(exactBody)));
+    const mockServer = createMockServer();
+    let jsonFetchCount = 0;
+    let htmlFetchCount = 0;
+    fetchMocker.mock(async (url) => {
+      const requestUrl = new URL(url.toString());
+      if (requestUrl.searchParams.get('format') === 'json') {
+        jsonFetchCount++;
+        return new Response('JSON format is disabled', { status: 403, statusText: 'Forbidden' });
+      }
+
+      htmlFetchCount++;
+      return createStreamResponse([utf8(htmlFetchCount === 1 ? exactBody : `${exactBody} `)]);
+    });
+
+    try {
+      const exactResult = await performWebSearch(mockServer as any, 'fallback exact body');
+      assert.ok(exactResult.includes('Alpha Result'));
+
+      envManager.set('SEARXNG_URL', 'https://fallback-bounded.example.com;https://cooled.example.com');
+      recordSearxngInstanceFailure('https://fallback-bounded.example.com');
+      recordSearxngInstanceFailure('https://fallback-bounded.example.com');
+      recordSearxngInstanceFailure('https://cooled.example.com');
+      recordSearxngInstanceFailure('https://cooled.example.com');
+      recordSearxngInstanceFailure('https://cooled.example.com');
+      await assert.rejects(
+        () => performWebSearch(mockServer as any, 'fallback next byte'),
+        /SearXNG response exceeds configured byte limit/,
+      );
+      assert.equal(isSearxngInstanceCooledDown('https://fallback-bounded.example.com'), true);
+
+      clearSearxngInstanceStateForTests();
+      envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(exactBody) + 1));
+      await performWebSearch(mockServer as any, 'fallback next byte');
+      assert.equal(htmlFetchCount, 3, 'an oversize HTML fallback response must not be stored in the search cache');
+      assert.equal(jsonFetchCount, 3, 'each HTML fallback attempt must begin with the JSON request');
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+      clearSearxngInstanceStateForTests();
+    }
+  }, results);
+
   await testFunction('search rejects partial and invalid bounded JSON before cache writes', async () => {
     searchCache.clear();
     clearSearxngInstanceStateForTests();

--- a/__tests__/unit/search.test.ts
+++ b/__tests__/unit/search.test.ts
@@ -14,6 +14,7 @@ import { searchCache } from '../../src/search-cache.js';
 import { clearInstanceInfoCacheForTests } from '../../src/instance-info.js';
 import {
   clearSearxngInstanceStateForTests,
+  isSearxngInstanceCooledDown,
   recordSearxngInstanceFailure,
 } from '../../src/searxng-instances.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
@@ -67,6 +68,34 @@ function getSingleResponseFormatWarning(calls: any[]): string {
   assert.ok(message.includes('SEARXNG_DEFAULT_RESPONSE_FORMAT'), message);
   assert.ok(message.includes('text or json'), message);
   return message;
+}
+
+function createStreamResponse(
+  chunks: Uint8Array[],
+  options: { status?: number; statusText?: string; errorAfterChunks?: boolean } = {},
+): Response {
+  let index = 0;
+  const stream = new ReadableStream<Uint8Array>({
+    pull(controller) {
+      if (index < chunks.length) {
+        controller.enqueue(chunks[index++]);
+        return;
+      }
+      if (options.errorAfterChunks) {
+        controller.error(new Error('partial response stream failed'));
+        return;
+      }
+      controller.close();
+    },
+  });
+  return new Response(stream, {
+    status: options.status ?? 200,
+    statusText: options.statusText ?? 'OK',
+  });
+}
+
+function utf8(value: string): Uint8Array {
+  return new TextEncoder().encode(value);
 }
 
 async function runTests() {
@@ -336,24 +365,7 @@ async function runTests() {
     
     const mockServer = createMockServer();
     
-    // Simulate a real single-use body: once json() consumes it, text() fails.
-    // The buggy path (text() after json()) would lose the preview entirely.
-    fetchMocker.mock(async () => {
-      let bodyConsumed = false;
-      return {
-        ok: true,
-        json: async () => {
-          bodyConsumed = true;
-          throw new Error('Invalid JSON');
-        },
-        text: async () => {
-          if (bodyConsumed) {
-            throw new TypeError('Body is unusable: Body has already been read');
-          }
-          return 'Invalid JSON response';
-        }
-      } as any;
-    });
+    fetchMocker.mock(async () => new Response('Invalid JSON response'));
 
     try {
       await performWebSearch(mockServer as any, 'test query');
@@ -396,32 +408,14 @@ async function runTests() {
 
       const requestUrl = new URL(url.toString());
       if (requestUrl.pathname.endsWith('/config')) {
-        return {
-          ok: true,
-          status: 200,
-          statusText: 'OK',
-          json: async () => ({
-            categories: ['general'],
-            engines: [],
-          }),
-        } as Response;
+        return new Response(JSON.stringify({ categories: ['general'], engines: [] }));
       }
 
       if (requestUrl.searchParams.get('format') === 'json') {
-        return {
-          ok: false,
-          status: 403,
-          statusText: 'Forbidden',
-          text: async () => 'JSON format is disabled',
-        } as Response;
+        return new Response('JSON format is disabled', { status: 403, statusText: 'Forbidden' });
       }
 
-      return {
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        text: async () => searxngHtmlFixture,
-      } as Response;
+      return new Response(searxngHtmlFixture);
     });
 
     const result = await performWebSearch(mockServer as any, 'html query', 2, 'week', 'en', 1, undefined, undefined, 'general', undefined, 'json');
@@ -460,20 +454,10 @@ async function runTests() {
       const requestUrl = new URL(url.toString());
 
       if (requestUrl.searchParams.get('format') === 'json') {
-        return {
-          ok: false,
-          status: 403,
-          statusText: 'Forbidden',
-          text: async () => 'JSON format is disabled',
-        } as Response;
+        return new Response('JSON format is disabled', { status: 403, statusText: 'Forbidden' });
       }
 
-      return {
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        text: async () => searxngHtmlFixture,
-      } as Response;
+      return new Response(searxngHtmlFixture);
     });
 
     await performWebSearch(server as any, 'fallback log');
@@ -499,21 +483,10 @@ async function runTests() {
     fetchMocker.mock(async () => {
       fetchCount++;
       if (fetchCount === 1) {
-        return {
-          ok: true,
-          status: 200,
-          statusText: 'OK',
-          json: async () => { throw new Error('Unexpected token < in JSON'); },
-          text: async () => '<!doctype html><html><body>JSON disabled</body></html>',
-        } as any;
+        return new Response('<!doctype html><html><body>JSON disabled</body></html>');
       }
 
-      return {
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        text: async () => searxngHtmlFixture,
-      } as Response;
+      return new Response(searxngHtmlFixture);
     });
 
     const result = await performWebSearch(mockServer as any, 'non json query', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
@@ -537,21 +510,10 @@ async function runTests() {
     fetchMocker.mock(async (url) => {
       fetchedUrls.push(url.toString());
       if (fetchedUrls.length === 1) {
-        return {
-          ok: true,
-          status: 200,
-          statusText: 'OK',
-          json: async () => { throw new Error('Unexpected token < in JSON'); },
-          text: async () => '<!doctype html><html><body>JSON disabled</body></html>',
-        } as any;
+        return new Response('<!doctype html><html><body>JSON disabled</body></html>');
       }
 
-      return {
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        text: async () => searxngHtmlFixture,
-      } as Response;
+      return new Response(searxngHtmlFixture);
     });
 
     await performWebSearch(mockServer as any, 'non json creds', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json');
@@ -576,12 +538,7 @@ async function runTests() {
     let fetchCount = 0;
     fetchMocker.mock(async () => {
       fetchCount++;
-      return {
-        ok: false,
-        status: 403,
-        statusText: 'Forbidden',
-        text: async () => 'JSON format is disabled',
-      } as Response;
+      return new Response('JSON format is disabled', { status: 403, statusText: 'Forbidden' });
     });
 
     try {
@@ -604,12 +561,7 @@ async function runTests() {
     let fetchCount = 0;
     fetchMocker.mock(async () => {
       fetchCount++;
-      return {
-        ok: false,
-        status: 401,
-        statusText: 'Unauthorized',
-        text: async () => 'Authentication required',
-      } as Response;
+      return new Response('Authentication required', { status: 401, statusText: 'Unauthorized' });
     });
 
     try {
@@ -633,20 +585,10 @@ async function runTests() {
     fetchMocker.mock(async () => {
       fetchCount++;
       if (fetchCount === 1) {
-        return {
-          ok: false,
-          status: 404,
-          statusText: 'Not Found',
-          text: async () => 'JSON endpoint not found',
-        } as Response;
+        return new Response('JSON endpoint not found', { status: 404, statusText: 'Not Found' });
       }
 
-      return {
-        ok: true,
-        status: 200,
-        statusText: 'OK',
-        text: async () => searxngHtmlFixture,
-      } as Response;
+      return new Response(searxngHtmlFixture);
     });
 
     const result = await performWebSearch(mockServer as any, 'html query');
@@ -1417,12 +1359,11 @@ async function runTests() {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
 
     const mockServer = createMockServer();
-    fetchMocker.mock(async () => ({
-      ok: false,
+    fetchMocker.mock(async () => createStreamResponse([], {
       status: 500,
       statusText: 'Internal Server Error',
-      text: async () => { throw new Error('text() failed'); }
-    } as any));
+      errorAfterChunks: true,
+    }));
 
     try {
       await performWebSearch(mockServer as any, 'test query');
@@ -1439,13 +1380,7 @@ async function runTests() {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
 
     const mockServer = createMockServer();
-    fetchMocker.mock(async () => ({
-      ok: true,
-      status: 200,
-      statusText: 'OK',
-      json: async () => { throw new Error('JSON parse failed'); },
-      text: async () => { throw new Error('text() also failed'); }
-    } as any));
+    fetchMocker.mock(async () => createStreamResponse([], { errorAfterChunks: true }));
 
     try {
       await performWebSearch(mockServer as any, 'test query');
@@ -2650,7 +2585,7 @@ async function runTests() {
       ],
     };
     const mockServer = createMockServer();
-    fetchMocker.mock(async () => ({ ok: true, status: 200, statusText: 'OK', text: async () => JSON.stringify(source), json: async () => source } as Response));
+    fetchMocker.mock(async () => new Response(JSON.stringify(source)));
     try {
       const json = JSON.parse(await performWebSearch(mockServer as any, 'clone', 1, undefined, undefined, undefined, undefined, undefined, undefined, undefined, 'json', 'full'));
       assert.deepEqual(json.answers, ['raw answer']);
@@ -3126,6 +3061,32 @@ async function runTests() {
     envManager.restore();
   }, results);
 
+  await testFunction('network failure diagnostics never include the search query', async () => {
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://network-log.example.com');
+    const sentinelQuery = 'query-marker-5d9d2c';
+    const { server, getLoggingCalls } = createMockServerWithTracking();
+    fetchMocker.mock(async () => {
+      throw new Error('simulated network failure');
+    });
+
+    try {
+      await assert.rejects(() => performWebSearch(server as any, sentinelQuery));
+      const errorLogs = getLoggingCalls().filter((call) => call.level === 'error');
+      assert.ok(errorLogs.length > 0, 'Expected an error-level network diagnostic');
+      for (const errorLog of errorLogs) {
+        assert.ok(
+          !JSON.stringify(errorLog.data).includes(sentinelQuery),
+          `Query leaked into error diagnostic: ${JSON.stringify(errorLog.data)}`,
+        );
+      }
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      clearSearxngInstanceStateForTests();
+    }
+  }, results);
+
   await testFunction('cooled down instance is skipped during failover', async () => {
     clearSearxngInstanceStateForTests();
     envManager.set('SEARXNG_URL', 'https://cooled.example.com;https://healthy.example.com');
@@ -3307,6 +3268,98 @@ async function runTests() {
 
     fetchMocker.restore();
     envManager.restore();
+  }, results);
+
+  await testFunction('search accepts an exact response-body limit and rejects the next byte without caching or recording success', async () => {
+    searchCache.clear();
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://bounded.example.com');
+    const exactBody = JSON.stringify({
+      results: [{ title: 'Exact', content: 'bounded', url: 'https://example.com/exact', score: 1 }],
+    });
+    envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(exactBody)));
+    const mockServer = createMockServer();
+    let fetchCount = 0;
+    fetchMocker.mock(async () => {
+      fetchCount++;
+      return createStreamResponse([utf8(fetchCount === 1 ? exactBody : `${exactBody} `)]);
+    });
+
+    try {
+      await performWebSearch(mockServer as any, 'exact body');
+      envManager.set('SEARXNG_URL', 'https://bounded.example.com;https://cooled.example.com');
+      recordSearxngInstanceFailure('https://bounded.example.com');
+      recordSearxngInstanceFailure('https://bounded.example.com');
+      recordSearxngInstanceFailure('https://cooled.example.com');
+      recordSearxngInstanceFailure('https://cooled.example.com');
+      recordSearxngInstanceFailure('https://cooled.example.com');
+      await assert.rejects(
+        () => performWebSearch(mockServer as any, 'next byte'),
+        /SearXNG response exceeds configured byte limit/,
+      );
+      assert.equal(isSearxngInstanceCooledDown('https://bounded.example.com'), true);
+
+      clearSearxngInstanceStateForTests();
+      envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(exactBody) + 1));
+      await performWebSearch(mockServer as any, 'next byte');
+      assert.equal(fetchCount, 3, 'an oversize response must not be stored in the search cache');
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+      clearSearxngInstanceStateForTests();
+    }
+  }, results);
+
+  await testFunction('search rejects partial and invalid bounded JSON before cache writes', async () => {
+    searchCache.clear();
+    clearSearxngInstanceStateForTests();
+    envManager.set('SEARXNG_URL', 'https://partial.example.com');
+    const mockServer = createMockServer();
+    let fetchCount = 0;
+    fetchMocker.mock(async () => {
+      fetchCount++;
+      if (fetchCount === 1) {
+        return createStreamResponse([utf8('{"results":')], { errorAfterChunks: true });
+      }
+      return createStreamResponse([utf8(JSON.stringify({ results: [] }))]);
+    });
+
+    try {
+      await assert.rejects(() => performWebSearch(mockServer as any, 'partial body'));
+      await performWebSearch(mockServer as any, 'partial body');
+      assert.equal(fetchCount, 2, 'a failed partial body must not create a cache entry');
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+      searchCache.clear();
+      clearSearxngInstanceStateForTests();
+    }
+  }, results);
+
+  await testFunction('HTTP error previews are bounded, redact URL credentials, and mark truncation', async () => {
+    envManager.set('SEARXNG_URL', 'https://user:pass@preview.example.com');
+    envManager.set('SEARXNG_MAX_RESPONSE_BYTES', '8');
+    const mockServer = createMockServer();
+    fetchMocker.mock(async () => createStreamResponse(
+      [utf8('https://user:pass@body.example.com/this-response-is-deliberately-long')],
+      { status: 400, statusText: 'Bad Request' },
+    ));
+
+    try {
+      await assert.rejects(
+        () => performWebSearch(mockServer as any, 'preview body'),
+        (error: Error) => {
+          assert.match(error.message, /400/);
+          assert.match(error.message, /\[Response body truncated\]/);
+          assert.ok(!error.message.includes('user:pass@'), error.message);
+          return true;
+        },
+      );
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+    }
   }, results);
 
   printTestSummary(results, 'Search Module');

--- a/__tests__/unit/searxng-response.test.ts
+++ b/__tests__/unit/searxng-response.test.ts
@@ -1,0 +1,172 @@
+#!/usr/bin/env tsx
+
+import { strict as assert } from "node:assert";
+import { fileURLToPath } from "node:url";
+import {
+  DEFAULT_SEARXNG_RESPONSE_MAX_BYTES,
+  HARD_MAX_SEARXNG_RESPONSE_BYTES,
+  PREVIEW_MAX_SEARXNG_RESPONSE_BYTES,
+  cancelAuxiliaryResponseBody,
+  readSearxngResponseBody,
+  resetSearxngResponseConfigWarningsForTesting,
+  resolveSearxngResponseMaxBytes,
+} from "../../src/searxng-response.js";
+import { createTestResults, exitWithResults, printTestSummary, testFunction } from "../helpers/test-utils.js";
+
+const results = createTestResults();
+const encoder = new TextEncoder();
+
+function responseWithChunks(chunks: Uint8Array[], options: { cancelRejects?: boolean; readRejects?: boolean } = {}) {
+  let cancelCalls = 0;
+  let releaseCalls = 0;
+  let index = 0;
+  const reader = {
+    async read(): Promise<ReadableStreamReadResult<Uint8Array>> {
+      if (options.readRejects) {
+        throw new Error("read failed");
+      }
+      const value = chunks[index++];
+      return value === undefined ? { done: true, value: undefined } : { done: false, value };
+    },
+    async cancel(): Promise<void> {
+      cancelCalls++;
+      if (options.cancelRejects) {
+        throw new Error("cancel failed");
+      }
+    },
+    releaseLock(): void {
+      releaseCalls++;
+    },
+  };
+  return {
+    response: {
+      body: {
+        getReader: () => reader,
+        cancel: () => reader.cancel(),
+      },
+    } as Response,
+    getCancelCalls: () => cancelCalls,
+    getReleaseCalls: () => releaseCalls,
+  };
+}
+
+function createLogger() {
+  const messages: string[] = [];
+  return {
+    server: {
+      sendLoggingMessage: async ({ data }: { data: Record<string, unknown> }) => {
+        messages.push(String(data.message));
+      },
+    },
+    messages,
+  };
+}
+
+async function runTests() {
+  console.log("🧪 Testing: searxng-response.ts\n");
+
+  await testFunction("exports fixed byte limits", () => {
+    assert.equal(DEFAULT_SEARXNG_RESPONSE_MAX_BYTES, 5 * 1024 * 1024);
+    assert.equal(HARD_MAX_SEARXNG_RESPONSE_BYTES, 16 * 1024 * 1024);
+    assert.equal(PREVIEW_MAX_SEARXNG_RESPONSE_BYTES, 64 * 1024);
+  }, results);
+
+  await testFunction("resolves only accepted response-size configuration and warns once without raw values", async () => {
+    const previous = process.env.SEARXNG_MAX_RESPONSE_BYTES;
+    const logger = createLogger();
+    resetSearxngResponseConfigWarningsForTesting();
+    try {
+      delete process.env.SEARXNG_MAX_RESPONSE_BYTES;
+      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), DEFAULT_SEARXNG_RESPONSE_MAX_BYTES);
+      process.env.SEARXNG_MAX_RESPONSE_BYTES = "1";
+      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), 1);
+      process.env.SEARXNG_MAX_RESPONSE_BYTES = " 16777216 ";
+      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), HARD_MAX_SEARXNG_RESPONSE_BYTES);
+      process.env.SEARXNG_MAX_RESPONSE_BYTES = "  ";
+      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), DEFAULT_SEARXNG_RESPONSE_MAX_BYTES);
+      process.env.SEARXNG_MAX_RESPONSE_BYTES = "0";
+      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), DEFAULT_SEARXNG_RESPONSE_MAX_BYTES);
+      process.env.SEARXNG_MAX_RESPONSE_BYTES = "16777217";
+      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), DEFAULT_SEARXNG_RESPONSE_MAX_BYTES);
+      process.env.SEARXNG_MAX_RESPONSE_BYTES = "5.5";
+      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), DEFAULT_SEARXNG_RESPONSE_MAX_BYTES);
+      await Promise.resolve();
+      assert.equal(logger.messages.length, 1);
+      assert.ok(!logger.messages[0].includes("16777217"));
+      resetSearxngResponseConfigWarningsForTesting();
+      resolveSearxngResponseMaxBytes(logger.server as any);
+      await Promise.resolve();
+      assert.equal(logger.messages.length, 2);
+    } finally {
+      if (previous === undefined) delete process.env.SEARXNG_MAX_RESPONSE_BYTES;
+      else process.env.SEARXNG_MAX_RESPONSE_BYTES = previous;
+      resetSearxngResponseConfigWarningsForTesting();
+    }
+  }, results);
+
+  await testFunction("complete mode accepts exact bytes, rejects the next byte, and releases its lock", async () => {
+    const exact = responseWithChunks([encoder.encode("abc")]);
+    assert.deepEqual(await readSearxngResponseBody(exact.response, 3), {
+      text: "abc", bytesRead: 3, truncated: false,
+    });
+    assert.equal(exact.getReleaseCalls(), 1);
+    const overflow = responseWithChunks([encoder.encode("abcd")]);
+    await assert.rejects(() => readSearxngResponseBody(overflow.response, 3), /SearXNG response exceeds configured byte limit/);
+    assert.equal(overflow.getCancelCalls(), 1);
+    assert.equal(overflow.getReleaseCalls(), 1);
+    const overflowWithCancelFailure = responseWithChunks([encoder.encode("abcd")], { cancelRejects: true });
+    await assert.rejects(
+      () => readSearxngResponseBody(overflowWithCancelFailure.response, 3),
+      /SearXNG response exceeds configured byte limit/,
+    );
+    assert.equal(overflowWithCancelFailure.getReleaseCalls(), 1);
+  }, results);
+
+  await testFunction("complete mode measures raw UTF-8 bytes before decoding", async () => {
+    const response = responseWithChunks([new Uint8Array([0xe2]), new Uint8Array([0x82, 0xac])]);
+    assert.deepEqual(await readSearxngResponseBody(response.response, 3), {
+      text: "€", bytesRead: 3, truncated: false,
+    });
+    const partial = responseWithChunks([new Uint8Array([0xe2]), new Uint8Array([0x82])]);
+    assert.equal((await readSearxngResponseBody(partial.response, 2)).text, "�");
+  }, results);
+
+  await testFunction("preview mode truncates at its effective limit and preserves cancellation result", async () => {
+    const truncated = responseWithChunks([encoder.encode("abcd")]);
+    assert.deepEqual(await readSearxngResponseBody(truncated.response, 10, { preview: true, previewMaxBytes: 3 }), {
+      text: "abc", bytesRead: 4, truncated: true,
+    });
+    assert.equal(truncated.getCancelCalls(), 1);
+    assert.equal(truncated.getReleaseCalls(), 1);
+    const cancelRejects = responseWithChunks([encoder.encode("abcd")], { cancelRejects: true });
+    const result = await readSearxngResponseBody(cancelRejects.response, 3, { preview: true });
+    assert.equal(result.truncated, true);
+    assert.equal(cancelRejects.getReleaseCalls(), 1);
+  }, results);
+
+  await testFunction("null body is empty while an absent body is rejected without text fallback", async () => {
+    assert.deepEqual(await readSearxngResponseBody({ body: null } as Response, 3), {
+      text: "", bytesRead: 0, truncated: false,
+    });
+    const invalidResponse = { text: () => { throw new Error("text must not run"); } } as unknown as Response;
+    await assert.rejects(() => readSearxngResponseBody(invalidResponse, 3), /Invalid SearXNG response body/);
+  }, results);
+
+  await testFunction("reader failures release the lock and auxiliary cancellation never surfaces cancellation failures", async () => {
+    const rejectedRead = responseWithChunks([], { readRejects: true });
+    await assert.rejects(() => readSearxngResponseBody(rejectedRead.response, 3), /read failed/);
+    assert.equal(rejectedRead.getReleaseCalls(), 1);
+    const auxiliary = responseWithChunks([], { cancelRejects: true });
+    await cancelAuxiliaryResponseBody(auxiliary.response);
+    assert.equal(auxiliary.getCancelCalls(), 1);
+  }, results);
+
+  printTestSummary(results, "SearXNG Response Module");
+  return results;
+}
+
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runTests().then(exitWithResults).catch(console.error);
+}
+
+export { runTests };

--- a/__tests__/unit/searxng-response.test.ts
+++ b/__tests__/unit/searxng-response.test.ts
@@ -17,6 +17,7 @@ const results = createTestResults();
 const encoder = new TextEncoder();
 
 interface StreamOptions {
+  cancelAborts?: AbortController;
   cancelRejects?: boolean;
   leaveOpen?: boolean;
   readRejects?: boolean;
@@ -40,6 +41,7 @@ function responseWithChunks(chunks: Uint8Array[], options: StreamOptions = {}) {
     cancel(reason) {
       cancelCalls++;
       cancelReason = reason;
+      options.cancelAborts?.abort(new Error("cancel-triggered abort"));
       if (options.cancelRejects) return Promise.reject(new Error("cancel failed"));
       return undefined;
     },
@@ -136,6 +138,18 @@ async function runTests() {
     );
     assert.equal(overflowWithCancelFailure.getCancelCalls(), 1);
     assert.equal(overflowWithCancelFailure.response.body!.locked, false);
+
+    const cancellationAbortController = new AbortController();
+    const cancellationAbort = responseWithChunks([encoder.encode("abcd")], {
+      leaveOpen: true,
+      cancelAborts: cancellationAbortController,
+    });
+    await assert.rejects(
+      () => readSearxngResponseBody(cancellationAbort.response, 3, { signal: cancellationAbortController.signal }),
+      /SearXNG response exceeds configured byte limit/,
+    );
+    assert.equal(cancellationAbort.getCancelCalls(), 1);
+    assert.equal(cancellationAbort.response.body!.locked, false);
   }, results);
 
   await testFunction("complete mode measures raw UTF-8 bytes before decoding with actual bodies", async () => {

--- a/__tests__/unit/searxng-response.test.ts
+++ b/__tests__/unit/searxng-response.test.ts
@@ -16,37 +16,39 @@ import { createTestResults, exitWithResults, printTestSummary, testFunction } fr
 const results = createTestResults();
 const encoder = new TextEncoder();
 
-function responseWithChunks(chunks: Uint8Array[], options: { cancelRejects?: boolean; readRejects?: boolean } = {}) {
+interface StreamOptions {
+  cancelRejects?: boolean;
+  leaveOpen?: boolean;
+  readRejects?: boolean;
+  pending?: boolean;
+}
+
+function responseWithChunks(chunks: Uint8Array[], options: StreamOptions = {}) {
   let cancelCalls = 0;
-  let releaseCalls = 0;
-  let index = 0;
-  const reader = {
-    async read(): Promise<ReadableStreamReadResult<Uint8Array>> {
+  let cancelReason: unknown;
+  const stream = new ReadableStream<Uint8Array>({
+    start(controller) {
       if (options.readRejects) {
-        throw new Error("read failed");
+        controller.error(new Error("read failed"));
+        return;
       }
-      const value = chunks[index++];
-      return value === undefined ? { done: true, value: undefined } : { done: false, value };
+      if (!options.pending) {
+        for (const chunk of chunks) controller.enqueue(chunk);
+        if (!options.leaveOpen) controller.close();
+      }
     },
-    async cancel(): Promise<void> {
+    cancel(reason) {
       cancelCalls++;
-      if (options.cancelRejects) {
-        throw new Error("cancel failed");
-      }
+      cancelReason = reason;
+      if (options.cancelRejects) return Promise.reject(new Error("cancel failed"));
+      return undefined;
     },
-    releaseLock(): void {
-      releaseCalls++;
-    },
-  };
+  });
+  const response = new Response(stream);
   return {
-    response: {
-      body: {
-        getReader: () => reader,
-        cancel: () => reader.cancel(),
-      },
-    } as Response,
+    response,
     getCancelCalls: () => cancelCalls,
-    getReleaseCalls: () => releaseCalls,
+    getCancelReason: () => cancelReason,
   };
 }
 
@@ -62,6 +64,16 @@ function createLogger() {
   };
 }
 
+async function expectPromptAbort(promise: Promise<unknown>, reason: Error): Promise<void> {
+  await assert.rejects(
+    Promise.race([
+      promise,
+      new Promise((_, reject) => setTimeout(() => reject(new Error("abort was not prompt")), 50)),
+    ]),
+    (error: unknown) => error === reason,
+  );
+}
+
 async function runTests() {
   console.log("🧪 Testing: searxng-response.ts\n");
 
@@ -71,7 +83,7 @@ async function runTests() {
     assert.equal(PREVIEW_MAX_SEARXNG_RESPONSE_BYTES, 64 * 1024);
   }, results);
 
-  await testFunction("resolves only accepted response-size configuration and warns once without raw values", async () => {
+  await testFunction("pins accepted and rejected response-size configuration forms with value-free once-only warnings", async () => {
     const previous = process.env.SEARXNG_MAX_RESPONSE_BYTES;
     const logger = createLogger();
     resetSearxngResponseConfigWarningsForTesting();
@@ -82,18 +94,21 @@ async function runTests() {
       assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), 1);
       process.env.SEARXNG_MAX_RESPONSE_BYTES = " 16777216 ";
       assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), HARD_MAX_SEARXNG_RESPONSE_BYTES);
+      process.env.SEARXNG_MAX_RESPONSE_BYTES = "+5242880";
+      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), 5242880);
+      process.env.SEARXNG_MAX_RESPONSE_BYTES = "0005242880";
+      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), 5242880);
       process.env.SEARXNG_MAX_RESPONSE_BYTES = "  ";
       assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), DEFAULT_SEARXNG_RESPONSE_MAX_BYTES);
-      process.env.SEARXNG_MAX_RESPONSE_BYTES = "0";
-      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), DEFAULT_SEARXNG_RESPONSE_MAX_BYTES);
-      process.env.SEARXNG_MAX_RESPONSE_BYTES = "16777217";
-      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), DEFAULT_SEARXNG_RESPONSE_MAX_BYTES);
-      process.env.SEARXNG_MAX_RESPONSE_BYTES = "5.5";
-      assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), DEFAULT_SEARXNG_RESPONSE_MAX_BYTES);
+      for (const invalid of ["0", "16777217", "5.5", "-0", "1e3", "5MB", "9007199254740992"]) {
+        process.env.SEARXNG_MAX_RESPONSE_BYTES = invalid;
+        assert.equal(resolveSearxngResponseMaxBytes(logger.server as any), DEFAULT_SEARXNG_RESPONSE_MAX_BYTES);
+      }
       await Promise.resolve();
       assert.equal(logger.messages.length, 1);
-      assert.ok(!logger.messages[0].includes("16777217"));
+      assert.ok(!logger.messages[0].includes("9007199254740992"));
       resetSearxngResponseConfigWarningsForTesting();
+      process.env.SEARXNG_MAX_RESPONSE_BYTES = "5MB";
       resolveSearxngResponseMaxBytes(logger.server as any);
       await Promise.resolve();
       assert.equal(logger.messages.length, 2);
@@ -104,44 +119,48 @@ async function runTests() {
     }
   }, results);
 
-  await testFunction("complete mode accepts exact bytes, rejects the next byte, and releases its lock", async () => {
+  await testFunction("complete mode accepts exact bytes, rejects the next byte, cancels, and unlocks actual bodies", async () => {
     const exact = responseWithChunks([encoder.encode("abc")]);
     assert.deepEqual(await readSearxngResponseBody(exact.response, 3), {
       text: "abc", bytesRead: 3, truncated: false,
     });
-    assert.equal(exact.getReleaseCalls(), 1);
-    const overflow = responseWithChunks([encoder.encode("abcd")]);
+    assert.equal(exact.response.body!.locked, false);
+    const overflow = responseWithChunks([encoder.encode("abcd")], { leaveOpen: true });
     await assert.rejects(() => readSearxngResponseBody(overflow.response, 3), /SearXNG response exceeds configured byte limit/);
     assert.equal(overflow.getCancelCalls(), 1);
-    assert.equal(overflow.getReleaseCalls(), 1);
-    const overflowWithCancelFailure = responseWithChunks([encoder.encode("abcd")], { cancelRejects: true });
+    assert.equal(overflow.response.body!.locked, false);
+    const overflowWithCancelFailure = responseWithChunks([encoder.encode("abcd")], { cancelRejects: true, leaveOpen: true });
     await assert.rejects(
       () => readSearxngResponseBody(overflowWithCancelFailure.response, 3),
       /SearXNG response exceeds configured byte limit/,
     );
-    assert.equal(overflowWithCancelFailure.getReleaseCalls(), 1);
+    assert.equal(overflowWithCancelFailure.getCancelCalls(), 1);
+    assert.equal(overflowWithCancelFailure.response.body!.locked, false);
   }, results);
 
-  await testFunction("complete mode measures raw UTF-8 bytes before decoding", async () => {
+  await testFunction("complete mode measures raw UTF-8 bytes before decoding with actual bodies", async () => {
     const response = responseWithChunks([new Uint8Array([0xe2]), new Uint8Array([0x82, 0xac])]);
     assert.deepEqual(await readSearxngResponseBody(response.response, 3), {
       text: "€", bytesRead: 3, truncated: false,
     });
+    assert.equal(response.response.body!.locked, false);
     const partial = responseWithChunks([new Uint8Array([0xe2]), new Uint8Array([0x82])]);
     assert.equal((await readSearxngResponseBody(partial.response, 2)).text, "�");
+    assert.equal(partial.response.body!.locked, false);
   }, results);
 
-  await testFunction("preview mode truncates at its effective limit and preserves cancellation result", async () => {
-    const truncated = responseWithChunks([encoder.encode("abcd")]);
+  await testFunction("preview mode truncates at its effective limit, cancels, and unlocks actual bodies", async () => {
+    const truncated = responseWithChunks([encoder.encode("abcd")], { leaveOpen: true });
     assert.deepEqual(await readSearxngResponseBody(truncated.response, 10, { preview: true, previewMaxBytes: 3 }), {
       text: "abc", bytesRead: 4, truncated: true,
     });
     assert.equal(truncated.getCancelCalls(), 1);
-    assert.equal(truncated.getReleaseCalls(), 1);
-    const cancelRejects = responseWithChunks([encoder.encode("abcd")], { cancelRejects: true });
+    assert.equal(truncated.response.body!.locked, false);
+    const cancelRejects = responseWithChunks([encoder.encode("abcd")], { cancelRejects: true, leaveOpen: true });
     const result = await readSearxngResponseBody(cancelRejects.response, 3, { preview: true });
     assert.equal(result.truncated, true);
-    assert.equal(cancelRejects.getReleaseCalls(), 1);
+    assert.equal(cancelRejects.getCancelCalls(), 1);
+    assert.equal(cancelRejects.response.body!.locked, false);
   }, results);
 
   await testFunction("null body is empty while an absent body is rejected without text fallback", async () => {
@@ -152,13 +171,37 @@ async function runTests() {
     await assert.rejects(() => readSearxngResponseBody(invalidResponse, 3), /Invalid SearXNG response body/);
   }, results);
 
-  await testFunction("reader failures release the lock and auxiliary cancellation never surfaces cancellation failures", async () => {
+  await testFunction("reader failures unlock actual bodies and auxiliary cancellation hides cancellation rejection", async () => {
     const rejectedRead = responseWithChunks([], { readRejects: true });
     await assert.rejects(() => readSearxngResponseBody(rejectedRead.response, 3), /read failed/);
-    assert.equal(rejectedRead.getReleaseCalls(), 1);
-    const auxiliary = responseWithChunks([], { cancelRejects: true });
+    assert.equal(rejectedRead.response.body!.locked, false);
+    const auxiliary = responseWithChunks([], { pending: true, cancelRejects: true });
     await cancelAuxiliaryResponseBody(auxiliary.response);
     assert.equal(auxiliary.getCancelCalls(), 1);
+    assert.equal(auxiliary.response.body!.locked, false);
+  }, results);
+
+  await testFunction("signal abort cancels through the reader, unlocks the actual body, and keeps abort stable when cancel rejects", async () => {
+    const controller = new AbortController();
+    const reason = new Error("caller aborted");
+    const pending = responseWithChunks([], { pending: true });
+    const read = readSearxngResponseBody(pending.response, 3, { signal: controller.signal });
+    await Promise.resolve();
+    controller.abort(reason);
+    await expectPromptAbort(read, reason);
+    assert.equal(pending.getCancelCalls(), 1);
+    assert.equal(pending.getCancelReason(), reason);
+    assert.equal(pending.response.body!.locked, false);
+
+    const rejectingController = new AbortController();
+    const rejectingReason = new Error("caller aborted with rejecting cancel");
+    const rejecting = responseWithChunks([], { pending: true, cancelRejects: true });
+    const rejectingRead = readSearxngResponseBody(rejecting.response, 3, { signal: rejectingController.signal });
+    await Promise.resolve();
+    rejectingController.abort(rejectingReason);
+    await expectPromptAbort(rejectingRead, rejectingReason);
+    assert.equal(rejecting.getCancelCalls(), 1);
+    assert.equal(rejecting.response.body!.locked, false);
   }, results);
 
   printTestSummary(results, "SearXNG Response Module");

--- a/__tests__/unit/suggestions.test.ts
+++ b/__tests__/unit/suggestions.test.ts
@@ -11,8 +11,10 @@ import { fileURLToPath } from 'node:url';
 import { performSearchSuggestions } from '../../src/suggestions.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 import { createMockServer } from '../helpers/mock-server.js';
+import { createMockServerWithTracking } from '../helpers/mock-server.js';
 import { FetchMocker, createMockFetch, createCapturingMockFetch } from '../helpers/mock-fetch.js';
 import { EnvManager } from '../helpers/env-utils.js';
+import { setLogLevel } from '../../src/logging.js';
 
 const results = createTestResults();
 const fetchMocker = new FetchMocker();
@@ -89,6 +91,142 @@ async function runTests() {
 
     fetchMocker.restore();
     envManager.restore();
+  }, results);
+
+  await testFunction('uses the byte ceiling for exact JSON responses and rejects the next byte', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    const mockServer = createMockServer();
+    const exactText = JSON.stringify(['type', ['typescript']]);
+
+    try {
+      envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(exactText)));
+      fetchMocker.mock(async () => new Response(exactText, { status: 200 }));
+      assert.deepEqual(await performSearchSuggestions(mockServer as any, 'type'), ['typescript']);
+
+      envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(exactText) - 1));
+      fetchMocker.mock(async () => new Response(exactText, { status: 200 }));
+      assert.deepEqual(await performSearchSuggestions(mockServer as any, 'type'), []);
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('resolves the response ceiling before fetch and reads the response body instead of response.json', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    const mockServer = createMockServer();
+    const body = JSON.stringify(['type', ['typescript']]);
+
+    try {
+      envManager.set('SEARXNG_MAX_RESPONSE_BYTES', String(Buffer.byteLength(body)));
+      fetchMocker.mock(async () => {
+        envManager.set('SEARXNG_MAX_RESPONSE_BYTES', '1');
+        const response = new Response(body, { status: 200 });
+        Object.defineProperty(response, 'json', {
+          value: async () => { throw new Error('response.json must not be used'); },
+        });
+        return response;
+      });
+      assert.deepEqual(await performSearchSuggestions(mockServer as any, 'type'), ['typescript']);
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('returns empty suggestions for malformed and partial response bodies without response.json fallback', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    const mockServer = createMockServer();
+
+    try {
+      for (const body of ['{bad json', '["type", ["unfinished"']) {
+        fetchMocker.mock(async () => {
+          const response = new Response(body, { status: 200 });
+          Object.defineProperty(response, 'json', {
+            value: async () => { throw new Error('response.json must not be used'); },
+          });
+          return response;
+        });
+        assert.deepEqual(await performSearchSuggestions(mockServer as any, 'type'), []);
+      }
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('keeps the five-second signal active while a headers-first body stalls', async () => {
+    envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
+    const mockServer = createMockServer();
+    const originalTimeout = AbortSignal.timeout;
+    const controller = new AbortController();
+    let requestedTimeout: number | undefined;
+
+    try {
+      Object.defineProperty(AbortSignal, 'timeout', {
+        configurable: true,
+        value: (milliseconds: number) => {
+          requestedTimeout = milliseconds;
+          return controller.signal;
+        },
+      });
+      fetchMocker.mock(async () => {
+        const response = {
+          ok: true,
+          body: new ReadableStream<Uint8Array>({
+            start(streamController) {
+              controller.signal.addEventListener('abort', () => streamController.error(new Error('aborted while reading body')));
+            },
+          }),
+          json: async () => ['type', ['unbounded-json-result']],
+        } as unknown as Response;
+        return response;
+      });
+      const pending = performSearchSuggestions(mockServer as any, 'type');
+      await Promise.resolve();
+      controller.abort();
+      assert.deepEqual(await pending, []);
+      assert.equal(requestedTimeout, 5000);
+    } finally {
+      Object.defineProperty(AbortSignal, 'timeout', { configurable: true, value: originalTimeout });
+      fetchMocker.restore();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('cancels non-success bodies even when cancellation rejects and logs failures without sensitive values', async () => {
+    const privateWord = ['pass', 'word'].join('');
+    const sensitiveQuery = ['top', ['sec', 'ret'].join(''), 'query'].join(' ');
+    envManager.set('SEARXNG_URL', `https://user:${privateWord}@test-searx.example.com`);
+    envManager.set('SEARXNG_MAX_RESPONSE_BYTES', '1');
+    const { server, getLoggingCalls } = createMockServerWithTracking();
+    setLogLevel(server as any, 'debug');
+    let cancelCalls = 0;
+
+    try {
+      fetchMocker.mock(async () => ({
+        ok: false,
+        body: {
+          cancel: async () => {
+            cancelCalls++;
+            throw new Error('cancellation rejected');
+          },
+          getReader: () => { throw new Error('non-success body must not be read'); },
+        },
+      } as unknown as Response));
+      assert.deepEqual(await performSearchSuggestions(server as any, sensitiveQuery), []);
+      assert.equal(cancelCalls, 1);
+
+      fetchMocker.mock(async () => new Response('["type", ["oversized"]]', { status: 200 }));
+      assert.deepEqual(await performSearchSuggestions(server as any, sensitiveQuery), []);
+      await Promise.resolve();
+      const messages = getLoggingCalls().map((call) => String(call.data?.message));
+      assert.ok(messages.includes('Autocomplete request failed; returning empty suggestions'));
+      assert.ok(messages.every((message) => !message.includes(sensitiveQuery) && !message.includes(privateWord) && !message.includes('oversized')));
+    } finally {
+      fetchMocker.restore();
+      envManager.restore();
+    }
   }, results);
 
   await testFunction('language parameter is appended when provided', async () => {

--- a/__tests__/unit/suggestions.test.ts
+++ b/__tests__/unit/suggestions.test.ts
@@ -155,12 +155,16 @@ async function runTests() {
     }
   }, results);
 
-  await testFunction('keeps the five-second signal active while a headers-first body stalls', async () => {
+  await testFunction('cancels a stalled response body with the five-second request signal', async () => {
     envManager.set('SEARXNG_URL', 'https://test-searx.example.com');
     const mockServer = createMockServer();
     const originalTimeout = AbortSignal.timeout;
     const controller = new AbortController();
+    const abortReason = new Error('autocomplete deadline elapsed');
     let requestedTimeout: number | undefined;
+    let cancelCalls = 0;
+    let cancellationReason: unknown;
+    let responseBody: ReadableStream<Uint8Array> | undefined;
 
     try {
       Object.defineProperty(AbortSignal, 'timeout', {
@@ -171,22 +175,30 @@ async function runTests() {
         },
       });
       fetchMocker.mock(async () => {
-        const response = {
-          ok: true,
-          body: new ReadableStream<Uint8Array>({
-            start(streamController) {
-              controller.signal.addEventListener('abort', () => streamController.error(new Error('aborted while reading body')));
-            },
-          }),
-          json: async () => ['type', ['unbounded-json-result']],
-        } as unknown as Response;
+        const stalledStream = new ReadableStream<Uint8Array>({
+          cancel(reason) {
+            cancelCalls++;
+            cancellationReason = reason;
+          },
+        });
+        const response = new Response(stalledStream, { status: 200 });
+        responseBody = response.body ?? undefined;
         return response;
       });
       const pending = performSearchSuggestions(mockServer as any, 'type');
       await Promise.resolve();
-      controller.abort();
-      assert.deepEqual(await pending, []);
+      controller.abort(abortReason);
+      const result = await Promise.race([
+        pending,
+        new Promise<never>((_resolve, reject) => {
+          setTimeout(() => reject(new Error('autocomplete did not finish after its abort signal')), 100);
+        }),
+      ]);
+      assert.deepEqual(result, []);
       assert.equal(requestedTimeout, 5000);
+      assert.equal(cancelCalls, 1);
+      assert.equal(cancellationReason, abortReason);
+      assert.equal(responseBody?.locked, false);
     } finally {
       Object.defineProperty(AbortSignal, 'timeout', { configurable: true, value: originalTimeout });
       fetchMocker.restore();

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -1,6 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logMessage } from "./logging.js";
 import { applySearchRequestConfig, fetchSearxng } from "./proxy.js";
+import {
+  cancelAuxiliaryResponseBody,
+  readSearxngResponseBody,
+  resolveSearxngResponseMaxBytes,
+} from "./searxng-response.js";
 import { getSearxngInstances, redactSearxngInstanceUrl, stripSearxngInstanceUrlUserinfo } from "./searxng-instances.js";
 
 type SearXNGConfig = Record<string, any>;
@@ -259,7 +264,45 @@ function cacheFailure(base: string, message: string, status?: number): void {
   });
 }
 
-async function requestInstanceConfig(mcpServer: McpServer, base: string): Promise<ConfigResult> {
+function safeInstanceLogTarget(base: string): string {
+  try {
+    const url = new URL(base);
+    return `${url.protocol}//${url.host}${url.pathname}`;
+  } catch {
+    return "[invalid SearXNG URL]";
+  }
+}
+
+async function readConfigResponseBody(response: Response, maxBytes: number, signal: AbortSignal): Promise<string> {
+  if (signal.aborted) {
+    await cancelAuxiliaryResponseBody(response);
+    throw signal.reason;
+  }
+
+  let onAbort: (() => void) | undefined;
+  const aborted = new Promise<never>((_, reject) => {
+    onAbort = () => {
+      void cancelAuxiliaryResponseBody(response);
+      reject(signal.reason);
+    };
+    signal.addEventListener("abort", onAbort, { once: true });
+  });
+
+  try {
+    const result = await Promise.race([
+      readSearxngResponseBody(response, maxBytes),
+      aborted,
+    ]);
+    signal.throwIfAborted?.();
+    return result.text;
+  } finally {
+    if (onAbort) {
+      signal.removeEventListener("abort", onAbort);
+    }
+  }
+}
+
+async function requestInstanceConfig(mcpServer: McpServer, base: string, maxResponseBytes: number): Promise<ConfigResult> {
   try {
     const parsedBase = new URL(base.endsWith("/") ? base : `${base}/`);
     const url = new URL("config", parsedBase);
@@ -271,6 +314,7 @@ async function requestInstanceConfig(mcpServer: McpServer, base: string): Promis
 
     const response = await fetchSearxng(requestUrl.toString(), requestOptions);
     if (!response.ok) {
+      await cancelAuxiliaryResponseBody(response);
       const message = `SearXNG /config is unavailable: HTTP ${response.status} ${response.statusText}`;
       return {
         available: false,
@@ -280,12 +324,10 @@ async function requestInstanceConfig(mcpServer: McpServer, base: string): Promis
       };
     }
 
-    const config = await response.json() as SearXNGConfig;
+    const config = JSON.parse(await readConfigResponseBody(response, maxResponseBytes, requestOptions.signal!)) as SearXNGConfig;
     return { available: true, config, sourceUrl: base };
-  } catch (error) {
-    const rawMessage = error instanceof Error ? error.message : String(error);
-    const safeMessage = rawMessage.replaceAll(base, redactSearxngInstanceUrl(base));
-    logMessage(mcpServer, "warning", `SearXNG /config fetch failed for ${redactSearxngInstanceUrl(base)}: ${safeMessage}`);
+  } catch {
+    logMessage(mcpServer, "warning", `SearXNG /config fetch failed for ${safeInstanceLogTarget(base)}: request or response processing failed.`);
     const message = "SearXNG /config is unavailable; instance capability discovery could not complete.";
     return {
       available: false,
@@ -295,7 +337,11 @@ async function requestInstanceConfig(mcpServer: McpServer, base: string): Promis
   }
 }
 
-async function fetchConfigFromInstance(mcpServer: McpServer, base: string): Promise<ConfigResult> {
+async function fetchConfigFromInstance(
+  mcpServer: McpServer,
+  base: string,
+  maxResponseBytes: number,
+): Promise<ConfigResult> {
   const cached = cachedConfigs.get(base);
   if (cached) {
     return { available: true, config: cached, sourceUrl: base };
@@ -306,7 +352,7 @@ async function fetchConfigFromInstance(mcpServer: McpServer, base: string): Prom
     return cachedFailure;
   }
 
-  const result = await requestInstanceConfig(mcpServer, base);
+  const result = await requestInstanceConfig(mcpServer, base, maxResponseBytes);
   if (result.available) {
     cachedConfigs.set(base, result.config);
     cachedConfigFailures.delete(base);
@@ -318,6 +364,7 @@ async function fetchConfigFromInstance(mcpServer: McpServer, base: string): Prom
 }
 
 async function fetchConfigs(mcpServer: McpServer, refresh = false): Promise<AggregateConfigResult> {
+  const maxResponseBytes = resolveSearxngResponseMaxBytes(mcpServer);
   const instances = getSearxngInstances();
   if (instances.length === 0) {
     return {
@@ -332,7 +379,9 @@ async function fetchConfigs(mcpServer: McpServer, refresh = false): Promise<Aggr
     cachedConfigFailures.clear();
   }
 
-  const results = await Promise.all(instances.map((instance) => fetchConfigFromInstance(mcpServer, instance)));
+  const results = await Promise.all(
+    instances.map((instance) => fetchConfigFromInstance(mcpServer, instance, maxResponseBytes)),
+  );
   const configs = results
     .filter((result): result is { available: true; config: SearXNGConfig; sourceUrl: string } => result.available)
     .map(({ config, sourceUrl }) => ({ config, sourceUrl }));

--- a/src/instance-info.ts
+++ b/src/instance-info.ts
@@ -273,43 +273,13 @@ function safeInstanceLogTarget(base: string): string {
   }
 }
 
-async function readConfigResponseBody(response: Response, maxBytes: number, signal: AbortSignal): Promise<string> {
-  if (signal.aborted) {
-    await cancelAuxiliaryResponseBody(response);
-    throw signal.reason;
-  }
-
-  let onAbort: (() => void) | undefined;
-  const aborted = new Promise<never>((_, reject) => {
-    onAbort = () => {
-      void cancelAuxiliaryResponseBody(response);
-      reject(signal.reason);
-    };
-    signal.addEventListener("abort", onAbort, { once: true });
-  });
-
-  try {
-    const result = await Promise.race([
-      readSearxngResponseBody(response, maxBytes),
-      aborted,
-    ]);
-    signal.throwIfAborted?.();
-    return result.text;
-  } finally {
-    if (onAbort) {
-      signal.removeEventListener("abort", onAbort);
-    }
-  }
-}
-
 async function requestInstanceConfig(mcpServer: McpServer, base: string, maxResponseBytes: number): Promise<ConfigResult> {
   try {
     const parsedBase = new URL(base.endsWith("/") ? base : `${base}/`);
     const url = new URL("config", parsedBase);
     const requestUrl = stripSearxngInstanceUrlUserinfo(url);
-    const requestOptions: RequestInit = {
-      signal: AbortSignal.timeout(5000),
-    };
+    const timeoutSignal = AbortSignal.timeout(5000);
+    const requestOptions: RequestInit = { signal: timeoutSignal };
     applySearchRequestConfig(requestOptions, url.toString());
 
     const response = await fetchSearxng(requestUrl.toString(), requestOptions);
@@ -324,7 +294,8 @@ async function requestInstanceConfig(mcpServer: McpServer, base: string, maxResp
       };
     }
 
-    const config = JSON.parse(await readConfigResponseBody(response, maxResponseBytes, requestOptions.signal!)) as SearXNGConfig;
+    const { text } = await readSearxngResponseBody(response, maxResponseBytes, { signal: timeoutSignal });
+    const config = JSON.parse(text) as SearXNGConfig;
     return { available: true, config, sourceUrl: base };
   } catch {
     logMessage(mcpServer, "warning", `SearXNG /config fetch failed for ${safeInstanceLogTarget(base)}: request or response processing failed.`);

--- a/src/search.ts
+++ b/src/search.ts
@@ -7,6 +7,12 @@ import { logMessage } from "./logging.js";
 import { searchCache } from "./search-cache.js";
 import { parseStrictInteger } from "./env-int.js";
 import {
+  cancelAuxiliaryResponseBody,
+  readSearxngResponseBody,
+  resolveSearxngResponseMaxBytes,
+} from "./searxng-response.js";
+import { sanitizeDiagnosticText } from "./diagnostic-sanitizer.js";
+import {
   getHealthySearxngInstances,
   getSearxngInstances,
   isSearxngFanoutEnabled,
@@ -157,33 +163,42 @@ function parseHtmlSearchResults(html: string, query: string): SearXNGWeb {
   };
 }
 
-async function fetchWithSearchTimeout(
+async function fetchWithSearchTimeout<T>(
   mcpServer: McpServer,
   url: URL,
   requestOptions: RequestInit,
   timeoutMs: number,
-  query: string,
   searxngUrl: string,
-): Promise<Response> {
+  handleResponse: (response: Response) => Promise<T>,
+): Promise<T> {
   const controller = new AbortController();
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   const rawUrl = url.toString();
   const redactedUrl = redactSearxngInstanceUrl(rawUrl);
+  const diagnosticUrl = new URL(redactedUrl);
+  diagnosticUrl.search = "";
+  diagnosticUrl.hash = "";
 
   try {
     logMessage(mcpServer, "info", `Making request to: ${redactedUrl}`);
-    return await fetchSearxng(rawUrl, {
+    const response = await fetchSearxng(rawUrl, {
       ...requestOptions,
       signal: controller.signal,
     });
+    return await handleResponse(response);
   } catch (error: any) {
+    if (error instanceof MCPSearXNGError) {
+      throw error;
+    }
     const safeMessage = typeof error?.message === "string"
-      ? error.message.replaceAll(rawUrl, redactedUrl)
+      ? error.message.replaceAll(rawUrl, diagnosticUrl.toString())
       : error?.message;
     const safeError = new Error(safeMessage);
     (safeError as any).code = error?.code;
     (safeError as any).cause = error?.cause;
-    logMessage(mcpServer, "error", `Network error during search request: ${safeMessage}`, { query, url: redactedUrl });
+    logMessage(mcpServer, "error", `Network error during search request: ${safeMessage}`, {
+      url: diagnosticUrl.toString(),
+    });
     const context: ErrorContext = {
       url: redactedUrl,
       searxngUrl: redactSearxngInstanceUrl(searxngUrl),
@@ -195,6 +210,28 @@ async function fetchWithSearchTimeout(
   }
 }
 
+async function throwBoundedServerError(
+  response: Response,
+  maxResponseBytes: number,
+  context: ErrorContext,
+): Promise<never> {
+  let responseBody = "[Could not read response body]";
+  let truncated = false;
+  try {
+    const preview = await readSearxngResponseBody(response, maxResponseBytes, { preview: true });
+    responseBody = sanitizeDiagnosticText(preview.text);
+    truncated = preview.truncated;
+  } catch {
+    // The status remains more useful than an unavailable diagnostic preview.
+  }
+
+  const serverError = createServerError(response.status, response.statusText, responseBody, context);
+  if (truncated) {
+    serverError.message += " [Response body truncated]";
+  }
+  throw serverError;
+}
+
 async function fetchHtmlFallbackSearch(
   mcpServer: McpServer,
   jsonUrl: URL,
@@ -202,28 +239,29 @@ async function fetchHtmlFallbackSearch(
   timeoutMs: number,
   query: string,
   searxngUrl: string,
+  maxResponseBytes: number,
 ): Promise<SearXNGWeb> {
   const htmlUrl = buildHtmlFallbackUrl(jsonUrl);
   logMessage(mcpServer, "info", `Retrying search with HTML fallback: ${redactSearxngInstanceUrl(htmlUrl.toString())}`);
 
-  const response = await fetchWithSearchTimeout(mcpServer, htmlUrl, requestOptions, timeoutMs, query, searxngUrl);
-  if (!response.ok) {
-    let responseBody: string;
-    try {
-      responseBody = await response.text();
-    } catch {
-      responseBody = '[Could not read response body]';
-    }
-
-    const context: ErrorContext = {
-      url: redactSearxngInstanceUrl(htmlUrl.toString()),
-      searxngUrl: redactSearxngInstanceUrl(searxngUrl),
-    };
-    throw createServerError(response.status, response.statusText, responseBody, context);
-  }
-
-  const html = await response.text();
-  return parseHtmlSearchResults(html, query);
+  return fetchWithSearchTimeout(
+    mcpServer,
+    htmlUrl,
+    requestOptions,
+    timeoutMs,
+    searxngUrl,
+    async (response) => {
+      const context: ErrorContext = {
+        url: redactSearxngInstanceUrl(htmlUrl.toString()),
+        searxngUrl: redactSearxngInstanceUrl(searxngUrl),
+      };
+      if (!response.ok) {
+        return throwBoundedServerError(response, maxResponseBytes, context);
+      }
+      const { text } = await readSearxngResponseBody(response, maxResponseBytes);
+      return parseHtmlSearchResults(text, query);
+    },
+  );
 }
 
 function hasItems<T>(items: T[] | undefined): items is T[] {
@@ -278,6 +316,7 @@ type SearchRequest = {
   effectiveSafesearch?: number;
   filters: NormalizedFilters;
   timeoutMs: number;
+  maxResponseBytes: number;
 };
 
 type InstanceSearchResult = {
@@ -556,57 +595,61 @@ async function fetchSearchFromInstance(
   const url = buildSearchUrl(instanceUrl, request);
   const requestOptions = buildSearchRequestOptions(url);
   const requestUrl = stripSearxngInstanceUrlUserinfo(url);
-  const response = await fetchWithSearchTimeout(mcpServer, requestUrl, requestOptions, request.timeoutMs, request.query, instanceUrl);
-
-  let data: SearXNGWeb;
-
-  if (!response.ok) {
-    if (isHtmlFallbackEnabled() && shouldFallbackForStatus(response.status)) {
-      data = await fetchHtmlFallbackSearch(mcpServer, requestUrl, requestOptions, request.timeoutMs, request.query, instanceUrl);
-    } else {
-      let responseBody: string;
-      try {
-        responseBody = await response.text();
-      } catch {
-        responseBody = '[Could not read response body]';
-      }
-
-      const context: ErrorContext = {
-        url: redactSearxngInstanceUrl(url.toString()),
-        searxngUrl: redactSearxngInstanceUrl(instanceUrl)
-      };
-      throw createServerError(response.status, response.statusText, responseBody, context);
-    }
-  } else {
-    // Read the body as text once, then parse — a Response body is single-use, so
-    // calling response.text() after response.json() consumed it always throws and
-    // would leave the error preview empty.
-    let responseText: string;
-    try {
-      responseText = await response.text();
-    } catch {
-      responseText = '[Could not read response text]';
-    }
-
-    try {
-      data = JSON.parse(responseText) as SearXNGWeb;
-    } catch {
-      if (isHtmlFallbackEnabled()) {
-        data = await fetchHtmlFallbackSearch(mcpServer, requestUrl, requestOptions, request.timeoutMs, request.query, instanceUrl);
-      } else {
-        throw createJSONError(responseText);
-      }
-    }
-  }
-
-  if (!data.results) {
-    throw createDataError();
-  }
-
-  return {
+  return fetchWithSearchTimeout(
+    mcpServer,
+    requestUrl,
+    requestOptions,
+    request.timeoutMs,
     instanceUrl,
-    data,
-  };
+    async (response) => {
+      let data: SearXNGWeb;
+
+      if (!response.ok) {
+        if (isHtmlFallbackEnabled() && shouldFallbackForStatus(response.status)) {
+          await cancelAuxiliaryResponseBody(response);
+          data = await fetchHtmlFallbackSearch(
+            mcpServer,
+            requestUrl,
+            requestOptions,
+            request.timeoutMs,
+            request.query,
+            instanceUrl,
+            request.maxResponseBytes,
+          );
+        } else {
+          return throwBoundedServerError(response, request.maxResponseBytes, {
+            url: redactSearxngInstanceUrl(url.toString()),
+            searxngUrl: redactSearxngInstanceUrl(instanceUrl),
+          });
+        }
+      } else {
+        const { text } = await readSearxngResponseBody(response, request.maxResponseBytes);
+        try {
+          data = JSON.parse(text) as SearXNGWeb;
+        } catch {
+          if (isHtmlFallbackEnabled()) {
+            data = await fetchHtmlFallbackSearch(
+              mcpServer,
+              requestUrl,
+              requestOptions,
+              request.timeoutMs,
+              request.query,
+              instanceUrl,
+              request.maxResponseBytes,
+            );
+          } else {
+            throw createJSONError(sanitizeDiagnosticText(text));
+          }
+        }
+      }
+
+      if (!data.results) {
+        throw createDataError();
+      }
+
+      return { instanceUrl, data };
+    },
+  );
 }
 
 function hasSearchResults(data: SearXNGWeb): boolean {
@@ -802,6 +845,7 @@ export async function performWebSearch(
   logMessage(mcpServer, "info", `Starting web search: "${query}" (${searchParams})`);
 
   const SEARCH_TIMEOUT_MS = getSearchTimeoutMs(mcpServer);
+  const responseMaxBytes = resolveSearxngResponseMaxBytes(mcpServer);
   const instances = getSearxngInstances();
   const fanoutEnabled = isSearxngFanoutEnabled();
   const includeProvenance = instances.length > 1;
@@ -813,6 +857,7 @@ export async function performWebSearch(
     effectiveSafesearch,
     filters,
     timeoutMs: SEARCH_TIMEOUT_MS,
+    maxResponseBytes: responseMaxBytes,
   };
   const cacheArgs: Record<string, unknown> = {
     query,

--- a/src/search.ts
+++ b/src/search.ts
@@ -120,6 +120,19 @@ function buildHtmlFallbackUrl(jsonUrl: URL): URL {
   return htmlUrl;
 }
 
+function getSearchDiagnosticUrl(redactedUrl: string): string {
+  try {
+    const diagnosticUrl = new URL(redactedUrl);
+    diagnosticUrl.search = "";
+    diagnosticUrl.hash = "";
+    return diagnosticUrl.toString();
+  } catch {
+    // redactSearxngInstanceUrl already removes userinfo. Retain that safe value
+    // while stripping any query or fragment if URL construction ever fails.
+    return redactedUrl.split(/[?#]/u, 1)[0];
+  }
+}
+
 function parseHtmlSearchResults(html: string, query: string): SearXNGWeb {
   const root = parse(html);
   const articles = root.querySelectorAll("article.result");
@@ -175,11 +188,10 @@ async function fetchWithSearchTimeout<T>(
   const timeoutId = setTimeout(() => controller.abort(), timeoutMs);
   const rawUrl = url.toString();
   const redactedUrl = redactSearxngInstanceUrl(rawUrl);
-  const diagnosticUrl = new URL(redactedUrl);
-  diagnosticUrl.search = "";
-  diagnosticUrl.hash = "";
+  let diagnosticUrl = redactedUrl;
 
   try {
+    diagnosticUrl = getSearchDiagnosticUrl(redactedUrl);
     logMessage(mcpServer, "info", `Making request to: ${redactedUrl}`);
     const response = await fetchSearxng(rawUrl, {
       ...requestOptions,
@@ -191,13 +203,13 @@ async function fetchWithSearchTimeout<T>(
       throw error;
     }
     const safeMessage = typeof error?.message === "string"
-      ? error.message.replaceAll(rawUrl, diagnosticUrl.toString())
+      ? error.message.replaceAll(rawUrl, diagnosticUrl)
       : error?.message;
     const safeError = new Error(safeMessage);
     (safeError as any).code = error?.code;
     (safeError as any).cause = error?.cause;
     logMessage(mcpServer, "error", `Network error during search request: ${safeMessage}`, {
-      url: diagnosticUrl.toString(),
+      url: diagnosticUrl,
     });
     const context: ErrorContext = {
       url: redactedUrl,

--- a/src/searxng-response.ts
+++ b/src/searxng-response.ts
@@ -13,6 +13,7 @@ let warnedInvalidConfigurationServers = new WeakSet<object>();
 export interface SearxngResponseReadOptions {
   preview?: boolean;
   previewMaxBytes?: number;
+  signal?: AbortSignal;
 }
 
 export interface SearxngResponseReadResult {
@@ -70,12 +71,21 @@ function responseBodyOrThrow(response: Response): ReadableStream<Uint8Array> | n
   return response.body;
 }
 
-async function bestEffortCancel(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+async function bestEffortCancel(reader: ReadableStreamDefaultReader<Uint8Array>, reason?: unknown): Promise<void> {
   try {
-    await reader.cancel();
+    await reader.cancel(reason);
   } catch {
     // A cancelled network body is best effort; it must not replace the bounded result.
   }
+}
+
+function abortReason(signal: AbortSignal): unknown {
+  if (signal.reason !== undefined) {
+    return signal.reason;
+  }
+  const error = new Error("The operation was aborted");
+  error.name = "AbortError";
+  return error;
 }
 
 export async function readSearxngResponseBody(
@@ -95,10 +105,33 @@ export async function readSearxngResponseBody(
   const chunks: Uint8Array[] = [];
   let bytesRetained = 0;
   let bytesRead = 0;
+  let abortRequested = false;
+  let abortedWith: unknown;
+  let abortHandler: (() => void) | undefined;
+  let abortPromise: Promise<never> | undefined;
+  const signal = options.signal;
+
+  if (signal !== undefined) {
+    abortPromise = new Promise<never>((_resolve, reject) => {
+      abortHandler = () => {
+        abortRequested = true;
+        abortedWith = abortReason(signal);
+        reject(abortedWith);
+      };
+      if (signal.aborted) {
+        abortHandler();
+      } else {
+        signal.addEventListener("abort", abortHandler, { once: true });
+      }
+    });
+  }
 
   try {
     while (true) {
-      const { done, value } = await reader.read();
+      const readPromise = reader.read();
+      const { done, value } = abortPromise === undefined
+        ? await readPromise
+        : await Promise.race([readPromise, abortPromise]);
       if (done) {
         break;
       }
@@ -127,7 +160,16 @@ export async function readSearxngResponseBody(
       chunks.push(value);
       bytesRetained += value.byteLength;
     }
+  } catch (error) {
+    if (abortRequested) {
+      await bestEffortCancel(reader, abortedWith);
+      throw abortedWith;
+    }
+    throw error;
   } finally {
+    if (signal !== undefined && abortHandler !== undefined) {
+      signal.removeEventListener("abort", abortHandler);
+    }
     reader.releaseLock();
   }
 

--- a/src/searxng-response.ts
+++ b/src/searxng-response.ts
@@ -8,6 +8,7 @@ export const PREVIEW_MAX_SEARXNG_RESPONSE_BYTES = 64 * 1024;
 
 const INVALID_RESPONSE_BODY_MESSAGE = "Invalid SearXNG response body";
 const RESPONSE_TOO_LARGE_MESSAGE = "SearXNG response exceeds configured byte limit";
+const responseLimitErrors = new WeakSet<Error>();
 let warnedInvalidConfigurationServers = new WeakSet<object>();
 
 export interface SearxngResponseReadOptions {
@@ -88,6 +89,117 @@ function abortReason(signal: AbortSignal): unknown {
   return error;
 }
 
+function responseTooLargeError(): Error {
+  const error = new Error(RESPONSE_TOO_LARGE_MESSAGE);
+  responseLimitErrors.add(error);
+  return error;
+}
+
+interface ResponseAccumulator {
+  chunks: Uint8Array[];
+  bytesRead: number;
+  bytesRetained: number;
+}
+
+interface AbortReadRace {
+  dispose(): void;
+  read(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<ReadableStreamReadResult<Uint8Array>>;
+  throwIfAborted(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void>;
+}
+
+function createAbortReadRace(signal: AbortSignal | undefined): AbortReadRace {
+  let abortRequested = false;
+  let abortedWith: unknown;
+  let abortHandler: (() => void) | undefined;
+  let abortPromise: Promise<never> | undefined;
+
+  if (signal !== undefined) {
+    abortPromise = new Promise<never>((_resolve, reject) => {
+      abortHandler = () => {
+        abortRequested = true;
+        abortedWith = abortReason(signal);
+        reject(abortedWith);
+      };
+      if (signal.aborted) abortHandler();
+      else signal.addEventListener("abort", abortHandler, { once: true });
+    });
+  }
+
+  return {
+    dispose: () => {
+      if (signal !== undefined && abortHandler !== undefined) signal.removeEventListener("abort", abortHandler);
+    },
+    read: (reader) => abortPromise === undefined
+      ? reader.read()
+      : Promise.race([reader.read(), abortPromise]),
+    throwIfAborted: async (reader) => {
+      if (abortRequested) {
+        await bestEffortCancel(reader, abortedWith);
+        throw abortedWith;
+      }
+    },
+  };
+}
+
+function buildReadResult(accumulator: ResponseAccumulator, truncated: boolean): SearxngResponseReadResult {
+  return {
+    text: new TextDecoder("utf-8").decode(concatenateChunks(accumulator.chunks, accumulator.bytesRetained)),
+    bytesRead: accumulator.bytesRead,
+    truncated,
+  };
+}
+
+async function retainResponseChunk(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  value: Uint8Array | undefined,
+  effectiveLimit: number,
+  preview: boolean,
+  accumulator: ResponseAccumulator,
+): Promise<SearxngResponseReadResult | undefined> {
+  if (!value) return undefined;
+
+  accumulator.bytesRead += value.byteLength;
+  const remaining = effectiveLimit - accumulator.bytesRetained;
+  if (value.byteLength <= remaining) {
+    accumulator.chunks.push(value);
+    accumulator.bytesRetained += value.byteLength;
+    return undefined;
+  }
+
+  if (preview && remaining > 0) {
+    accumulator.chunks.push(value.subarray(0, remaining));
+    accumulator.bytesRetained += remaining;
+  }
+  await bestEffortCancel(reader);
+  if (preview) return buildReadResult(accumulator, true);
+  throw responseTooLargeError();
+}
+
+async function consumeResponseBody(
+  reader: ReadableStreamDefaultReader<Uint8Array>,
+  effectiveLimit: number,
+  preview: boolean,
+  signal: AbortSignal | undefined,
+): Promise<SearxngResponseReadResult> {
+  const accumulator: ResponseAccumulator = { chunks: [], bytesRead: 0, bytesRetained: 0 };
+  const abortRace = createAbortReadRace(signal);
+
+  try {
+    while (true) {
+      const { done, value } = await abortRace.read(reader);
+      if (done) return buildReadResult(accumulator, false);
+      const truncated = await retainResponseChunk(reader, value, effectiveLimit, preview, accumulator);
+      if (truncated !== undefined) return truncated;
+    }
+  } catch (error) {
+    if (error instanceof Error && responseLimitErrors.has(error)) throw error;
+    await abortRace.throwIfAborted(reader);
+    throw error;
+  } finally {
+    abortRace.dispose();
+  }
+}
+
 export async function readSearxngResponseBody(
   response: Response,
   maxBytes: number,
@@ -102,82 +214,12 @@ export async function readSearxngResponseBody(
   const previewLimit = options.previewMaxBytes ?? PREVIEW_MAX_SEARXNG_RESPONSE_BYTES;
   const effectiveLimit = preview ? Math.min(maxBytes, previewLimit) : maxBytes;
   const reader = body.getReader();
-  const chunks: Uint8Array[] = [];
-  let bytesRetained = 0;
-  let bytesRead = 0;
-  let abortRequested = false;
-  let abortedWith: unknown;
-  let abortHandler: (() => void) | undefined;
-  let abortPromise: Promise<never> | undefined;
-  const signal = options.signal;
-
-  if (signal !== undefined) {
-    abortPromise = new Promise<never>((_resolve, reject) => {
-      abortHandler = () => {
-        abortRequested = true;
-        abortedWith = abortReason(signal);
-        reject(abortedWith);
-      };
-      if (signal.aborted) {
-        abortHandler();
-      } else {
-        signal.addEventListener("abort", abortHandler, { once: true });
-      }
-    });
-  }
 
   try {
-    while (true) {
-      const readPromise = reader.read();
-      const { done, value } = abortPromise === undefined
-        ? await readPromise
-        : await Promise.race([readPromise, abortPromise]);
-      if (done) {
-        break;
-      }
-      if (!value) {
-        continue;
-      }
-
-      bytesRead += value.byteLength;
-      const remaining = effectiveLimit - bytesRetained;
-      if (value.byteLength > remaining) {
-        if (preview && remaining > 0) {
-          chunks.push(value.subarray(0, remaining));
-          bytesRetained += remaining;
-        }
-        await bestEffortCancel(reader);
-        if (preview) {
-          return {
-            text: new TextDecoder("utf-8").decode(concatenateChunks(chunks, bytesRetained)),
-            bytesRead,
-            truncated: true,
-          };
-        }
-        throw new Error(RESPONSE_TOO_LARGE_MESSAGE);
-      }
-
-      chunks.push(value);
-      bytesRetained += value.byteLength;
-    }
-  } catch (error) {
-    if (abortRequested) {
-      await bestEffortCancel(reader, abortedWith);
-      throw abortedWith;
-    }
-    throw error;
+    return await consumeResponseBody(reader, effectiveLimit, preview, options.signal);
   } finally {
-    if (signal !== undefined && abortHandler !== undefined) {
-      signal.removeEventListener("abort", abortHandler);
-    }
     reader.releaseLock();
   }
-
-  return {
-    text: new TextDecoder("utf-8").decode(concatenateChunks(chunks, bytesRetained)),
-    bytesRead,
-    truncated: false,
-  };
 }
 
 export async function cancelAuxiliaryResponseBody(response: Response): Promise<void> {

--- a/src/searxng-response.ts
+++ b/src/searxng-response.ts
@@ -1,0 +1,147 @@
+import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
+import { parseStrictInteger } from "./env-int.js";
+import { logMessage } from "./logging.js";
+
+export const DEFAULT_SEARXNG_RESPONSE_MAX_BYTES = 5 * 1024 * 1024;
+export const HARD_MAX_SEARXNG_RESPONSE_BYTES = 16 * 1024 * 1024;
+export const PREVIEW_MAX_SEARXNG_RESPONSE_BYTES = 64 * 1024;
+
+const INVALID_RESPONSE_BODY_MESSAGE = "Invalid SearXNG response body";
+const RESPONSE_TOO_LARGE_MESSAGE = "SearXNG response exceeds configured byte limit";
+let warnedInvalidConfigurationServers = new WeakSet<object>();
+
+export interface SearxngResponseReadOptions {
+  preview?: boolean;
+  previewMaxBytes?: number;
+}
+
+export interface SearxngResponseReadResult {
+  text: string;
+  bytesRead: number;
+  truncated: boolean;
+}
+
+export function resetSearxngResponseConfigWarningsForTesting(): void {
+  warnedInvalidConfigurationServers = new WeakSet<object>();
+}
+
+export function resolveSearxngResponseMaxBytes(mcpServer: McpServer): number {
+  const rawValue = process.env.SEARXNG_MAX_RESPONSE_BYTES;
+  if (rawValue === undefined || rawValue.trim() === "") {
+    return DEFAULT_SEARXNG_RESPONSE_MAX_BYTES;
+  }
+
+  const parsed = parseStrictInteger(rawValue);
+  if (parsed !== undefined && parsed >= 1 && parsed <= HARD_MAX_SEARXNG_RESPONSE_BYTES) {
+    return parsed;
+  }
+
+  if (!warnedInvalidConfigurationServers.has(mcpServer)) {
+    warnedInvalidConfigurationServers.add(mcpServer);
+    logMessage(
+      mcpServer,
+      "warning",
+      "Ignoring invalid SEARXNG_MAX_RESPONSE_BYTES; using the safe default response limit.",
+    );
+  }
+  return DEFAULT_SEARXNG_RESPONSE_MAX_BYTES;
+}
+
+function concatenateChunks(chunks: Uint8Array[], totalBytes: number): Uint8Array {
+  const result = new Uint8Array(totalBytes);
+  let offset = 0;
+  for (const chunk of chunks) {
+    result.set(chunk, offset);
+    offset += chunk.byteLength;
+  }
+  return result;
+}
+
+function responseBodyOrThrow(response: Response): ReadableStream<Uint8Array> | null {
+  if (response === null || typeof response !== "object" || !("body" in response)) {
+    throw new Error(INVALID_RESPONSE_BODY_MESSAGE);
+  }
+  if (response.body === null) {
+    return null;
+  }
+  if (response.body === undefined || typeof response.body.getReader !== "function") {
+    throw new Error(INVALID_RESPONSE_BODY_MESSAGE);
+  }
+  return response.body;
+}
+
+async function bestEffortCancel(reader: ReadableStreamDefaultReader<Uint8Array>): Promise<void> {
+  try {
+    await reader.cancel();
+  } catch {
+    // A cancelled network body is best effort; it must not replace the bounded result.
+  }
+}
+
+export async function readSearxngResponseBody(
+  response: Response,
+  maxBytes: number,
+  options: SearxngResponseReadOptions = {},
+): Promise<SearxngResponseReadResult> {
+  const body = responseBodyOrThrow(response);
+  if (body === null) {
+    return { text: "", bytesRead: 0, truncated: false };
+  }
+
+  const preview = options.preview === true;
+  const previewLimit = options.previewMaxBytes ?? PREVIEW_MAX_SEARXNG_RESPONSE_BYTES;
+  const effectiveLimit = preview ? Math.min(maxBytes, previewLimit) : maxBytes;
+  const reader = body.getReader();
+  const chunks: Uint8Array[] = [];
+  let bytesRetained = 0;
+  let bytesRead = 0;
+
+  try {
+    while (true) {
+      const { done, value } = await reader.read();
+      if (done) {
+        break;
+      }
+      if (!value) {
+        continue;
+      }
+
+      bytesRead += value.byteLength;
+      const remaining = effectiveLimit - bytesRetained;
+      if (value.byteLength > remaining) {
+        if (preview && remaining > 0) {
+          chunks.push(value.subarray(0, remaining));
+          bytesRetained += remaining;
+        }
+        await bestEffortCancel(reader);
+        if (preview) {
+          return {
+            text: new TextDecoder("utf-8").decode(concatenateChunks(chunks, bytesRetained)),
+            bytesRead,
+            truncated: true,
+          };
+        }
+        throw new Error(RESPONSE_TOO_LARGE_MESSAGE);
+      }
+
+      chunks.push(value);
+      bytesRetained += value.byteLength;
+    }
+  } finally {
+    reader.releaseLock();
+  }
+
+  return {
+    text: new TextDecoder("utf-8").decode(concatenateChunks(chunks, bytesRetained)),
+    bytesRead,
+    truncated: false,
+  };
+}
+
+export async function cancelAuxiliaryResponseBody(response: Response): Promise<void> {
+  try {
+    await response.body?.cancel();
+  } catch {
+    // Auxiliary response cleanup cannot hide the useful upstream outcome.
+  }
+}

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -1,6 +1,11 @@
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { logMessage } from "./logging.js";
 import { applySearchRequestConfig, fetchSearxng } from "./proxy.js";
+import {
+  cancelAuxiliaryResponseBody,
+  readSearxngResponseBody,
+  resolveSearxngResponseMaxBytes,
+} from "./searxng-response.js";
 import { getPrimarySearxngInstance, stripSearxngInstanceUrlUserinfo } from "./searxng-instances.js";
 
 export async function performSearchSuggestions(
@@ -12,6 +17,7 @@ export async function performSearchSuggestions(
   if (!base) {
     return [];
   }
+  const responseMaxBytes = resolveSearxngResponseMaxBytes(mcpServer);
 
   const parsedBase = new URL(base.endsWith("/") ? base : `${base}/`);
   const url = new URL("autocompleter", parsedBase);
@@ -29,10 +35,12 @@ export async function performSearchSuggestions(
 
     const response = await fetchSearxng(requestUrl.toString(), requestOptions);
     if (!response.ok) {
+      await cancelAuxiliaryResponseBody(response);
       return [];
     }
 
-    const data = await response.json() as [string, string[]];
+    const { text } = await readSearxngResponseBody(response, responseMaxBytes);
+    const data = JSON.parse(text) as [string, string[]];
     return Array.isArray(data[1]) ? data[1] : [];
   } catch {
     logMessage(mcpServer, "debug", "Autocomplete request failed; returning empty suggestions");

--- a/src/suggestions.ts
+++ b/src/suggestions.ts
@@ -28,8 +28,9 @@ export async function performSearchSuggestions(
   const requestUrl = stripSearxngInstanceUrlUserinfo(url);
 
   try {
+    const signal = AbortSignal.timeout(5000);
     const requestOptions: RequestInit = {
-      signal: AbortSignal.timeout(5000),
+      signal,
     };
     applySearchRequestConfig(requestOptions, url.toString());
 
@@ -39,7 +40,7 @@ export async function performSearchSuggestions(
       return [];
     }
 
-    const { text } = await readSearxngResponseBody(response, responseMaxBytes);
+    const { text } = await readSearxngResponseBody(response, responseMaxBytes, { signal });
     const data = JSON.parse(text) as [string, string[]];
     return Array.isArray(data[1]) ? data[1] : [];
   } catch {


### PR DESCRIPTION
## Summary
- bound streamed SearXNG response consumption for search JSON, HTML fallback, error previews, instance capability discovery, and autocomplete
- keep request deadlines active through response-body reads and prevent failed or oversized bodies from populating caches or health success
- document SEARXNG_MAX_RESPONSE_BYTES, its strict grammar, limits, and per-response scope

## Verification
- npm run lint
- npm run audit:deps and npm audit --omit=dev (0 vulnerabilities)
- npm run test:coverage (736/736; 94.90% lines, 92.02% branches)
- npm run build && npm run test:e2e (28/28; optional protected-PDF live endpoint skipped)
- npm run verify:packed-consumer (adapters=2.1.1, audit=0, tools=4)