### PR TITLE
feat(runtime): require Node.js 22 and refresh PDF parsing

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        node-version: ['20', '22', '24', '26.7.0']
+        node-version: ['22', '24', '26.7.0']
 
     steps:
       - name: Checkout code
@@ -42,3 +42,6 @@ jobs:
 
       - name: Test coverage
         run: npm run test:coverage
+
+      - name: E2E tests
+        run: npm run test:e2e

--- a/README.md
+++ b/README.md
@@ -181,7 +181,7 @@ For SearXNG deployment, configuration, and troubleshooting, see
 
 ## Installation
 
-Node.js 20 remains supported but is deprecated and end-of-life. Node.js 22 or later is recommended. Node.js 20 will be removed only in a future major release.
+Node.js 22 or later is required.
 
 <details>
 <summary>NPM (global install)</summary>

--- a/__tests__/e2e/url-reader.e2e.ts
+++ b/__tests__/e2e/url-reader.e2e.ts
@@ -11,24 +11,129 @@
  */
 
 import { strict as assert } from 'node:assert';
+import http from 'node:http';
+import net from 'node:net';
 import { fileURLToPath } from 'node:url';
 import {
   checkSkipConditions,
   INIT_PARAMS,
   spawnWithMessages,
+  spawnWithMessagesAsync,
   LIVE_URL,
 } from './helpers/spawn-server.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
+import { createTextPdf } from '../helpers/pdf-fixtures.js';
 
 const results = createTestResults();
