### PR TITLE
feat(runtime): deprecate Node.js 20 and refresh dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '24']
+        node-version: ['20', '22', '24', '26.7.0']
 
     steps:
       - name: Checkout code

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,7 +25,7 @@ jobs:
         uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
 
       - name: Initialize CodeQL
-        uses: github/codeql-action/init@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/init@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           languages: javascript-typescript
           queries: security-and-quality
@@ -34,6 +34,6 @@ jobs:
         run: npm ci && npm run build
 
       - name: Perform CodeQL Analysis
-        uses: github/codeql-action/analyze@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/analyze@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           category: /language:javascript-typescript

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -60,7 +60,7 @@ jobs:
           exit-code: '1'
 
       - name: Upload Trivy scan results to Security tab
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/docker-publish.yml
+++ b/.github/workflows/docker-publish.yml
@@ -83,7 +83,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -148,7 +148,7 @@ jobs:
         uses: docker/setup-buildx-action@bb05f3f5519dd87d3ba754cc423b652a5edd6d2c # v4.2.0
 
       - name: Log in to Docker Hub
-        uses: docker/login-action@abd2ef45e78c5afb21d64d4ca52ee8550d9572c7 # v4.5.1
+        uses: docker/login-action@dbcb813823bdd20940b903addbd779551569679f # v4.6.0
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}

--- a/.github/workflows/docker-rebuild.yml
+++ b/.github/workflows/docker-rebuild.yml
@@ -105,7 +105,7 @@ jobs:
           exit-code: '1'
 
       - name: Upload Trivy scan results to Security tab
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         if: always()
         with:
           sarif_file: 'trivy-results.sarif'

--- a/.github/workflows/scorecard.yml
+++ b/.github/workflows/scorecard.yml
@@ -73,6 +73,6 @@ jobs:
       # Upload the results to GitHub's code scanning dashboard (optional).
       # Commenting out will disable upload of results to your repo's Code Scanning dashboard
       - name: "Upload to code-scanning"
-        uses: github/codeql-action/upload-sarif@e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81 # v4.37.3
+        uses: github/codeql-action/upload-sarif@ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd # v4.37.7
         with:
           sarif_file: results.sarif

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ For SearXNG deployment, configuration, and troubleshooting, see
 
 ## Installation
 
-Requires Node.js 20 or later.
+Node.js 20 remains supported but is deprecated and end-of-life. Node.js 22 or later is recommended. Node.js 20 will be removed only in a future major release.
 
 <details>
 <summary>NPM (global install)</summary>

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -67,6 +67,49 @@ function readText(url: URL): string {
   return readFileSync(url, 'utf-8');
 }
 
+function hasDependabotIgnoreEntry(source: string, dependencyName: string): boolean {
+  let updateIndentation = -1;
+  let ignoreIndentation = -1;
+
+  for (const rawLine of source.split(/\r?\n/u)) {
+    const lineWithoutComment = rawLine.replace(/\s+#.*$/u, '');
+    const line = lineWithoutComment.trim();
+    if (line === '') continue;
+
+    const indentation = rawLine.length - rawLine.trimStart().length;
+    if (/^-\s+package-ecosystem\s*:/u.test(line)) {
+      updateIndentation = indentation;
+      ignoreIndentation = -1;
+      continue;
+    }
+    if (updateIndentation === -1) continue;
+    if (indentation <= updateIndentation && /^-\s+/u.test(line)) {
+      updateIndentation = -1;
+      ignoreIndentation = -1;
+      continue;
+    }
+    if (ignoreIndentation !== -1 && indentation <= ignoreIndentation) {
+      ignoreIndentation = -1;
+    }
+    if (indentation > updateIndentation && /^ignore\s*:\s*$/u.test(line)) {
+      ignoreIndentation = indentation;
+      continue;
+    }
+    if (ignoreIndentation === -1 || indentation <= ignoreIndentation) continue;
+
+    const match = line.match(/^-\s*dependency-name\s*:\s*(.+?)\s*$/u);
+    if (match === null) continue;
+    const value = match[1].trim();
+    const unquotedValue = (value.startsWith('"') && value.endsWith('"'))
+      || (value.startsWith("'") && value.endsWith("'"))
+      ? value.slice(1, -1)
+      : value;
+    if (unquotedValue === dependencyName) return true;
+  }
+
+  return false;
+}
+
 function extractFences(markdown: string, language: string): string[] {
   const blocks: string[] = [];
   let active: string[] | null = null;
@@ -225,9 +268,90 @@ export async function runTests(): Promise<TestResult> {
     }
   }, results);
 
