### PR TITLE
security(mcp): bound tool invocation admission

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -352,6 +352,48 @@ After a stateless request consumes its rate-limit token and passes authorization
 
 The in-memory store is per-process; for horizontally scaled deployments replace it with a shared Redis store via `express-rate-limit`'s `store` option.
 
+## Tool Invocation Admission (all transports)
+
+Tool invocation admission is a separate, process-local protection for MCP
+`tools/call` work. It applies uniformly to STDIO, stateful HTTP sessions, and
+stateless HTTP requests; it does not replace or change the HTTP request limiter
+above. One busy session or transport can consume the shared process budget.
+
+| Variable | Required | Default | Accepted range | Description |
+|---|---|---:|---|---|
+| `MCP_TOOL_RATE_WINDOW_MS` | No | `60000` | `1000`-`2147483647` | Fixed admission window in milliseconds. |
+| `MCP_TOOL_RATE_MAX` | No | `300` | `1`-`10000` | Tool-call attempts admitted per fixed window. |
+| `MCP_TOOL_MAX_IN_FLIGHT` | No | `16` | `1`-`256` | Hard no-queue ceiling for accepted tool calls executing at once. |
+
+Values use the same strict safe-integer grammar as the HTTP rate controls:
+surrounding whitespace, a leading `+` or `-`, and leading zeros are accepted,
+but suffixes, fractions, exponents, unsafe integers, and out-of-range values
+are rejected. Blank or unset values use their defaults silently. Each invalid
+nonblank value falls back to its default and emits one startup-only stderr
+warning naming the variable and fallback, never the supplied value. Values are
+read once when the process starts.
+
+```bash
+MCP_TOOL_RATE_WINDOW_MS=60000
+MCP_TOOL_RATE_MAX=300
+MCP_TOOL_MAX_IN_FLIGHT=16
+```
+
+The window starts lazily with the first tool attempt and uses a monotonic clock.
+It is an ordinary fixed window, so calls immediately on both sides of a window
+boundary can produce a burst of up to twice the configured maximum. Every tool
+attempt consumes a rate token, including malformed, unknown, and concurrency-
+rejected calls. After rate admission, execution must acquire an in-flight slot;
+there is no queue. A rejected call receives the stable retry-with-backoff tool
+error without configured limits, counters, timing details, arguments, or other
+call data.
+
+Size the limits for expected workload and have clients back off on rejection.
+Use separate process replicas when stronger tenant isolation is required. A
+never-settling handler intentionally retains its in-flight slot until process
+restart; this policy does not add a watchdog or alter existing cancellation and
+timeout timing.
+
 When HTTP mode runs behind a trusted reverse proxy, set `MCP_HTTP_TRUST_PROXY` so Express can resolve the client IP from proxy headers before rate-limit keys and request logs are computed. For a single trusted proxy hop, use `MCP_HTTP_TRUST_PROXY=1`. Leave it unset for direct exposure; enabling it without a trusted proxy lets clients spoof `X-Forwarded-For`. This setting is distinct from outbound `HTTP_PROXY` / `HTTPS_PROXY`, which control this server's requests to SearXNG or URLs.
 
 Requests whose client IP cannot be resolved share one fail-closed capacity bucket. This prevents missing identity data from bypassing the per-IP cap, but such requests can receive HTTP 503 when another unresolved-IP request occupies that bucket.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -291,9 +291,10 @@ in-flight ceiling. Rejection is a stable retry-with-backoff tool result and
 does not expose arguments, credentials, configured limits, counters, or timing
 details.
 