+const E2E_TIMEOUT_MS = 15_000;
+const LOCAL_PDF_FIRST_PAGE = 'Local PDF first page for E2E';
+const LOCAL_PDF_SECOND_PAGE = 'Local PDF second page for E2E';
+
+interface TestServer {
+  url: string;
+  close: () => Promise<void>;
+}
+
+function startPdfServer(pdf: Uint8Array): Promise<TestServer> {
+  return new Promise((resolve, reject) => {
+    const server = http.createServer((_, response) => {
+      response.writeHead(200, {
+        'content-type': 'application/pdf',
+        'content-length': String(pdf.byteLength),
+      });
+      response.end(Buffer.from(pdf));
+    });
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address() as net.AddressInfo;
+      resolve({
+        url: `http://127.0.0.1:${address.port}/fixture.pdf`,
+        close: () => new Promise<void>((done, rejectClose) => {
+          server.closeAllConnections();
+          server.close((error) => error ? rejectClose(error) : done());
+        }),
+      });
+    });
+    server.once('error', reject);
+  });
+}
+
+function readUrlMessages(url: string): object[] {
+  return [
+    { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+    {
+      jsonrpc: '2.0',
+      id: 2,
+      method: 'tools/call',
+      params: {
+        name: 'web_url_read',
+        arguments: { url },
+      },
+    },
+  ];
+}
+
+async function withinTestBoundary<T>(operation: Promise<T>): Promise<T> {
+  let timeout: NodeJS.Timeout | undefined;
+  try {
+    return await Promise.race([
+      operation,
+      new Promise<never>((_, reject) => {
+        timeout = setTimeout(
+          () => reject(new Error(`Local PDF E2E test timed out after ${E2E_TIMEOUT_MS}ms`)),
+          E2E_TIMEOUT_MS,
+        );
+      }),
+    ]);
+  } finally {
+    if (timeout) clearTimeout(timeout);
+  }
+}
 
 async function runTests() {
   console.log('🌐 E2E Testing: web_url_read (live)\n');
 
-  const skip = checkSkipConditions();
-  if (skip) {
-    console.log(skip);
-    return { passed: 0, failed: 0, errors: [] };
+  await testFunction('web_url_read reads a two-page local PDF only with the private URL override', async () => {
+    await withinTestBoundary((async () => {
+      const server = await startPdfServer(createTextPdf([
+        LOCAL_PDF_FIRST_PAGE,
+        LOCAL_PDF_SECOND_PAGE,
+      ]));
+      try {
+        const blockedResponses = await spawnWithMessagesAsync(
+          readUrlMessages(server.url),
+          'https://test-searx.example.com',
+          E2E_TIMEOUT_MS,
+        );
+        const blockedResponse = blockedResponses[2];
+        assert.ok(blockedResponse?.error, 'loopback PDF request should be blocked by the SSRF boundary');
+        assert.match(
+          String(blockedResponse.error.message ?? ''),
+          /URL blocked by security policy/i,
+          JSON.stringify(blockedResponse.error),
+        );
+
+        const allowedResponses = await spawnWithMessagesAsync(
+          readUrlMessages(server.url),
+          'https://test-searx.example.com',
+          E2E_TIMEOUT_MS,
+          { MCP_HTTP_ALLOW_PRIVATE_URLS: 'true' },
+        );
+        const allowedResponse = allowedResponses[2];
+        assert.ok(allowedResponse && !allowedResponse.error, JSON.stringify(allowedResponse?.error));
+        const text: string = allowedResponse.result?.content?.[0]?.text ?? '';
+        assert.ok(text.includes(LOCAL_PDF_FIRST_PAGE), text);
+        assert.ok(text.includes(LOCAL_PDF_SECOND_PAGE), text);
+      } finally {
+        await server.close();
+      }
+    })());
+  }, results);
+
+  const liveSkip = checkSkipConditions();
+  if (liveSkip) {
+    console.log(liveSkip);
+    printTestSummary(results, 'E2E: URL Reader');
+    return results;
   }
 
   await testFunction('web_url_read fetches example.com and returns markdown', async () => {

--- a/__tests__/unit/documentation.test.ts
+++ b/__tests__/unit/documentation.test.ts
@@ -83,6 +83,10 @@ type PackageManifest = {
   version?: unknown;
 };
 
+type PackageLock = {
+  packages?: Record<string, PackageManifest>;
+};
+
 function toYamlLine(rawLine: string): YamlLine {
   return {
     indentation: rawLine.length - rawLine.trimStart().length,
@@ -148,15 +152,38 @@ function hasDependabotIgnoreEntry(source: string, dependencyName: string): boole
 
 function assertPackageMetadata(): void {
   const packageManifest = JSON.parse(readText(new URL('../../package.json', import.meta.url))) as PackageManifest;
+  const packageLock = JSON.parse(readText(new URL('../../package-lock.json', import.meta.url))) as PackageLock;
   assert.equal(packageManifest.version, '1.16.0');
-  assert.equal(packageManifest.engines?.node, '>=20');
+  assert.equal(packageManifest.engines?.node, '>=22');
+  assert.equal(packageManifest.dependencies?.unpdf, '1.8.1');
+  assert.equal(packageLock.packages?.[''].engines?.node, '>=22');
+  assert.equal(packageLock.packages?.[''].dependencies?.unpdf, '1.8.1');
   assert.equal(packageManifest.dependencies?.['express-rate-limit'], '^8.5.2');
 }
 
 function assertReadmeNodePolicy(readme: string): void {
-  assert.ok(readme.includes('Node.js 20 remains supported but is deprecated and end-of-life.'));
-  assert.ok(readme.includes('Node.js 22 or later is recommended.'));
-  assert.ok(readme.includes('Node.js 20 will be removed only in a future major release.'));
+  assert.ok(readme.includes('Node.js 22 or later is required.'));
+  assert.ok(!readme.includes('Node.js 20'), 'README must not claim Node.js 20 support');
+  for (const formerPromise of [
+    'Node.js 20 remains supported',
+    'Node.js 20 will be removed',
+    'Node.js 22 or later is recommended',
+  ]) {
+    assert.ok(!readme.includes(formerPromise), `README must not retain: ${formerPromise}`);
+  }
+}
+
+function assertClientGuideNodePolicy(guide: string): void {
+  assert.ok(guide.includes('Requires Node.js 22 or later.'));
+  assert.ok(!guide.includes('Node.js 20'), 'client guide must not claim Node.js 20 support');
+  for (const formerPromise of [
+    'Requires Node.js 20',
+    'Node.js 20 remains supported',
+    'Node.js 20 will be removed',
+    'Node.js 22 or later is recommended',
+  ]) {
+    assert.ok(!guide.includes(formerPromise), `client guide must not retain: ${formerPromise}`);
+  }
 }
 
 function assertCiMatrix(ci: string): void {
@@ -164,7 +191,7 @@ function assertCiMatrix(ci: string): void {
   assert.ok(matrix, 'CI must declare an inline Node version matrix');
   assert.deepEqual(
     [...matrix[1].matchAll(/['"]([^'"]+)['"]/gu)].map((match) => match[1]),
-    ['20', '22', '24', '26.7.0'],
+    ['22', '24', '26.7.0'],
   );
 }
 
@@ -174,9 +201,16 @@ function assertCiCommonJob(ci: string): void {
   assert.match(ci, /uses:\s*actions\/checkout@/u);
   assert.match(ci, /uses:\s*actions\/setup-node@/u);
   assert.match(ci, /cache:\s*['"]npm['"]/u);
-  for (const command of [/run:\s*npm ci/u, /run:\s*npm run lint/u, /run:\s*npm run build/u, /run:\s*npm run test:coverage/u]) {
+  for (const command of [
+    /run:\s*npm ci/u,
+    /run:\s*npm run lint/u,
+    /run:\s*npm run build/u,
+    /run:\s*npm run test:coverage/u,
+    /run:\s*npm run test:e2e/u,
+  ]) {
     assert.match(ci, command);
   }
+  assert.match(ci, /run:\s*npm run test:coverage\s*\n\s*- name: E2E tests\s*\n\s*run:\s*npm run test:e2e/u);
   assert.doesNotMatch(ci, /^\s*include\s*:/mu);
   assert.doesNotMatch(ci, /^\s*if\s*:/mu);
   assert.doesNotMatch(ci, /continue-on-error\s*:/u);
@@ -392,6 +426,7 @@ export async function runTests(): Promise<TestResult> {
     const dependabot = readText(new URL('../../.github/dependabot.yml', import.meta.url));
     assertPackageMetadata();
     assertReadmeNodePolicy(readme);
+    assertClientGuideNodePolicy(readText(guideUrl));
     assertCiMatrix(ci);
     assertCiCommonJob(ci);
     assertCodeqlActionPins(codeql);

--- a/__tests__/unit/pdf-reader.test.ts
+++ b/__tests__/unit/pdf-reader.test.ts
@@ -1,10 +1,13 @@
 import assert from "node:assert/strict";
+import { randomUUID } from "node:crypto";
+import { BroadcastChannel } from "node:worker_threads";
+import { getDocumentProxy } from "unpdf";
 import {
   extractPdfText,
   PDF_PARSE_TIMEOUT_MS,
   PDF_WORKER_RESOURCE_LIMITS,
 } from "../../src/pdf-reader.js";
-import { PDF_DOCUMENT_OPTIONS } from "../../src/pdf-worker.js";
+import { extractPdfWorkerInput, PDF_DOCUMENT_OPTIONS } from "../../src/pdf-worker.js";
 import { createTestResults, printTestSummary, testFunction } from "../helpers/test-utils.js";
 import { createEncryptedPdf, createTextPdf } from "../helpers/pdf-fixtures.js";
 
@@ -13,6 +16,115 @@ function createDelayedWorkerUrl(delayMs: number): URL {
     `import { parentPort } from "node:worker_threads";` +
     `setTimeout(() => parentPort.postMessage({version:1,kind:"text",text:"delayed",totalPages:1,textBytes:7}), ${delayMs});`;
   return new URL(`data:text/javascript,${encodeURIComponent(source)}`);
+}
+
+function createNeverPostingWorkerUrl(): URL {
+  const source =
+    `import { parentPort } from "node:worker_threads";` +
+    `parentPort.on("message", () => {});`;
+  return new URL(`data:text/javascript,${encodeURIComponent(source)}`);
+}
+
+const HANGING_TEARDOWN_PARENT_TIMEOUT_MS = 3_000;
+const HANGING_TEARDOWN_READY_TIMEOUT_MS = 1_500;
+
+function createHangingTeardownWorkerUrl(expectedText: string, channelName: string): URL {
+  const unpdfUrl = import.meta.resolve("unpdf");
+  const source = `
+    import { BroadcastChannel, parentPort, workerData } from "node:worker_threads";
+    import { getDocumentProxy } from ${JSON.stringify(unpdfUrl)};
+
+    const readiness = new BroadcastChannel(${JSON.stringify(channelName)});
+
+    try {
+      const pdf = await getDocumentProxy(new Uint8Array(workerData.pdfBytes));
+      const page = await pdf.getPage(1);
+      const content = await page.getTextContent();
+      const text = content.items.map((item) => item.str).join("");
+      if (text !== ${JSON.stringify(expectedText)}) {
+        throw new Error("unexpected worker extraction result");
+      }
+      const simulatedTeardown = new Promise(() => {});
+      readiness.postMessage({ type: "ready" });
+      readiness.close();
+      setInterval(() => {}, 1000);
+      await simulatedTeardown;
+    } catch {
+      readiness.postMessage({ type: "failure" });
+      readiness.close();
+      parentPort.postMessage({ version: 1, kind: "parse_error" });
+    }
+  `;
+  return new URL(`data:text/javascript,${encodeURIComponent(source)}`);
+}
+
+function waitForWorkerReadiness(channel: BroadcastChannel): Promise<void> {
+  return new Promise((resolve, reject) => {
+    const timeout = setTimeout(() => {
+      channel.onmessage = null;
+      reject(new Error("worker did not reach simulated teardown before the readiness deadline"));
+    }, HANGING_TEARDOWN_READY_TIMEOUT_MS);
+    channel.onmessage = (event: MessageEvent<{ type?: unknown }>) => {
+      clearTimeout(timeout);
+      channel.onmessage = null;
+      if (event.data?.type === "ready") {
+        resolve();
+      } else {
+        reject(new Error("worker failed before simulated teardown readiness"));
+      }
+    };
+  });
+}
+
+type TestPdfFixture = {
+  pdf: {
+    numPages: number;
+    getPage: () => Promise<{
+      getTextContent: () => Promise<{ items: Array<{ str: string }> }>;
+      cleanup: () => void;
+    }>;
+    loadingTask: { destroy: () => Promise<void> };
+  };
+  destroyCalls: () => number;
+};
+
+function createTestPdfFixture({
+  text = "",
+  numPages = 1,
+  pageError,
+  destroyError,
+}: {
+  text?: string;
+  numPages?: number;
+  pageError?: unknown;
+  destroyError?: unknown;
+} = {}): TestPdfFixture {
+  let destroyCount = 0;
+  return {
+    pdf: {
+      numPages,
+      async getPage() {
+        if (pageError !== undefined) {
+          throw pageError;
+        }
+        return {
+          async getTextContent() {
+            return { items: text === "" ? [] : [{ str: text }] };
+          },
+          cleanup() {},
+        };
+      },
+      loadingTask: {
+        async destroy() {
+          destroyCount++;
+          if (destroyError !== undefined) {
+            throw destroyError;
+          }
+        },
+      },
+    },
+    destroyCalls: () => destroyCount,
+  };
 }
 
 export async function runTests() {
@@ -39,6 +151,61 @@ export async function runTests() {
       iccUrl: undefined,
       verbosity: 0,
     });
+  }, results);
+
+  await testFunction("tears down the loaded document once after every settled extraction result", async () => {
+    const cases = [
+      { name: "text", fixture: createTestPdfFixture({ text: "hello" }), maxTextBytes: 1024, expected: { version: 1, kind: "text", text: "hello", totalPages: 1, textBytes: 5 } },
+      { name: "text with teardown failure", fixture: createTestPdfFixture({ text: "hello", destroyError: new Error("teardown") }), maxTextBytes: 1024, expected: { version: 1, kind: "text", text: "hello", totalPages: 1, textBytes: 5 } },
+      { name: "no text", fixture: createTestPdfFixture(), maxTextBytes: 1024, expected: { version: 1, kind: "no_text", totalPages: 1 } },
+      { name: "text too large", fixture: createTestPdfFixture({ text: "too large" }), maxTextBytes: 1, expected: { version: 1, kind: "text_too_large", bytes: 9 } },
+      { name: "too many pages", fixture: createTestPdfFixture({ numPages: 501 }), maxTextBytes: 1024, expected: { version: 1, kind: "too_many_pages", totalPages: 501 } },
+      { name: "parse error", fixture: createTestPdfFixture({ pageError: new Error("parse") }), maxTextBytes: 1024, expected: { version: 1, kind: "parse_error" } },
+      { name: "password error", fixture: createTestPdfFixture({ pageError: { name: "PasswordException" } }), maxTextBytes: 1024, expected: { version: 1, kind: "password_protected" } },
+      { name: "external fetch", fixture: createTestPdfFixture({ pageError: { name: "ExternalFetchAttemptError" } }), maxTextBytes: 1024, expected: { version: 1, kind: "external_fetch_attempt" } },
+    ];
+
+    for (const testCase of cases) {
+      const result = await extractPdfWorkerInput({
+        version: 1,
+        pdfBytes: new ArrayBuffer(1),
+        maxTextBytes: testCase.maxTextBytes,
+      }, async () => testCase.fixture.pdf as never);
+      assert.deepEqual(result, testCase.expected, testCase.name);
+      assert.equal(testCase.fixture.destroyCalls(), 1, `${testCase.name} teardown count`);
+    }
+  }, results);
+
+  await testFunction("awaits one real unpdf loading-task teardown through worker extraction", async () => {
+    const documentBytes = createTextPdf(["real loading task"]);
+    const inputBytes = documentBytes.slice();
+    const pdf = await getDocumentProxy(documentBytes, PDF_DOCUMENT_OPTIONS);
+    const originalDestroy = pdf.loadingTask.destroy.bind(pdf.loadingTask);
+    let destroyCalls = 0;
+    pdf.loadingTask.destroy = async () => {
+      destroyCalls++;
+      await originalDestroy();
+    };
+
+    try {
+      const result = await extractPdfWorkerInput({
+        version: 1,
+        pdfBytes: inputBytes.buffer,
+        maxTextBytes: 1024,
+      }, async () => pdf);
+      assert.deepEqual(result, {
+        version: 1,
+        kind: "text",
+        text: "real loading task",
+        totalPages: 1,
+        textBytes: 17,
+      });
+      assert.equal(destroyCalls, 1);
+    } finally {
+      if (destroyCalls === 0) {
+        await originalDestroy();
+      }
+    }
   }, results);
 
   await testFunction("extracts text from a real in-memory PDF", async () => {
@@ -100,6 +267,44 @@ export async function runTests() {
       workerUrl: createDelayedWorkerUrl(1000),
     });
     assert.deepEqual(result, { version: 1, kind: "timeout" });
+  }, results);
+
+  await testFunction("times out a never-posting worker and releases its concurrency slot", async () => {
+    const workerUrl = createNeverPostingWorkerUrl();
+    const first = extractPdfText(createTextPdf(["first ignored"]), 1024, {
+      timeoutMs: 20,
+      workerUrl,
+    });
+    const second = extractPdfText(createTextPdf(["second ignored"]), 1024, {
+      timeoutMs: 20,
+      workerUrl,
+    });
+    assert.deepEqual(await first, { version: 1, kind: "timeout" });
+    assert.deepEqual(await second, { version: 1, kind: "timeout" });
+
+    const next = await extractPdfText(createTextPdf(["after timeout"]), 1024);
+    assert.equal(next.kind, "text");
+  }, results);
+
+  await testFunction("parent timeout reclaims a worker that hangs after real PDF extraction", async () => {
+    const readiness = new BroadcastChannel(`pdf-hanging-teardown-${randomUUID()}`);
+    const pending = extractPdfText(createTextPdf(["worker teardown"]), 1024, {
+      timeoutMs: HANGING_TEARDOWN_PARENT_TIMEOUT_MS,
+      workerUrl: createHangingTeardownWorkerUrl("worker teardown", readiness.name),
+    });
+
+    try {
+      await waitForWorkerReadiness(readiness);
+      assert.deepEqual(await pending, { version: 1, kind: "timeout" });
+    } catch (error) {
+      await pending;
+      throw error;
+    } finally {
+      readiness.close();
+    }
+
+    const next = await extractPdfText(createTextPdf(["after hanging teardown"]), 1024);
+    assert.equal(next.kind, "text");
   }, results);
 
   await testFunction("cancellation terminates the worker and promptly releases its slot", async () => {

--- a/docs/client-configurations.md
+++ b/docs/client-configurations.md
@@ -6,8 +6,7 @@ SearXNG with this server, or install `mcp-searxng` as a client plugin.
 
 Choose one connection mode:
 
-- **NPX/STDIO:** the client starts the npm package locally. Requires Node.js 20
-  or newer.
+- **NPX/STDIO:** the client starts the npm package locally. Requires Node.js 22 or later.
 - **Docker/STDIO:** the client starts the published container locally. Requires
   Docker.
 - **HTTP:** the client connects to an independently running Streamable HTTP

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
                 "node-html-markdown": "^2.0.0",
                 "node-html-parser": "^6.1.13",
                 "undici": "7.29.0",
-                "unpdf": "1.7.0"
+                "unpdf": "1.8.1"
             },
             "bin": {
                 "mcp-searxng": "dist/cli.js"
@@ -39,7 +39,7 @@
                 "typescript": "^5.8.3"
             },
             "engines": {
-                "node": ">=20"
+                "node": ">=22"
             }
         },
         "node_modules/@bcoe/v8-coverage": {
@@ -4326,12 +4326,15 @@
             "license": "MIT"
         },
         "node_modules/unpdf": {
-            "version": "1.7.0",
-            "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.7.0.tgz",
-            "integrity": "sha512-MiDhbougTETOvbw/x3hnNr18jzFFrlSitevfO/BHInvtUx68R3Fke9A36GLQfN1LpG1NiJZaV4oPvjioPk9vKQ==",
+            "version": "1.8.1",
+            "resolved": "https://registry.npmjs.org/unpdf/-/unpdf-1.8.1.tgz",
+            "integrity": "sha512-xkURhy2SoGpOIH0a1gLHNkASPIQYonadDJs2AQwPEfUakafeD9EA1WTWWsaR++gfTCXJpV27W7tU1nXuk82UKQ==",
             "license": "MIT",
+            "engines": {
+                "node": ">=22"
+            },
             "peerDependencies": {
-                "@napi-rs/canvas": "^0.1.69"
+                "@napi-rs/canvas": "^0.1.69 || ^1.0.0"
             },
             "peerDependenciesMeta": {
                 "@napi-rs/canvas": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "dist"
     ],
     "engines": {
-        "node": ">=20"
+        "node": ">=22"
     },
     "scripts": {
         "build": "tsc && shx chmod +x dist/*.js",
@@ -58,7 +58,7 @@
         "node-html-markdown": "^2.0.0",
         "node-html-parser": "^6.1.13",
         "undici": "7.29.0",
-        "unpdf": "1.7.0"
+        "unpdf": "1.8.1"
     },
     "devDependencies": {
         "@types/node": "22.20.1",

--- a/src/pdf-worker-bootstrap.mjs
+++ b/src/pdf-worker-bootstrap.mjs
@@ -1,6 +1,6 @@
-// Node 20 resolves a worker's TypeScript entrypoint before tsx's inherited
-// loader hooks are active. Register tsx inside this JavaScript entrypoint for
-// source tests. Published builds run pdf-worker.js directly.
+// Worker entrypoints resolve before inherited tsx loader hooks are active.
+// Register tsx inside this JavaScript entrypoint for source tests. Published
+// builds run pdf-worker.js directly.
 import { register } from "tsx/esm/api";
 
 const unregister = register();

--- a/src/pdf-worker.ts
+++ b/src/pdf-worker.ts
@@ -27,7 +27,20 @@ export const PDF_DOCUMENT_OPTIONS = Object.freeze({
 type PdfDocumentProxy = Awaited<
   ReturnType<(typeof import("unpdf"))["getDocumentProxy"]>
 >;
+type PdfLoadingTask = Pick<PdfDocumentProxy["loadingTask"], "destroy">;
 type PdfPageProxy = Awaited<ReturnType<PdfDocumentProxy["getPage"]>>;
+type PdfDocumentLoader = (
+  pdfBytes: Uint8Array,
+  options: typeof PDF_DOCUMENT_OPTIONS,
+) => Promise<PdfDocumentProxy>;
+
+export async function teardownPdfLoadingTask(loadingTask: PdfLoadingTask | undefined): Promise<void> {
+  try {
+    await loadingTask?.destroy();
+  } catch {
+    // The extraction result is authoritative; teardown failures stay inside the worker.
+  }
+}
 
 function containsExternalFetchMarker(error: unknown): boolean {
   let current = error;
@@ -132,8 +145,19 @@ function classifyParserError(error: unknown): PdfWorkerResult {
     : { version: 1, kind: "parse_error" };
 }
 
-async function extract(): Promise<PdfWorkerResult> {
-  if (!isPdfWorkerInput(workerData)) {
+async function loadPdfDocument(
+  pdfBytes: Uint8Array,
+  options: typeof PDF_DOCUMENT_OPTIONS,
+): Promise<PdfDocumentProxy> {
+  const { getDocumentProxy } = await import("unpdf");
+  return getDocumentProxy(pdfBytes, options);
+}
+
+export async function extractPdfWorkerInput(
+  input: unknown,
+  loadDocument: PdfDocumentLoader = loadPdfDocument,
+): Promise<PdfWorkerResult> {
+  if (!isPdfWorkerInput(input)) {
     return { version: 1, kind: "parse_error" };
   }
 
@@ -147,22 +171,17 @@ async function extract(): Promise<PdfWorkerResult> {
   try {
     // Import after the guards are active so parser dependencies cannot retain
     // unguarded references to Node network primitives during module loading.
-    const { getDocumentProxy } = await import("unpdf");
-    pdf = await getDocumentProxy(new Uint8Array(workerData.pdfBytes), PDF_DOCUMENT_OPTIONS);
-    return await extractDocumentText(pdf, workerData.maxTextBytes);
+    pdf = await loadDocument(new Uint8Array(input.pdfBytes), PDF_DOCUMENT_OPTIONS);
+    return await extractDocumentText(pdf, input.maxTextBytes);
   } catch (error) {
     return classifyParserError(error);
   } finally {
+    await teardownPdfLoadingTask(pdf?.loadingTask);
     restoreNetwork();
-    try {
-      await pdf?.destroy();
-    } catch {
-      // The extraction result is authoritative; teardown failures stay inside the worker.
-    }
   }
 }
 
 const outputPort = parentPort;
 if (outputPort) {
-  void extract().then((result) => outputPort.postMessage(result));
+  void extractPdfWorkerInput(workerData).then((result) => outputPort.postMessage(result));
 }


### PR DESCRIPTION
## Summary
- require Node.js 22 or later and test Node 22, 24, and 26.7.0 in CI
- update unpdf to 1.8.1 and migrate PDF teardown to the loading-task API
- add deterministic local PDF E2E coverage and make E2E mandatory on every CI runtime
- update installation guidance for the new runtime floor

## Breaking change
Node.js 20 is no longer supported. Consumers must use Node.js 22 or later.

## Verification
- 740/740 unit and integration tests; 95.93% line coverage
- 17/17 local E2E tests, including real two-page loopback PDF extraction
- clean runtime gates on Node 22.23.2, 24.19.0, and 26.7.0
- packed-consumer verification and npm audit pass
- clean Docker build; runtime reports Node 24.19.0

This pull request does not change the package version, create a tag, or publish artifacts.