-  await testFunction('README states the supported Node runtime floor', () => {
+  await testFunction('README and public workflow metadata state the Node support policy', () => {
     const readme = readText(new URL('../../README.md', import.meta.url));
-    assert.ok(readme.includes('Requires Node.js 20 or later.'));
+    const ci = readText(new URL('../../.github/workflows/ci.yml', import.meta.url));
+    const codeql = readText(new URL('../../.github/workflows/codeql.yml', import.meta.url));
+    const scorecard = readText(new URL('../../.github/workflows/scorecard.yml', import.meta.url));
+    const dockerPublish = readText(new URL('../../.github/workflows/docker-publish.yml', import.meta.url));
+    const dockerRebuild = readText(new URL('../../.github/workflows/docker-rebuild.yml', import.meta.url));
+    const dependabot = readText(new URL('../../.github/dependabot.yml', import.meta.url));
+    const packageManifest = JSON.parse(readText(new URL('../../package.json', import.meta.url))) as {
+      dependencies?: Record<string, unknown>;
+      engines?: Record<string, unknown>;
+      version?: unknown;
+    };
+
+    assert.equal(packageManifest.version, '1.16.0');
+    assert.equal(packageManifest.engines?.node, '>=20');
+    assert.equal(packageManifest.dependencies?.['express-rate-limit'], '^8.5.2');
+
+    assert.ok(readme.includes('Node.js 20 remains supported but is deprecated and end-of-life.'));
+    assert.ok(readme.includes('Node.js 22 or later is recommended.'));
+    assert.ok(readme.includes('Node.js 20 will be removed only in a future major release.'));
+
+    const matrix = ci.match(/^\s*node-version:\s*\[([^\]]+)\]\s*$/mu);
+    assert.ok(matrix, 'CI must declare an inline Node version matrix');
+    assert.deepEqual(
+      [...matrix[1].matchAll(/['"]([^'"]+)['"]/gu)].map((match) => match[1]),
+      ['20', '22', '24', '26.7.0'],
+    );
+    const jobs = ci.slice(ci.indexOf('jobs:'));
+    assert.deepEqual((jobs.match(/^  [A-Za-z0-9_-]+:\s*$/gmu) ?? []).map((line) => line.trim()), ['test:']);
+    assert.match(ci, /uses:\s*actions\/checkout@/u);
+    assert.match(ci, /uses:\s*actions\/setup-node@/u);
+    assert.match(ci, /cache:\s*['"]npm['"]/u);
+    for (const command of [
+      /run:\s*npm ci/u,
+      /run:\s*npm run lint/u,
+      /run:\s*npm run build/u,
+      /run:\s*npm run test:coverage/u,
+    ]) {
+      assert.match(ci, command);
+    }
+    assert.doesNotMatch(ci, /^\s*include\s*:/mu);
+    assert.doesNotMatch(ci, /^\s*if\s*:/mu);
+    assert.doesNotMatch(ci, /continue-on-error\s*:/u);
+
+    const oldCodeqlSha = 'e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81';
+    const newCodeqlSha = 'ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd';
+    for (const workflow of [codeql, scorecard]) {
+      assert.ok(!workflow.includes(oldCodeqlSha));
+      const codeqlReferences = [
+        ...workflow.matchAll(/uses:\s*github\/codeql-action\/[^@\s]+@([a-f0-9]{40})\s*#\s*(v[^\s]+)/gu),
+      ];
+      assert.ok(codeqlReferences.length > 0, 'workflow must retain CodeQL action references');
+      for (const reference of codeqlReferences) {
+        assert.equal(reference[1], newCodeqlSha);
+        assert.equal(reference[2], 'v4.37.7');
+      }
+    }
+
+    const oldDockerLoginSha = 'abd2ef45e78c5afb21d64d4ca52ee8550d9572c7';
+    const newDockerLoginSha = 'dbcb813823bdd20940b903addbd779551569679f';
+    for (const workflow of [dockerPublish, dockerRebuild]) {
+      assert.ok(!workflow.includes(oldDockerLoginSha));
+      const dockerLoginReferences = [
+        ...workflow.matchAll(/uses:\s*docker\/login-action@([a-f0-9]{40})\s*#\s*(v[^\s]+)/gu),
+      ];
+      assert.equal(dockerLoginReferences.length, 1);
+      assert.equal(dockerLoginReferences[0][1], newDockerLoginSha);
+      assert.equal(dockerLoginReferences[0][2], 'v4.6.0');
+    }
+
+    const ignoredUnpdfFixture = `updates:
+  - package-ecosystem: npm
+    ignore:
+      - dependency-name: "unpdf" # controlled ignored package
+`;
+    const allowedUnpdfFixture = `updates:
+  - package-ecosystem: npm
+    allow:
+      - dependency-name: unpdf # controlled allowed package
+`;
+    assert.ok(hasDependabotIgnoreEntry(ignoredUnpdfFixture, 'unpdf'));
+    assert.ok(!hasDependabotIgnoreEntry(allowedUnpdfFixture, 'unpdf'));
+    assert.ok(!hasDependabotIgnoreEntry(dependabot, 'unpdf'));
   }, results);
 
   await testFunction('cookbook exists and README links to it', () => {

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -67,47 +67,161 @@ function readText(url: URL): string {
   return readFileSync(url, 'utf-8');
 }
 
+type DependabotIgnoreState = {
+  ignoreIndentation: number;
+  updateIndentation: number;
+};
+
+type YamlLine = {
+  indentation: number;
+  text: string;
+};
+
+type PackageManifest = {
+  dependencies?: Record<string, unknown>;
+  engines?: Record<string, unknown>;
+  version?: unknown;
+};
+
+function toYamlLine(rawLine: string): YamlLine {
+  return {
+    indentation: rawLine.length - rawLine.trimStart().length,
+    text: rawLine.replace(/\s+#.*$/u, '').trim(),
+  };
+}
+
+function isDependabotUpdate(line: YamlLine): boolean {
+  return /^-\s+package-ecosystem\s*:/u.test(line.text);
+}
+
+function isNextUpdateEntry(state: DependabotIgnoreState, line: YamlLine): boolean {
+  return state.updateIndentation !== -1
+    && line.indentation <= state.updateIndentation
+    && /^-\s+/u.test(line.text);
+}
+
+function startsIgnoreBlock(state: DependabotIgnoreState, line: YamlLine): boolean {
+  return state.updateIndentation !== -1
+    && line.indentation > state.updateIndentation
+    && /^ignore\s*:\s*$/u.test(line.text);
+}
+
+function endsIgnoreBlock(state: DependabotIgnoreState, line: YamlLine): boolean {
+  return state.ignoreIndentation !== -1 && line.indentation <= state.ignoreIndentation;
+}
+
+function nextDependabotIgnoreState(state: DependabotIgnoreState, line: YamlLine): DependabotIgnoreState {
+  if (line.text === '') return state;
+  if (isDependabotUpdate(line)) return { updateIndentation: line.indentation, ignoreIndentation: -1 };
+  if (isNextUpdateEntry(state, line)) return { updateIndentation: -1, ignoreIndentation: -1 };
+  if (startsIgnoreBlock(state, line)) return { ...state, ignoreIndentation: line.indentation };
+  if (endsIgnoreBlock(state, line)) return { ...state, ignoreIndentation: -1 };
+  return state;
+}
+
+function unquoteYamlScalar(value: string): string {
+  const trimmed = value.trim();
+  const quote = trimmed[0];
+  return quote === '"' || quote === "'" ? trimmed.slice(1, -1) : trimmed;
+}
+
+function dependencyNameFromIgnoreItem(line: YamlLine): string | undefined {
+  const match = line.text.match(/^-\s*dependency-name\s*:\s*(.+?)\s*$/u);
+  return match === null ? undefined : unquoteYamlScalar(match[1]);
+}
+
+function isIgnoredDependency(state: DependabotIgnoreState, line: YamlLine, dependencyName: string): boolean {
+  return state.ignoreIndentation !== -1
+    && line.indentation > state.ignoreIndentation
+    && dependencyNameFromIgnoreItem(line) === dependencyName;
+}
+
 function hasDependabotIgnoreEntry(source: string, dependencyName: string): boolean {
-  let updateIndentation = -1;
-  let ignoreIndentation = -1;
-
+  let state: DependabotIgnoreState = { updateIndentation: -1, ignoreIndentation: -1 };
   for (const rawLine of source.split(/\r?\n/u)) {
-    const lineWithoutComment = rawLine.replace(/\s+#.*$/u, '');
-    const line = lineWithoutComment.trim();
-    if (line === '') continue;
-
-    const indentation = rawLine.length - rawLine.trimStart().length;
-    if (/^-\s+package-ecosystem\s*:/u.test(line)) {
-      updateIndentation = indentation;
-      ignoreIndentation = -1;
-      continue;
-    }
-    if (updateIndentation === -1) continue;
-    if (indentation <= updateIndentation && /^-\s+/u.test(line)) {
-      updateIndentation = -1;
-      ignoreIndentation = -1;
-      continue;
-    }
-    if (ignoreIndentation !== -1 && indentation <= ignoreIndentation) {
-      ignoreIndentation = -1;
-    }
-    if (indentation > updateIndentation && /^ignore\s*:\s*$/u.test(line)) {
-      ignoreIndentation = indentation;
-      continue;
-    }
-    if (ignoreIndentation === -1 || indentation <= ignoreIndentation) continue;
-
-    const match = line.match(/^-\s*dependency-name\s*:\s*(.+?)\s*$/u);
-    if (match === null) continue;
-    const value = match[1].trim();
-    const unquotedValue = (value.startsWith('"') && value.endsWith('"'))
-      || (value.startsWith("'") && value.endsWith("'"))
-      ? value.slice(1, -1)
-      : value;
-    if (unquotedValue === dependencyName) return true;
+    const line = toYamlLine(rawLine);
+    state = nextDependabotIgnoreState(state, line);
+    if (isIgnoredDependency(state, line, dependencyName)) return true;
   }
-
   return false;
+}
+
+function assertPackageMetadata(): void {
+  const packageManifest = JSON.parse(readText(new URL('../../package.json', import.meta.url))) as PackageManifest;
+  assert.equal(packageManifest.version, '1.16.0');
+  assert.equal(packageManifest.engines?.node, '>=20');
+  assert.equal(packageManifest.dependencies?.['express-rate-limit'], '^8.5.2');
+}
+
+function assertReadmeNodePolicy(readme: string): void {
+  assert.ok(readme.includes('Node.js 20 remains supported but is deprecated and end-of-life.'));
+  assert.ok(readme.includes('Node.js 22 or later is recommended.'));
+  assert.ok(readme.includes('Node.js 20 will be removed only in a future major release.'));
+}
+
+function assertCiMatrix(ci: string): void {
+  const matrix = ci.match(/^\s*node-version:\s*\[([^\]]+)\]\s*$/mu);
+  assert.ok(matrix, 'CI must declare an inline Node version matrix');
+  assert.deepEqual(
+    [...matrix[1].matchAll(/['"]([^'"]+)['"]/gu)].map((match) => match[1]),
+    ['20', '22', '24', '26.7.0'],
+  );
+}
+
+function assertCiCommonJob(ci: string): void {
+  const jobs = ci.slice(ci.indexOf('jobs:'));
+  assert.deepEqual((jobs.match(/^  [A-Za-z0-9_-]+:\s*$/gmu) ?? []).map((line) => line.trim()), ['test:']);
+  assert.match(ci, /uses:\s*actions\/checkout@/u);
+  assert.match(ci, /uses:\s*actions\/setup-node@/u);
+  assert.match(ci, /cache:\s*['"]npm['"]/u);
+  for (const command of [/run:\s*npm ci/u, /run:\s*npm run lint/u, /run:\s*npm run build/u, /run:\s*npm run test:coverage/u]) {
+    assert.match(ci, command);
+  }
+  assert.doesNotMatch(ci, /^\s*include\s*:/mu);
+  assert.doesNotMatch(ci, /^\s*if\s*:/mu);
+  assert.doesNotMatch(ci, /continue-on-error\s*:/u);
+}
+
+function assertCodeqlActionPins(workflow: string): void {
+  const oldCodeqlSha = 'e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81';
+  const newCodeqlSha = 'ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd';
+  assert.ok(!workflow.includes(oldCodeqlSha));
+  const references = [
+    ...workflow.matchAll(/uses:\s*github\/codeql-action\/[^@\s]+@([a-f0-9]{40})\s*#\s*(v[^\s]+)/gu),
+  ];
+  assert.ok(references.length > 0, 'workflow must retain CodeQL action references');
+  for (const reference of references) {
+    assert.equal(reference[1], newCodeqlSha);
+    assert.equal(reference[2], 'v4.37.7');
+  }
+}
+
+function assertDockerLoginPin(workflow: string): void {
+  const oldDockerLoginSha = 'abd2ef45e78c5afb21d64d4ca52ee8550d9572c7';
+  const newDockerLoginSha = 'dbcb813823bdd20940b903addbd779551569679f';
+  assert.ok(!workflow.includes(oldDockerLoginSha));
+  const references = [
+    ...workflow.matchAll(/uses:\s*docker\/login-action@([a-f0-9]{40})\s*#\s*(v[^\s]+)/gu),
+  ];
+  assert.equal(references.length, 1);
+  assert.equal(references[0][1], newDockerLoginSha);
+  assert.equal(references[0][2], 'v4.6.0');
+}
+
+function assertDependabotUnpdfPolicy(dependabot: string): void {
+  const ignoredUnpdfFixture = `updates:
+  - package-ecosystem: npm
+    ignore:
+      - dependency-name: "unpdf" # controlled ignored package
+`;
+  const allowedUnpdfFixture = `updates:
+  - package-ecosystem: npm
+    allow:
+      - dependency-name: unpdf # controlled allowed package
+`;
+  assert.ok(hasDependabotIgnoreEntry(ignoredUnpdfFixture, 'unpdf'));
+  assert.ok(!hasDependabotIgnoreEntry(allowedUnpdfFixture, 'unpdf'));
+  assert.ok(!hasDependabotIgnoreEntry(dependabot, 'unpdf'));
 }
 
 function extractFences(markdown: string, language: string): string[] {
@@ -276,82 +390,15 @@ export async function runTests(): Promise<TestResult> {
     const dockerPublish = readText(new URL('../../.github/workflows/docker-publish.yml', import.meta.url));
     const dockerRebuild = readText(new URL('../../.github/workflows/docker-rebuild.yml', import.meta.url));
     const dependabot = readText(new URL('../../.github/dependabot.yml', import.meta.url));
-    const packageManifest = JSON.parse(readText(new URL('../../package.json', import.meta.url))) as {
-      dependencies?: Record<string, unknown>;
-      engines?: Record<string, unknown>;
-      version?: unknown;
-    };
-
-    assert.equal(packageManifest.version, '1.16.0');
-    assert.equal(packageManifest.engines?.node, '>=20');
-    assert.equal(packageManifest.dependencies?.['express-rate-limit'], '^8.5.2');
-
-    assert.ok(readme.includes('Node.js 20 remains supported but is deprecated and end-of-life.'));
-    assert.ok(readme.includes('Node.js 22 or later is recommended.'));
-    assert.ok(readme.includes('Node.js 20 will be removed only in a future major release.'));
-
-    const matrix = ci.match(/^\s*node-version:\s*\[([^\]]+)\]\s*$/mu);
-    assert.ok(matrix, 'CI must declare an inline Node version matrix');
-    assert.deepEqual(
-      [...matrix[1].matchAll(/['"]([^'"]+)['"]/gu)].map((match) => match[1]),
-      ['20', '22', '24', '26.7.0'],
-    );
-    const jobs = ci.slice(ci.indexOf('jobs:'));
-    assert.deepEqual((jobs.match(/^  [A-Za-z0-9_-]+:\s*$/gmu) ?? []).map((line) => line.trim()), ['test:']);
-    assert.match(ci, /uses:\s*actions\/checkout@/u);
-    assert.match(ci, /uses:\s*actions\/setup-node@/u);
-    assert.match(ci, /cache:\s*['"]npm['"]/u);
-    for (const command of [
-      /run:\s*npm ci/u,
-      /run:\s*npm run lint/u,
-      /run:\s*npm run build/u,
-      /run:\s*npm run test:coverage/u,
-    ]) {
-      assert.match(ci, command);
-    }
-    assert.doesNotMatch(ci, /^\s*include\s*:/mu);
-    assert.doesNotMatch(ci, /^\s*if\s*:/mu);
-    assert.doesNotMatch(ci, /continue-on-error\s*:/u);
-
-    const oldCodeqlSha = 'e4fba868fa4b1b91e1fdab776edc8cfbe6e9fb81';
-    const newCodeqlSha = 'ff2f1c621b7f889edc0d3c761ac2e6a3f8cdb0dd';
-    for (const workflow of [codeql, scorecard]) {
-      assert.ok(!workflow.includes(oldCodeqlSha));
-      const codeqlReferences = [
-        ...workflow.matchAll(/uses:\s*github\/codeql-action\/[^@\s]+@([a-f0-9]{40})\s*#\s*(v[^\s]+)/gu),
-      ];
-      assert.ok(codeqlReferences.length > 0, 'workflow must retain CodeQL action references');
-      for (const reference of codeqlReferences) {
-        assert.equal(reference[1], newCodeqlSha);
-        assert.equal(reference[2], 'v4.37.7');
-      }
-    }
-
-    const oldDockerLoginSha = 'abd2ef45e78c5afb21d64d4ca52ee8550d9572c7';
-    const newDockerLoginSha = 'dbcb813823bdd20940b903addbd779551569679f';
-    for (const workflow of [dockerPublish, dockerRebuild]) {
-      assert.ok(!workflow.includes(oldDockerLoginSha));
-      const dockerLoginReferences = [
-        ...workflow.matchAll(/uses:\s*docker\/login-action@([a-f0-9]{40})\s*#\s*(v[^\s]+)/gu),
-      ];
-      assert.equal(dockerLoginReferences.length, 1);
-      assert.equal(dockerLoginReferences[0][1], newDockerLoginSha);
-      assert.equal(dockerLoginReferences[0][2], 'v4.6.0');
-    }
-
-    const ignoredUnpdfFixture = `updates:
-  - package-ecosystem: npm
-    ignore:
-      - dependency-name: "unpdf" # controlled ignored package
-`;
-    const allowedUnpdfFixture = `updates:
-  - package-ecosystem: npm
-    allow:
-      - dependency-name: unpdf # controlled allowed package
-`;
-    assert.ok(hasDependabotIgnoreEntry(ignoredUnpdfFixture, 'unpdf'));
-    assert.ok(!hasDependabotIgnoreEntry(allowedUnpdfFixture, 'unpdf'));
-    assert.ok(!hasDependabotIgnoreEntry(dependabot, 'unpdf'));
+    assertPackageMetadata();
+    assertReadmeNodePolicy(readme);
+    assertCiMatrix(ci);
+    assertCiCommonJob(ci);
+    assertCodeqlActionPins(codeql);
+    assertCodeqlActionPins(scorecard);
+    assertDockerLoginPin(dockerPublish);
+    assertDockerLoginPin(dockerRebuild);
+    assertDependabotUnpdfPolicy(dependabot);
   }, results);
 
   await testFunction('cookbook exists and README links to it', () => {

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -396,6 +396,8 @@ export async function runTests(): Promise<TestResult> {
     assertCiCommonJob(ci);
     assertCodeqlActionPins(codeql);
     assertCodeqlActionPins(scorecard);
+    assertCodeqlActionPins(dockerPublish);
+    assertCodeqlActionPins(dockerRebuild);
     assertDockerLoginPin(dockerPublish);
     assertDockerLoginPin(dockerRebuild);
     assertDependabotUnpdfPolicy(dependabot);

--- a/package-lock.json
+++ b/package-lock.json
@@ -26,16 +26,16 @@
             "devDependencies": {
                 "@types/node": "22.20.1",
                 "@types/supertest": "^7.2.0",
-                "@typescript-eslint/eslint-plugin": "8.66.0",
-                "@typescript-eslint/parser": "8.66.0",
+                "@typescript-eslint/eslint-plugin": "8.67.0",
+                "@typescript-eslint/parser": "8.67.0",
                 "c8": "^11.0.0",
                 "cross-env": "^10.1.0",
-                "eslint": "10.8.0",
+                "eslint": "10.8.1",
                 "eslint-plugin-security": "^4.0.0",
                 "fast-check": "^4.8.0",
                 "shx": "^0.4.0",
                 "supertest": "^7.2.2",
-                "tsx": "4.23.5",
+                "tsx": "4.23.12",
                 "typescript": "^5.8.3"
             },
             "engines": {
@@ -976,17 +976,17 @@
             }
         },
         "node_modules/@typescript-eslint/eslint-plugin": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.66.0.tgz",
-            "integrity": "sha512-p088eaGrzYz1s+7cov0aMOCkNGTJlVxF4jgubf28c8L0Cv9Rloj8YBHnv4hXLq6IIEE1AsjNWavO+k+8kP2Y0A==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.67.0.tgz",
+            "integrity": "sha512-Un7Heoyj65NREbKAyIrFxeM143NZpExWmy1Nep4DLeQOeLlTeumPjoNKnBrU5D5moWXbPJgRa5Uwcdu0faVNGQ==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/regexpp": "^4.12.2",
-                "@typescript-eslint/scope-manager": "8.66.0",
-                "@typescript-eslint/type-utils": "8.66.0",
-                "@typescript-eslint/utils": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0",
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/type-utils": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
                 "ignore": "^7.0.5",
                 "natural-compare": "^1.4.0",
                 "ts-api-utils": "^2.5.0"
@@ -999,22 +999,22 @@
                 "url": "https://opencollective.com/typescript-eslint"
             },
             "peerDependencies": {
-                "@typescript-eslint/parser": "8.66.0",
+                "@typescript-eslint/parser": "8.67.0",
                 "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
                 "typescript": ">=4.8.4 <6.1.0"
             }
         },
         "node_modules/@typescript-eslint/parser": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.66.0.tgz",
-            "integrity": "sha512-X6ypGChaWYk6PBtUg2BwuTZEFFcHJAtGTVJ9/lCTOufhZ4i9fNolQNnktq+kkMCwMj7V8Svsq7+TxSDslmhE0g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-8.67.0.tgz",
+            "integrity": "sha512-fUBfTuuEulWqX6V8+O3PtScV01tzYYRUDTAirHFKoRAt7nOzoGiPt0M/bB47wWNy0coOOcgEwAMUtBpykMxl6w==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/scope-manager": "8.66.0",
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0",
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1030,14 +1030,14 @@
             }
         },
         "node_modules/@typescript-eslint/project-service": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.66.0.tgz",
-            "integrity": "sha512-7MthGPTt4BP69lSryqpqq8HQqxuzynssckL/jyDyk3+TNMQ3y2jFWkptCrktWvBrP+EH787Nl5N5Qpw7WZg+5g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/project-service/-/project-service-8.67.0.tgz",
+            "integrity": "sha512-cvE8c7ulYeXN9fYuszhCeCsbzyVEXuhrRCybnBre7TUmqb5nRmBfQAwCj0O3WJFDeyAZt4VYv51vMCC9LHSdYw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/tsconfig-utils": "^8.66.0",
-                "@typescript-eslint/types": "^8.66.0",
+                "@typescript-eslint/tsconfig-utils": "^8.67.0",
+                "@typescript-eslint/types": "^8.67.0",
                 "debug": "^4.4.3"
             },
             "engines": {
@@ -1052,14 +1052,14 @@
             }
         },
         "node_modules/@typescript-eslint/scope-manager": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.66.0.tgz",
-            "integrity": "sha512-8TGcH25j9zqJ/IULB/ppyhRvxA8QYfFEZ7nfbg6/BN9spDgb8fPWQXlE5l8TWBL50EtUx007uZ1o9VOwrq2/9g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/scope-manager/-/scope-manager-8.67.0.tgz",
+            "integrity": "sha512-EgvsleTwS4E+WzzSvem8fAUubLwatMNF1B5hHSLQxcvs7q2dtRhGyujHwLJSYlG41niJ7GP24Aha2+0mb1b2kg==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0"
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1070,9 +1070,9 @@
             }
         },
         "node_modules/@typescript-eslint/tsconfig-utils": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.66.0.tgz",
-            "integrity": "sha512-9D5gLYZG4rOjcoag8MQ/fWI8WqA9wcPDyOGyWtWFhvM1lHRbliqUSPIY5J3zqCU1tvSwzXxnnjhQhz5Ne7mJ4g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.67.0.tgz",
+            "integrity": "sha512-vV+LUSv5njUWsknE71fqKTlXUva+R76SaeORd6Zojcunk/6DvKFXONU3BrAs2H49mbygUXt6gbYunzwqNwlhdg==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1087,15 +1087,15 @@
             }
         },
         "node_modules/@typescript-eslint/type-utils": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.66.0.tgz",
-            "integrity": "sha512-LG2dWfjZQQp0ADtAu/EWJVayefGL2UEZ3CDeI44D9v3rXB/WYUqE/jpO28KrEKul5AySrmI+Zh1v6v+xW2U9+g==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/type-utils/-/type-utils-8.67.0.tgz",
+            "integrity": "sha512-aVWDXbRmdXO9siTfX4ditQI1T9+zVcNazT48EJCD0v40/9RIFoUgZ05CmGEq9H2gixRpjUn/iplwvlcvutJW/Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0",
-                "@typescript-eslint/utils": "8.66.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0",
+                "@typescript-eslint/utils": "8.67.0",
                 "debug": "^4.4.3",
                 "ts-api-utils": "^2.5.0"
             },
@@ -1112,9 +1112,9 @@
             }
         },
         "node_modules/@typescript-eslint/types": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.66.0.tgz",
-            "integrity": "sha512-H6gcYaSDOyvL3AD/jHUtUFo2jqGgn/F6nuyuZSu0QTesxL+cP4dQoIMrODRofuJC09g64+WgZ6tE19Y1N2YIFQ==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/types/-/types-8.67.0.tgz",
+            "integrity": "sha512-sBtgslww8nsMYUjhdPBiSyUqSzT8uR6g93A2QXnQC8+cGdjz0CyaOdqHDRJb1AtORbZCNUJBBeFA/tNR2uQmww==",
             "dev": true,
             "license": "MIT",
             "engines": {
@@ -1126,16 +1126,16 @@
             }
         },
         "node_modules/@typescript-eslint/typescript-estree": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.66.0.tgz",
-            "integrity": "sha512-8/x4INiiQb10jGgXYD7116/zQ+OL84ZIFn0za68wwFHCanT/VLbBEroWht8RV8fn0/ZCAoazHLQgwUC0UQcDfg==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/typescript-estree/-/typescript-estree-8.67.0.tgz",
+            "integrity": "sha512-EKQBCE9yNlRJYm7jdTW5AhDacDUmSwQb0FAJAmK2EKYrNXIsa2vxcSZx6PvJ/dEdI6lS+Y9W+EXckLj0iPFGcw==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/project-service": "8.66.0",
-                "@typescript-eslint/tsconfig-utils": "8.66.0",
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/visitor-keys": "8.66.0",
+                "@typescript-eslint/project-service": "8.67.0",
+                "@typescript-eslint/tsconfig-utils": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/visitor-keys": "8.67.0",
                 "debug": "^4.4.3",
                 "minimatch": "^10.2.2",
                 "semver": "^7.7.3",
@@ -1154,16 +1154,16 @@
             }
         },
         "node_modules/@typescript-eslint/utils": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.66.0.tgz",
-            "integrity": "sha512-jasearZPolBw5NJNYGMwxzHMF83niVWmMU1VdHzG1CyfI2VS7f7nZltnKtHcg20hW+7Uo5GfK4MeDPoU3qI8EA==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/utils/-/utils-8.67.0.tgz",
+            "integrity": "sha512-U9D1FdwEWBwok3hxxSdhclMb0twvt9QnjIQ0VfQ1AiX2epnpSgv2ubVDsayOFyY8K6FX+AQ7E0FKWVG3iKsj1A==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
                 "@eslint-community/eslint-utils": "^4.9.1",
-                "@typescript-eslint/scope-manager": "8.66.0",
-                "@typescript-eslint/types": "8.66.0",
-                "@typescript-eslint/typescript-estree": "8.66.0"
+                "@typescript-eslint/scope-manager": "8.67.0",
+                "@typescript-eslint/types": "8.67.0",
+                "@typescript-eslint/typescript-estree": "8.67.0"
             },
             "engines": {
                 "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -1178,13 +1178,13 @@
             }
         },
         "node_modules/@typescript-eslint/visitor-keys": {
-            "version": "8.66.0",
-            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.66.0.tgz",
-            "integrity": "sha512-dkKR8q+lKciskj1Y3vthHktl+3cMLWGyVUP23bRiPZ5O9BRT++4EqDDV+TVeIKBL1VXVEqrJlz8MYbcnvJcAlg==",
+            "version": "8.67.0",
+            "resolved": "https://registry.npmjs.org/@typescript-eslint/visitor-keys/-/visitor-keys-8.67.0.tgz",
+            "integrity": "sha512-fkv8dHRDqfGtTHuJeebdrQ7cX6Ad4WAS00rgHh9UGvMycF1mjBfsxry1XsLIFhWZ6Judlh6UdzK+TYlbpCXgnA==",
             "dev": true,
             "license": "MIT",
             "dependencies": {
-                "@typescript-eslint/types": "8.66.0",
+                "@typescript-eslint/types": "8.67.0",
                 "eslint-visitor-keys": "^5.0.0"
             },
             "engines": {
@@ -1942,9 +1942,9 @@
             }
         },
         "node_modules/eslint": {
-            "version": "10.8.0",
-            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-            "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+            "version": "10.8.1",
+            "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+            "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
             "dev": true,
             "license": "MIT",
             "workspaces": [
@@ -2358,9 +2358,9 @@
             }
         },
         "node_modules/express-rate-limit": {
-            "version": "8.6.1",
-            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.1.tgz",
-            "integrity": "sha512-0D493aP61w0TJ2A0wy27riRsO7FMQ7FK+KUHOKCSfPvYo0R55aiC6emCVgFUeShH0fq0ICPVzNcgoS+BsbXQCA==",
+            "version": "8.6.2",
+            "resolved": "https://registry.npmjs.org/express-rate-limit/-/express-rate-limit-8.6.2.tgz",
+            "integrity": "sha512-YH4ru+eOJxQABscKFfRCy9R7x9QFGdezclVMwwgFFndzS2Xnm0uo6B0ABZsLhcpeptGv2qvuJVWlQr9gQZoC3A==",
             "license": "MIT",
             "dependencies": {
                 "debug": "^4.4.3",
@@ -4234,9 +4234,9 @@
             }
         },
         "node_modules/tsx": {
-            "version": "4.23.5",
-            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.5.tgz",
-            "integrity": "sha512-rw55FUaqOoI7RvlQwLbhO4nSDApnQ4/CykPuiQ/EPvtrX3WA9Ig55jIt9VvbBJbzJuj12ueRu4PMZ2SxPVbihg==",
+            "version": "4.23.12",
+            "resolved": "https://registry.npmjs.org/tsx/-/tsx-4.23.12.tgz",
+            "integrity": "sha512-FDf4L4sYzKtzWYhU/Xm0AQFdTjdIxNo9ElTf2mxXM6k8YMHXzYUe4yODVaXP4V9uMFbVg8c0qyBccK2OOxb45Q==",
             "dev": true,
             "license": "MIT",
             "dependencies": {

--- a/package.json
+++ b/package.json
@@ -63,16 +63,16 @@
     "devDependencies": {
         "@types/node": "22.20.1",
         "@types/supertest": "^7.2.0",
-        "@typescript-eslint/eslint-plugin": "8.66.0",
-        "@typescript-eslint/parser": "8.66.0",
+        "@typescript-eslint/eslint-plugin": "8.67.0",
+        "@typescript-eslint/parser": "8.67.0",
         "c8": "^11.0.0",
         "cross-env": "^10.1.0",
-        "eslint": "10.8.0",
+        "eslint": "10.8.1",
         "eslint-plugin-security": "^4.0.0",
         "fast-check": "^4.8.0",
         "shx": "^0.4.0",
         "supertest": "^7.2.2",
-        "tsx": "4.23.5",
+        "tsx": "4.23.12",
         "typescript": "^5.8.3"
     },
     "overrides": {


### PR DESCRIPTION
## Summary
- deprecate Node.js 20 while keeping the existing `>=20` compatibility contract
- recommend Node.js 22+ and test Node 20, 22, 24, and 26.7.0 in CI
- combine the compatible dependency and immutable action-pin updates from #242, #243, and #247
- keep `unpdf` at 1.7.0 because the update in #246 requires Node.js 22+

## Verification
- `npm ci`, lint, build, and 736/736 coverage tests
- 28/28 E2E tests and packed-consumer verification
- clean npm audit
- official Node.js 20.20.2 and 26.7.0 compatibility runs
- workflow parsing and exact metadata contract checks

Supersedes #242, #243, and #247.