-The shared process budget is intentionally fail-closed, not a fairness
-guarantee: one session can starve another, and a handler that never settles
-retains its slot until restart. Configure the `MCP_TOOL_*` limits for the
+The shared process budget intentionally bounds total work rather than providing
+per-client fairness. Consequently, one session may exhaust another session's
+capacity, and a handler that never settles retains its slot until restart.
+Configure the `MCP_TOOL_*` limits for the
 deployment, require client backoff, and use separate process replicas where
 tenant isolation is needed. See [Tool Invocation Admission](CONFIGURATION.md#tool-invocation-admission-all-transports)
 for defaults, ranges, and fixed-window boundary behavior.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -292,8 +292,10 @@ does not expose arguments, credentials, configured limits, counters, or timing
 details.
 
 The shared process budget intentionally bounds total work rather than providing
-per-client fairness. Consequently, one session may exhaust another session's
-capacity, and a handler that never settles retains its slot until restart.
+per-client fairness. Consequently, one session may consume capacity needed by
+another. Slots normally return when handlers settle; if an upstream handler
+remains pending indefinitely, operators can restart the process to reclaim that
+capacity.
 Configure the `MCP_TOOL_*` limits for the
 deployment, require client backoff, and use separate process replicas where
 tenant isolation is needed. See [Tool Invocation Admission](CONFIGURATION.md#tool-invocation-admission-all-transports)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -280,6 +280,24 @@ Environment configuration is captured when the process starts. Restart the
 server after rotating or changing SearXNG Basic Auth credentials so both
 requests and diagnostic redaction use the new values.
 
+### Tool Invocation Admission
+
+The server applies one process-wide admission boundary to MCP `tools/call`
+requests from STDIO and both HTTP transport modes. This is distinct from the
+HTTP request rate limiter: protocol initialization, discovery, resources,
+logging, and health checks remain available even when the tool budget is
+exhausted. Tool admission uses a fixed monotonic window plus a hard no-queue
+in-flight ceiling. Rejection is a stable retry-with-backoff tool result and
+does not expose arguments, credentials, configured limits, counters, or timing
+details.
+
+The shared process budget is intentionally fail-closed, not a fairness
+guarantee: one session can starve another, and a handler that never settles
+retains its slot until restart. Configure the `MCP_TOOL_*` limits for the
+deployment, require client backoff, and use separate process replicas where
+tenant isolation is needed. See [Tool Invocation Admission](CONFIGURATION.md#tool-invocation-admission-all-transports)
+for defaults, ranges, and fixed-window boundary behavior.
+
 Because credentials may be embedded in it, treat the whole `SEARXNG_URL` as a secret: `AUTH_PASSWORD` remains available as a legacy global fallback when a `SEARXNG_URL` entry has no userinfo, and `MCP_HTTP_AUTH_TOKEN`, proxy credentials, and any credentials embedded in `SEARXNG_URL` are secrets. Avoid committing them to source control. Use secret management (Docker secrets, environment injection at runtime, or a secrets manager) in production.
 
 If an older release emitted SearXNG credentials into logs or client-visible

--- a/__tests__/e2e/timeout.e2e.ts
+++ b/__tests__/e2e/timeout.e2e.ts
@@ -12,9 +12,13 @@
  */
 
 import { strict as assert } from 'node:assert';
+import { spawn } from 'node:child_process';
 import http from 'node:http';
 import type { Socket } from 'node:net';
 import { fileURLToPath } from 'node:url';
+import { Client } from '@modelcontextprotocol/sdk/client/index.js';
+import { getDefaultEnvironment, StdioClientTransport } from '@modelcontextprotocol/sdk/client/stdio.js';
+import { StreamableHTTPClientTransport } from '@modelcontextprotocol/sdk/client/streamableHttp.js';
 import {
   checkSkipConditions,
   INIT_PARAMS,
@@ -68,6 +72,56 @@ async function startHeadersThenStallServer(
   });
 }
 
+async function startAdmissionHttpCli(stateless = false): Promise<{ url: URL; close: () => Promise<void> }> {
+  const port = await new Promise<number>((resolve, reject) => {
+    const reservation = http.createServer();
+    reservation.once('error', reject);
+    reservation.listen(0, '127.0.0.1', () => {
+      const address = reservation.address();
+      if (!address || typeof address === 'string') {
+        reservation.close(() => reject(new Error('Could not reserve a loopback port')));
+        return;
+      }
+      reservation.close((error) => error ? reject(error) : resolve(address.port));
+    });
+  });
+  const child = spawn(process.execPath, ['dist/cli.js'], {
+    env: {
+      ...process.env,
+      MCP_HTTP_HOST: '127.0.0.1',
+      MCP_HTTP_PORT: String(port),
+      MCP_TOOL_RATE_WINDOW_MS: '60000',
+      MCP_TOOL_RATE_MAX: '1',
+      MCP_TOOL_MAX_IN_FLIGHT: '1',
+      MCP_HTTP_STATELESS: stateless ? 'true' : 'false',
+      SEARXNG_URL: 'https://test-searx.example.com',
+    },
+    stdio: 'ignore',
+    windowsHide: true,
+  });
+  const url = new URL(`http://127.0.0.1:${port}/mcp`);
+  const deadline = Date.now() + 10_000;
+  while (Date.now() < deadline) {
+    if (child.exitCode !== null) throw new Error(`Admission HTTP CLI exited early with ${child.exitCode}`);
+    try {
+      const response = await fetch(new URL('/health', url));
+      if (response.ok) break;
+    } catch { /* server is still starting */ }
+    await new Promise((resolve) => setTimeout(resolve, 50));
+  }
+  if (Date.now() >= deadline) throw new Error('Admission HTTP CLI did not become healthy');
+  return {
+    url,
+    close: async () => {
+      if (child.exitCode !== null) return;
+      const closed = new Promise<void>((resolve) => child.once('close', () => resolve()));
+      child.kill('SIGTERM');
+      await Promise.race([closed, new Promise<void>((resolve) => setTimeout(resolve, 5000))]);
+      if (child.exitCode === null) child.kill('SIGKILL');
+    },
+  };
+}
+
 // Default fetch timeout in src/search.ts and src/url-reader.ts
 const FETCH_TIMEOUT_MS = 10000;
 // Allow 3s extra for process startup, JSON parsing, etc.
@@ -116,6 +170,89 @@ async function runTests() {
     console.log(skip);
     return { passed: 0, failed: 0, errors: [] };
   }
+
+  await testFunction('STDIO applies the configured tool admission budget without corrupting JSON-RPC output', async () => {
+    const responses = await spawnWithMessagesAsync(
+      [
+        { jsonrpc: '2.0', id: 1, method: 'initialize', params: INIT_PARAMS },
+        { jsonrpc: '2.0', id: 2, method: 'tools/call', params: { name: 'not_a_tool', arguments: {} } },
+        { jsonrpc: '2.0', id: 3, method: 'tools/call', params: { name: 'searxng_web_search', arguments: { query: 'must-not-run' } } },
+      ],
+      'https://test-searx.example.com',
+      10_000,
+      { MCP_TOOL_RATE_WINDOW_MS: '60000', MCP_TOOL_RATE_MAX: '1', MCP_TOOL_MAX_IN_FLIGHT: '1' },
+    );
+
+    assert.ok(responses[1]?.result?.serverInfo, JSON.stringify(responses));
+    assert.ok(responses[2]?.error, JSON.stringify(responses));
+    assert.equal(responses[3]?.result?.isError, true, JSON.stringify(responses));
+    assert.equal(responses[3]?.result?.content?.[0]?.text, 'Server busy. Retry later with backoff.');
+  }, results);
+
+  await testFunction('built STDIO recovers its tool rate budget after a fixed-window rollover', async () => {
+    const transport = new StdioClientTransport({
+      command: process.execPath,
+      args: ['dist/cli.js'],
+      cwd: process.cwd(),
+      env: {
+        ...getDefaultEnvironment(),
+        MCP_TOOL_RATE_WINDOW_MS: '5000',
+        MCP_TOOL_RATE_MAX: '1',
+        MCP_TOOL_MAX_IN_FLIGHT: '1',
+        SEARXNG_URL: 'https://test-searx.example.com',
+      },
+      stderr: 'pipe',
+    });
+    const client = new Client({ name: 'tool-admission-stdio-recovery', version: '1.0.0' });
+    try {
+      await client.connect(transport);
+      await assert.rejects(() => client.callTool({ name: 'not_a_tool', arguments: {} }), /Unknown tool/);
+      const rejection = await client.callTool({ name: 'not_a_tool', arguments: {} });
+      assert.equal(rejection.isError, true);
+      assert.equal((rejection.content[0] as { text: string }).text, 'Server busy. Retry later with backoff.');
+      await new Promise((resolve) => setTimeout(resolve, 5100));
+      await assert.rejects(() => client.callTool({ name: 'not_a_tool', arguments: {} }), /Unknown tool/);
+    } finally {
+      await client.close();
+    }
+  }, results);
+
+  await testFunction('HTTP applies the same stable tool admission rejection', async () => {
+    const server = await startAdmissionHttpCli();
+    const client = new Client({ name: 'tool-admission-e2e', version: '1.0.0' });
+    try {
+      await client.connect(new StreamableHTTPClientTransport(server.url));
+      await assert.rejects(() => client.callTool({ name: 'not_a_tool', arguments: {} }));
+      const rejection = await client.callTool({ name: 'searxng_web_search', arguments: { query: 'must-not-run' } });
+      assert.equal(rejection.isError, true);
+      assert.equal((rejection.content[0] as { text: string }).text, 'Server busy. Retry later with backoff.');
+      assert.equal((await client.listTools()).tools.length, 4);
+      assert.equal((await client.listResources()).resources.length, 2);
+      assert.equal((await client.readResource({ uri: 'help://usage-guide' })).contents.length, 1);
+      await client.setLoggingLevel('debug');
+      assert.equal((await fetch(new URL('/health', server.url))).ok, true);
+      const stillExhausted = await client.callTool({ name: 'searxng_web_search', arguments: { query: 'still-must-not-run' } });
+      assert.equal(stillExhausted.isError, true);
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }, results);
+
+  await testFunction('stateless HTTP requests share the same process tool budget', async () => {
+    const server = await startAdmissionHttpCli(true);
+    const client = new Client({ name: 'tool-admission-stateless-e2e', version: '1.0.0' });
+    try {
+      await client.connect(new StreamableHTTPClientTransport(server.url));
+      await assert.rejects(() => client.callTool({ name: 'not_a_tool', arguments: {} }), /Unknown tool/);
+      const rejection = await client.callTool({ name: 'not_a_tool', arguments: {} });
+      assert.equal(rejection.isError, true);
+      assert.equal((rejection.content[0] as { text: string }).text, 'Server busy. Retry later with backoff.');
+    } finally {
+      await client.close();
+      await server.close();
+    }
+  }, results);
 
   await testFunction('web_url_read times out against a hanging server', async () => {
     const { url, close } = await startHangingServer();

--- a/__tests__/e2e/timeout.e2e.ts
+++ b/__tests__/e2e/timeout.e2e.ts
@@ -100,25 +100,31 @@ async function startAdmissionHttpCli(stateless = false): Promise<{ url: URL; clo
     windowsHide: true,
   });
   const url = new URL(`http://127.0.0.1:${port}/mcp`);
+  const close = async () => {
+    if (child.exitCode !== null) return;
+    const closed = new Promise<void>((resolve) => child.once('close', () => resolve()));
+    child.kill('SIGTERM');
+    await Promise.race([closed, new Promise<void>((resolve) => setTimeout(resolve, 5000))]);
+    if (child.exitCode === null) child.kill('SIGKILL');
+  };
   const deadline = Date.now() + 10_000;
-  while (Date.now() < deadline) {
-    if (child.exitCode !== null) throw new Error(`Admission HTTP CLI exited early with ${child.exitCode}`);
-    try {
-      const response = await fetch(new URL('/health', url));
-      if (response.ok) break;
-    } catch { /* server is still starting */ }
-    await new Promise((resolve) => setTimeout(resolve, 50));
+  try {
+    while (Date.now() < deadline) {
+      if (child.exitCode !== null) throw new Error(`Admission HTTP CLI exited early with ${child.exitCode}`);
+      try {
+        const response = await fetch(new URL('/health', url));
+        if (response.ok) break;
+      } catch { /* server is still starting */ }
+      await new Promise((resolve) => setTimeout(resolve, 50));
+    }
+    if (Date.now() >= deadline) throw new Error('Admission HTTP CLI did not become healthy');
+  } catch (error) {
+    await close();
+    throw error;
   }
-  if (Date.now() >= deadline) throw new Error('Admission HTTP CLI did not become healthy');
   return {
     url,
-    close: async () => {
-      if (child.exitCode !== null) return;
-      const closed = new Promise<void>((resolve) => child.once('close', () => resolve()));
-      child.kill('SIGTERM');
-      await Promise.race([closed, new Promise<void>((resolve) => setTimeout(resolve, 5000))]);
-      if (child.exitCode === null) child.kill('SIGKILL');
-    },
+    close,
   };
 }
 

--- a/__tests__/integration/index.test.ts
+++ b/__tests__/integration/index.test.ts
@@ -12,7 +12,8 @@ import { fileURLToPath } from 'node:url';
 import { packageVersion } from '../../src/version.js';
 import {
   isWebUrlReadArgs,
-  createMcpServer
+  createMcpServer,
+  createToolAdmissionController,
 } from '../../src/index.js';
 import { isSearXNGWebSearchArgs } from '../../src/types.js';
 import { createConfigResource, createHelpResource } from '../../src/resources.js';
@@ -259,14 +260,15 @@ async function runTests() {
   }, results);
 
   await testFunction('createMcpServer returns an McpServer instance', () => {
-    const server = createMcpServer();
+    const server = createMcpServer(createToolAdmissionController());
     assert.ok(server, 'should return a truthy value');
     assert.ok(server.server, 'should expose underlying Server via .server');
   }, results);
 
   await testFunction('createMcpServer returns independent instances per call', () => {
-    const server1 = createMcpServer();
-    const server2 = createMcpServer();
+    const controller = createToolAdmissionController();
+    const server1 = createMcpServer(controller);
+    const server2 = createMcpServer(controller);
     assert.notEqual(server1, server2, 'factory should return distinct objects');
     assert.notEqual(server1.server, server2.server, 'underlying servers should differ');
   }, results);

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -142,6 +142,13 @@ async function withPrivateUrlReadsAllowed(test: () => Promise<void>) {
 async function runTests() {
   console.log('🧪 Integration Testing: MCP handler dispatch (InMemoryTransport)\n');
 
+  await testFunction('createMcpServer fails fast without the required admission controller', () => {
+    assert.throws(
+      () => createMcpServer(undefined as never),
+      /Tool admission controller is required/,
+    );
+  }, results);
+
   await testFunction('bounded tool admission configuration uses strict safe defaults', () => {
     assert.equal(parseStrictInteger(' +001 '), 1);
     assert.equal(parseStrictInteger('1e3'), undefined);

--- a/__tests__/integration/mcp-handlers.test.ts
+++ b/__tests__/integration/mcp-handlers.test.ts
@@ -15,7 +15,18 @@ import { fileURLToPath } from 'node:url';
 import { Client } from '@modelcontextprotocol/sdk/client/index.js';
 import { InMemoryTransport } from '@modelcontextprotocol/sdk/inMemory.js';
 import { LoggingMessageNotificationSchema } from '@modelcontextprotocol/sdk/types.js';
-import { createMcpServer } from '../../src/index.js';
+import {
+  createMcpServer,
+  createToolAdmissionController,
+  TOOL_ADMISSION_REJECTION_MESSAGE,
+  ToolAdmissionController,
+} from '../../src/index.js';
+import {
+  normalizePositiveInteger,
+  parseBoundedInteger,
+  parsePositiveInteger,
+  parseStrictInteger,
+} from '../../src/env-int.js';
 import {
   initializeDiagnosticSanitizer,
   resetDiagnosticSanitizerForTests,
@@ -31,9 +42,17 @@ const EXPECTED_PROTOCOL_ERROR_MESSAGE =
   + 'Set SEARXNG_URL (e.g., http://localhost:8080 or https://search.example.com)';
 
 /** Spin up a fresh Client↔Server pair for each test. Call client.close() when done. */
-async function connect() {
+function createTestAdmissionController() {
+  return new ToolAdmissionController({
+    rateWindowMs: 60_000,
+    rateMax: 10_000,
+    maxInFlight: 256,
+  });
+}
+
+async function connect(controller = createTestAdmissionController()) {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  const mcpServer = createMcpServer();
+  const mcpServer = createMcpServer(controller);
   const client = new Client(
     { name: 'test-client', version: '1.0.0' },
     { capabilities: {} }
@@ -43,9 +62,9 @@ async function connect() {
   return { client, mcpServer };
 }
 
-async function connectWithLogs() {
+async function connectWithLogs(controller = createTestAdmissionController()) {
   const [clientTransport, serverTransport] = InMemoryTransport.createLinkedPair();
-  const mcpServer = createMcpServer();
+  const mcpServer = createMcpServer(controller);
   const client = new Client(
     { name: 'test-client', version: '1.0.0' },
     { capabilities: {} },
@@ -122,6 +141,278 @@ async function withPrivateUrlReadsAllowed(test: () => Promise<void>) {
 
 async function runTests() {
   console.log('🧪 Integration Testing: MCP handler dispatch (InMemoryTransport)\n');
+
+  await testFunction('bounded tool admission configuration uses strict safe defaults', () => {
+    assert.equal(parseStrictInteger(' +001 '), 1);
+    assert.equal(parseStrictInteger('1e3'), undefined);
+    assert.equal(parsePositiveInteger(undefined, 7), 7);
+    assert.equal(parsePositiveInteger('  ', 7), 7);
+    assert.equal(parsePositiveInteger('-1', 7), 7);
+    assert.equal(normalizePositiveInteger(3, 7), 3);
+    assert.equal(normalizePositiveInteger(0, 7), 7);
+    assert.deepEqual(parseBoundedInteger(undefined, 300, 1, 10_000), { value: 300, invalid: false });
+    assert.deepEqual(parseBoundedInteger('  ', 300, 1, 10_000), { value: 300, invalid: false });
+    assert.deepEqual(parseBoundedInteger('  +001  ', 300, 1, 10_000), { value: 1, invalid: false });
+    assert.deepEqual(parseBoundedInteger('10000', 300, 1, 10_000), { value: 10_000, invalid: false });
+    assert.deepEqual(parseBoundedInteger('0', 300, 1, 10_000), { value: 300, invalid: true });
+    assert.deepEqual(parseBoundedInteger('10ms', 300, 1, 10_000), { value: 300, invalid: true });
+    assert.deepEqual(parseBoundedInteger('9007199254740992', 300, 1, 10_000), { value: 300, invalid: true });
+  }, results);
+
+  await testFunction('tool admission is rate-first, shared, and releases capacity exactly once', () => {
+    let now = 0;
+    const controller = new ToolAdmissionController(
+      { rateWindowMs: 1_000, rateMax: 2, maxInFlight: 1 },
+      () => now,
+    );
+    const first = controller.admit();
+    assert.ok(first.release, 'first call should reserve a slot');
+    assert.equal(controller.admit().reason, 'concurrency', 'rate admission must precede concurrency');
+    first.release!();
+    const exhausted = controller.admit();
+    assert.equal(exhausted.reason, 'rate');
+    now = 1_000;
+    const recovered = controller.admit();
+    assert.ok(recovered.release, 'the next fixed window should recover the rate budget');
+    recovered.release!();
+    recovered.release!();
+  }, results);
+
+  await testFunction('tool admission warnings are value-free and configuration is read once', () => {
+    const originalWindow = process.env.MCP_TOOL_RATE_WINDOW_MS;
+    const originalRate = process.env.MCP_TOOL_RATE_MAX;
+    const originalInFlight = process.env.MCP_TOOL_MAX_IN_FLIGHT;
+    const warnings: unknown[][] = [];
+    const originalWarn = console.warn;
+    process.env.MCP_TOOL_RATE_WINDOW_MS = 'window-invalid';
+    process.env.MCP_TOOL_RATE_MAX = 'rate-invalid';
+    process.env.MCP_TOOL_MAX_IN_FLIGHT = 'in-flight-invalid';
+    console.warn = (...values: unknown[]) => { warnings.push(values); };
+    try {
+      const controller = createToolAdmissionController();
+      assert.equal(controller.admit().release !== undefined, true);
+      assert.equal(warnings.length, 3);
+      const output = warnings.map((warning) => String(warning[0])).join('\n');
+      assert.ok(output.includes('MCP_TOOL_RATE_WINDOW_MS'), output);
+      assert.ok(output.includes('MCP_TOOL_RATE_MAX'), output);
+      assert.ok(output.includes('MCP_TOOL_MAX_IN_FLIGHT'), output);
+      assert.ok(output.includes('60000'), output);
+      assert.ok(output.includes('300'), output);
+      assert.ok(output.includes('16'), output);
+      assert.ok(!output.includes('window-invalid'), output);
+      assert.ok(!output.includes('rate-invalid'), output);
+      assert.ok(!output.includes('in-flight-invalid'), output);
+    } finally {
+      console.warn = originalWarn;
+      if (originalWindow === undefined) delete process.env.MCP_TOOL_RATE_WINDOW_MS;
+      else process.env.MCP_TOOL_RATE_WINDOW_MS = originalWindow;
+      if (originalRate === undefined) delete process.env.MCP_TOOL_RATE_MAX;
+      else process.env.MCP_TOOL_RATE_MAX = originalRate;
+      if (originalInFlight === undefined) delete process.env.MCP_TOOL_MAX_IN_FLIGHT;
+      else process.env.MCP_TOOL_MAX_IN_FLIGHT = originalInFlight;
+    }
+  }, results);
+
+  await testFunction('rate-window rollover leaves an outstanding in-flight reservation held', () => {
+    let monotonicNow = 10;
+    const controller = new ToolAdmissionController(
+      { rateWindowMs: 1_000, rateMax: 1, maxInFlight: 1 },
+      () => monotonicNow,
+    );
+    const held = controller.admit();
+    assert.ok(held.release);
+    const originalDateNow = Date.now;
+    try {
+      Date.now = () => Number.MAX_SAFE_INTEGER;
+      assert.equal(controller.admit().reason, 'rate', 'wall-clock jumps must not reset the rate window');
+      Date.now = () => -1_000_000;
+      assert.equal(controller.admit().reason, 'rate', 'backward wall-clock jumps must not reset the rate window');
+      monotonicNow = 1_010;
+      assert.equal(controller.admit().reason, 'concurrency');
+    } finally {
+      Date.now = originalDateNow;
+    }
+    held.release!();
+    monotonicNow = 2_010;
+    assert.ok(controller.admit().release, 'only the rate counter resets at monotonic rollover');
+  }, results);
+
+  await testFunction('the in-flight ceiling is exact and racing terminal releases are idempotent', async () => {
+    const controller = new ToolAdmissionController({ rateWindowMs: 60_000, rateMax: 10, maxInFlight: 2 });
+    let active = 0;
+    let peak = 0;
+    const reserve = () => {
+      const admission = controller.admit();
+      assert.ok(admission.release);
+      active += 1;
+      peak = Math.max(peak, active);
+      let terminal = false;
+      return () => {
+        admission.release!();
+        if (terminal) return;
+        terminal = true;
+        active -= 1;
+      };
+    };
+    const first = reserve();
+    const second = reserve();
+    assert.equal(controller.admit().reason, 'concurrency');
+    assert.equal(peak, 2);
+    await Promise.all([Promise.resolve().then(first), Promise.resolve().then(first)]);
+    assert.equal(active, 1);
+    const third = reserve();
+    assert.equal(peak, 2, 'the observed peak must equal, never exceed, the configured ceiling');
+    second();
+    third();
+    assert.equal(active, 0);
+  }, results);
+
+  await testFunction('shared servers reject exhausted tool calls while control traffic remains available', async () => {
+    const controller = new ToolAdmissionController({ rateWindowMs: 60_000, rateMax: 1, maxInFlight: 1 });
+    const first = await connect(controller);
+    const second = await connect(controller);
+    try {
+      await assert.rejects(() => first.client.callTool({ name: 'not_a_tool', arguments: {} }));
+      const listed = await second.client.listTools();
+      assert.equal(listed.tools.length, 4);
+      const rejection = await second.client.callTool({ name: 'not_a_tool', arguments: {} });
+      assert.equal(rejection.isError, true);
+      assert.equal((rejection.content[0] as { text: string }).text, TOOL_ADMISSION_REJECTION_MESSAGE);
+    } finally {
+      await first.client.close();
+      await second.client.close();
+    }
+  }, results);
+
+  await testFunction('concurrency rejection starts no extra upstream work and releases after completion', async () => {
+    const controller = new ToolAdmissionController({ rateWindowMs: 60_000, rateMax: 3, maxInFlight: 1 });
+    const first = await connect(controller);
+    const second = await connect(controller);
+    const originalUrl = process.env.SEARXNG_URL;
+    process.env.SEARXNG_URL = 'http://localhost:8080';
+    let fetches = 0;
+    let resolveFetch: ((response: Response) => void) | undefined;
+    fetchMocker.mock(() => {
+      fetches += 1;
+      return new Promise<Response>((resolve) => { resolveFetch = resolve; });
+    });
+    try {
+      const pending = first.client.callTool({ name: 'searxng_web_search', arguments: { query: 'first' } });
+      while (fetches === 0) await new Promise((resolve) => setTimeout(resolve, 1));
+      const rejected = await second.client.callTool({ name: 'searxng_web_search', arguments: { query: 'second' } });
+      assert.equal(rejected.isError, true);
+      assert.equal(fetches, 1, 'the rejected call must not reach the upstream fetch');
+      resolveFetch!(new Response(SEARXNG_RESPONSE, { status: 200, headers: { 'content-type': 'application/json' } }));
+      await pending;
+      fetchMocker.mock(createMockFetch({ body: SEARXNG_RESPONSE }));
+      const afterRelease = await second.client.callTool({ name: 'searxng_web_search', arguments: { query: 'third' } });
+      assert.equal(afterRelease.isError, undefined);
+    } finally {
+      fetchMocker.restore();
+      if (originalUrl === undefined) delete process.env.SEARXNG_URL;
+      else process.env.SEARXNG_URL = originalUrl;
+      await first.client.close();
+      await second.client.close();
+    }
+  }, results);
+
+  await testFunction('a handler failure releases its admission slot for a later accepted call', async () => {
+    const controller = new ToolAdmissionController({ rateWindowMs: 60_000, rateMax: 3, maxInFlight: 1 });
+    const { client } = await connect(controller);
+    const originalUrl = process.env.SEARXNG_URL;
+    process.env.SEARXNG_URL = 'http://localhost:8080';
+    fetchMocker.mock(createMockFetch({ body: SEARXNG_RESPONSE }));
+    try {
+      await assert.rejects(() => client.callTool({ name: 'not_a_tool', arguments: {} }));
+      const accepted = await client.callTool({ name: 'searxng_web_search', arguments: { query: 'after-failure' } });
+      assert.equal(accepted.isError, undefined);
+    } finally {
+      fetchMocker.restore();
+      if (originalUrl === undefined) delete process.env.SEARXNG_URL;
+      else process.env.SEARXNG_URL = originalUrl;
+      await client.close();
+    }
+  }, results);
+
+  await testFunction('client cancellation releases an admitted URL-read slot exactly once', async () => {
+    const controller = new ToolAdmissionController({ rateWindowMs: 60_000, rateMax: 4, maxInFlight: 1 });
+    const { client } = await connect(controller);
+    const originalPrivateUrls = process.env.MCP_HTTP_ALLOW_PRIVATE_URLS;
+    const originalUrl = process.env.SEARXNG_URL;
+    process.env.MCP_HTTP_ALLOW_PRIVATE_URLS = 'true';
+    process.env.SEARXNG_URL = 'http://localhost:8080';
+    const hangingServer = http.createServer((_request, _response) => { /* waits for client cancellation */ });
+    await new Promise<void>((resolve, reject) => {
+      hangingServer.listen(0, '127.0.0.1', resolve);
+      hangingServer.once('error', reject);
+    });
+    const address = hangingServer.address() as net.AddressInfo;
+    const aborter = new AbortController();
+    fetchMocker.mock(createMockFetch({ body: SEARXNG_RESPONSE }));
+    try {
+      const pending = client.callTool(
+        { name: 'web_url_read', arguments: { url: `http://127.0.0.1:${address.port}` } },
+        undefined,
+        { signal: aborter.signal },
+      );
+      setTimeout(() => aborter.abort(), 20);
+      await assert.rejects(pending);
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const accepted = await client.callTool({ name: 'searxng_web_search', arguments: { query: 'after-cancel' } });
+      assert.equal(accepted.isError, undefined);
+    } finally {
+      hangingServer.closeAllConnections();
+      await new Promise<void>((resolve) => hangingServer.close(() => resolve()));
+      fetchMocker.restore();
+      if (originalPrivateUrls === undefined) delete process.env.MCP_HTTP_ALLOW_PRIVATE_URLS;
+      else process.env.MCP_HTTP_ALLOW_PRIVATE_URLS = originalPrivateUrls;
+      if (originalUrl === undefined) delete process.env.SEARXNG_URL;
+      else process.env.SEARXNG_URL = originalUrl;
+      await client.close();
+    }
+  }, results);
+
+  await testFunction('client request timeout releases an admitted URL-read slot without an unhandled rejection', async () => {
+    const controller = new ToolAdmissionController({ rateWindowMs: 60_000, rateMax: 4, maxInFlight: 1 });
+    const { client } = await connect(controller);
+    const originalPrivateUrls = process.env.MCP_HTTP_ALLOW_PRIVATE_URLS;
+    const originalUrl = process.env.SEARXNG_URL;
+    process.env.MCP_HTTP_ALLOW_PRIVATE_URLS = 'true';
+    process.env.SEARXNG_URL = 'http://localhost:8080';
+    const hangingServer = http.createServer((_request, _response) => { /* waits for request timeout */ });
+    await new Promise<void>((resolve, reject) => {
+      hangingServer.listen(0, '127.0.0.1', resolve);
+      hangingServer.once('error', reject);
+    });
+    const address = hangingServer.address() as net.AddressInfo;
+    const unhandled: unknown[] = [];
+    const onUnhandled = (reason: unknown) => { unhandled.push(reason); };
+    process.on('unhandledRejection', onUnhandled);
+    fetchMocker.mock(createMockFetch({ body: SEARXNG_RESPONSE }));
+    try {
+      await assert.rejects(
+        client.callTool(
+          { name: 'web_url_read', arguments: { url: `http://127.0.0.1:${address.port}` } },
+          undefined,
+          { timeout: 20 },
+        ),
+      );
+      await new Promise((resolve) => setTimeout(resolve, 50));
+      const accepted = await client.callTool({ name: 'searxng_web_search', arguments: { query: 'after-timeout' } });
+      assert.equal(accepted.isError, undefined);
+      assert.deepEqual(unhandled, []);
+    } finally {
+      process.off('unhandledRejection', onUnhandled);
+      hangingServer.closeAllConnections();
+      await new Promise<void>((resolve) => hangingServer.close(() => resolve()));
+      fetchMocker.restore();
+      if (originalPrivateUrls === undefined) delete process.env.MCP_HTTP_ALLOW_PRIVATE_URLS;
+      else process.env.MCP_HTTP_ALLOW_PRIVATE_URLS = originalPrivateUrls;
+      if (originalUrl === undefined) delete process.env.SEARXNG_URL;
+      else process.env.SEARXNG_URL = originalUrl;
+      await client.close();
+    }
+  }, results);
 
   // ── tools/list ──────────────────────────────────────────────────────────────
 

--- a/src/env-int.ts
+++ b/src/env-int.ts
@@ -22,6 +22,28 @@ export function parsePositiveInteger(value: string | undefined, fallback: number
   return parsed === undefined || parsed <= 0 ? fallback : parsed;
 }
 
+/**
+ * Parses an optional strict integer and applies an inclusive safe range.
+ * The caller owns any diagnostic so this helper remains deterministic and pure.
+ */
+export function parseBoundedInteger(
+  value: string | undefined,
+  fallback: number,
+  minimum: number,
+  maximum: number,
+): { value: number; invalid: boolean } {
+  if (value === undefined || value.trim() === "") {
+    return { value: fallback, invalid: false };
+  }
+
+  const parsed = parseStrictInteger(value);
+  if (parsed === undefined || parsed < minimum || parsed > maximum) {
+    return { value: fallback, invalid: true };
+  }
+
+  return { value: parsed, invalid: false };
+}
+
 export function normalizePositiveInteger(value: number, fallback: number): number {
   return !Number.isFinite(value) || !Number.isInteger(value) || value <= 0 ? fallback : value;
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,10 +39,84 @@ import {
   sanitizeErrorForTransport,
 } from "./diagnostic-sanitizer.js";
 import { writeDiagnostic } from "./diagnostic-output.js";
-import { parseStrictInteger } from "./env-int.js";
+import { parseBoundedInteger, parseStrictInteger } from "./env-int.js";
 import { validateBrowserSolverEnvironment } from "./browser-solver-config.js";
 
 import { packageVersion } from "./version.js";
+
+export const TOOL_ADMISSION_REJECTION_MESSAGE = "Server busy. Retry later with backoff.";
+
+export interface ToolAdmissionConfig {
+  rateWindowMs: number;
+  rateMax: number;
+  maxInFlight: number;
+}
+
+export interface ToolAdmissionResult {
+  reason?: "rate" | "concurrency";
+  release?: () => void;
+}
+
+/** SDK-neutral, process-local admission state shared by every MCP transport. */
+export class ToolAdmissionController {
+  private windowStartedAt: number | undefined;
+  private rateCount = 0;
+  private inFlight = 0;
+
+  constructor(
+    private readonly config: ToolAdmissionConfig,
+    private readonly now: () => number = () => performance.now(),
+  ) {}
+
+  admit(): ToolAdmissionResult {
+    const now = this.now();
+    if (this.windowStartedAt === undefined || now - this.windowStartedAt >= this.config.rateWindowMs) {
+      this.windowStartedAt = now;
+      this.rateCount = 0;
+    }
+
+    if (this.rateCount >= this.config.rateMax) {
+      return { reason: "rate" };
+    }
+    this.rateCount += 1;
+
+    if (this.inFlight >= this.config.maxInFlight) {
+      return { reason: "concurrency" };
+    }
+    this.inFlight += 1;
+
+    let released = false;
+    return {
+      release: () => {
+        if (released) return;
+        released = true;
+        this.inFlight -= 1;
+      },
+    };
+  }
+}
+
+const TOOL_ADMISSION_ENV = [
+  ["MCP_TOOL_RATE_WINDOW_MS", "rateWindowMs", 60000, 1000, 2147483647],
+  ["MCP_TOOL_RATE_MAX", "rateMax", 300, 1, 10000],
+  ["MCP_TOOL_MAX_IN_FLIGHT", "maxInFlight", 16, 1, 256],
+] as const;
+
+export function createToolAdmissionController(): ToolAdmissionController {
+  const values: Record<string, number> = {};
+  for (const [name, property, fallback, minimum, maximum] of TOOL_ADMISSION_ENV) {
+    const parsed = parseBoundedInteger(process.env[name], fallback, minimum, maximum);
+    if (parsed.invalid) {
+      writeDiagnostic("warn", `Ignoring invalid ${name}. Using default ${fallback}.`);
+    }
+    values[property] = parsed.value;
+  }
+  return new ToolAdmissionController({
+    rateWindowMs: values.rateWindowMs,
+    rateMax: values.rateMax,
+    maxInFlight: values.maxInFlight,
+  });
+}
 
 // Type guard for URL reading args
 export function isWebUrlReadArgs(args: unknown): args is {
@@ -130,7 +204,7 @@ function getDefaultUrlReadMaxChars(mcpServer: McpServer): number | undefined {
  * Creates and configures a new McpServer with all handlers registered.
  * Called once per HTTP session, or once for STDIO mode.
  */
-export function createMcpServer(): McpServer {
+export function createMcpServer(admissionController: ToolAdmissionController): McpServer {
   const mcpServer = new McpServer(
     {
       name: "ihor-sokoliuk/mcp-searxng",
@@ -163,10 +237,20 @@ export function createMcpServer(): McpServer {
 
   // Call tool handler
   server.setRequestHandler(CallToolRequestSchema, async (request, extra) => {
-    const { name, arguments: args } = request.params;
-    logMessage(mcpServer, "debug", `Handling call_tool request: ${name}`);
+    const admission = admissionController.admit();
+    if (!admission.release) {
+      return {
+        content: [{ type: "text", text: TOOL_ADMISSION_REJECTION_MESSAGE }],
+        isError: true,
+      };
+    }
 
+    let name: string | undefined;
+    let args: unknown;
     try {
+      ({ name, arguments: args } = request.params);
+      logMessage(mcpServer, "debug", `Handling call_tool request: ${name}`);
+
       if (name === "searxng_web_search") {
         if (!isSearXNGWebSearchArgs(args)) {
           throw new Error("Invalid arguments for web search");
@@ -276,6 +360,8 @@ export function createMcpServer(): McpServer {
         error: safeError.stack,
       });
       throw safeError;
+    } finally {
+      admission.release();
     }
   });
 
@@ -354,6 +440,7 @@ export function createMcpServer(): McpServer {
 // Main function
 export async function main() {
   initializeDiagnosticSanitizer();
+  const toolAdmissionController = createToolAdmissionController();
   const browserSolverIssue = validateBrowserSolverEnvironment();
   if (browserSolverIssue) {
     throw new Error(browserSolverIssue);
@@ -370,7 +457,7 @@ export async function main() {
 
     const host = resolveBindHost(process.env.MCP_HTTP_HOST);
     writeDiagnostic("log", `Starting HTTP transport on ${host}:${port}`);
-    const app = await createHttpServer(createMcpServer, port);
+    const app = await createHttpServer(() => createMcpServer(toolAdmissionController), port);
     
     const httpServer = app.listen(port, host, () => {
       writeDiagnostic("log", `HTTP server listening on ${host}:${port}`);
@@ -392,7 +479,7 @@ export async function main() {
     process.on('SIGTERM', () => shutdown('SIGTERM'));
   } else {
     // Default STDIO transport — single session, single server
-    const mcpServer = createMcpServer();
+    const mcpServer = createMcpServer(toolAdmissionController);
 
     // Show helpful message when running in terminal
     if (process.stdin.isTTY) {

--- a/src/index.ts
+++ b/src/index.ts
@@ -205,6 +205,10 @@ function getDefaultUrlReadMaxChars(mcpServer: McpServer): number | undefined {
  * Called once per HTTP session, or once for STDIO mode.
  */
 export function createMcpServer(admissionController: ToolAdmissionController): McpServer {
+  if (!admissionController) {
+    throw new TypeError("Tool admission controller is required");
+  }
+
   const mcpServer = new McpServer(
     {
       name: "ihor-sokoliuk/mcp-searxng",
@@ -458,7 +462,7 @@ export async function main() {
     const host = resolveBindHost(process.env.MCP_HTTP_HOST);
     writeDiagnostic("log", `Starting HTTP transport on ${host}:${port}`);
     const app = await createHttpServer(() => createMcpServer(toolAdmissionController), port);
-    
+
     const httpServer = app.listen(port, host, () => {
       writeDiagnostic("log", `HTTP server listening on ${host}:${port}`);
       // Health/MCP URLs shown as localhost for developer convenience


### PR DESCRIPTION
## Summary
- add one process-wide tool admission controller shared by STDIO, stateful HTTP, and stateless HTTP
- enforce bounded fixed-window invocation rate and no-queue in-flight concurrency with sanitized retryable rejection
- document strict configuration, fixed-window behavior, and shared-budget availability trade-offs
- add deterministic parser, concurrency, cancellation, timeout, transport, recovery, and control-traffic coverage

## Verification
- `npm run lint`
- `npm run build`
- `npm run test:coverage` — 750 passed; 95.99% lines, 92.03% branches
- `npm run test:e2e` — 33 passed
- `npm run verify:packed-consumer` — audit 0, four tools
- `git diff --check`