### PR TITLE
web_url_read: add images param (none|links|inline) with bounded image inlining

### DIFF
--- a/__tests__/run-all.ts
+++ b/__tests__/run-all.ts
@@ -28,6 +28,7 @@ import { runTests as runSearchTests } from './unit/search.test.js';
 import { runTests as runSuggestionsTests } from './unit/suggestions.test.js';
 import { runTests as runInstanceInfoTests } from './unit/instance-info.test.js';
 import { runTests as runUrlReaderTests } from './unit/url-reader.test.js';
+import { runTests as runWebImagesTests } from './unit/web-images.test.js';
 import { runTests as runUrlSecurityTests } from './unit/url-security.test.js';
 import { runTests as runTlsConfigTests } from './unit/tls-config.test.js';
 import { runTests as runHttpServerUnitTests } from './unit/http-server.test.js';
@@ -70,6 +71,7 @@ const testSuites: TestSuite[] = [
   { name: 'Suggestions', category: 'unit', run: runSuggestionsTests },
   { name: 'Instance Info', category: 'unit', run: runInstanceInfoTests },
   { name: 'URL Reader', category: 'unit', run: runUrlReaderTests },
+  { name: 'Web Images', category: 'unit', run: runWebImagesTests },
   { name: 'URL Security', category: 'unit', run: runUrlSecurityTests },
   { name: 'TLS Config', category: 'unit', run: runTlsConfigTests },
   { name: 'HTTP Server', category: 'unit', run: runHttpServerUnitTests },

--- a/__tests__/unit/web-images.test.ts
+++ b/__tests__/unit/web-images.test.ts
@@ -1,0 +1,203 @@
+#!/usr/bin/env tsx
+
+/**
+ * Unit Tests: web-images.ts
+ *
+ * Tests for image reference extraction from markdown and bounded image
+ * inlining (web_url_read images:"inline").
+ */
+
+import { strict as assert } from 'node:assert';
+import * as http from 'node:http';
+import { fileURLToPath } from 'node:url';
+import {
+  extractImageRefs,
+  inlineImages,
+  getImageLimits,
+  DEFAULT_MAX_IMAGES,
+  DEFAULT_MAX_IMAGE_BYTES,
+  DEFAULT_MAX_TOTAL_IMAGE_BYTES,
+  type ImageLimits,
+} from '../../src/web-images.js';
+import { testFunction, createTestResults, printTestSummary, type TestResult } from '../helpers/test-utils.js';
+import { EnvManager } from '../helpers/env-utils.js';
+
+const PNG_1PX =
+  "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+
+const limits: ImageLimits = {
+  maxImages: DEFAULT_MAX_IMAGES,
+  maxImageBytes: DEFAULT_MAX_IMAGE_BYTES,
+  maxTotalBytes: DEFAULT_MAX_TOTAL_IMAGE_BYTES,
+};
+
+function startImageServer(handlers: Array<{ path: string; status?: number; body?: string; buffer?: Buffer; contentType?: string; hang?: boolean }>): Promise<{ url: string; close: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const server = http.createServer((req, res) => {
+      const handler = handlers.find((h) => req.url === h.path);
+      if (!handler) {
+        res.writeHead(404).end("not found");
+        return;
+      }
+      if (handler.hang) {
+        return; // never respond
+      }
+      res.writeHead(handler.status ?? 200, { "Content-Type": handler.contentType ?? "application/octet-stream" });
+      res.end(handler.buffer ?? handler.body ?? "");
+    });
+    server.listen(0, "127.0.0.1", () => {
+      const address = server.address();
+      const port = typeof address === "object" && address ? address.port : 0;
+      resolve({ url: `http://127.0.0.1:${port}`, close: () => new Promise((r) => server.close(r)) });
+    });
+  });
+}
+
+async function runTests(): Promise<TestResult> {
+  const results = createTestResults();
+  const envManager = new EnvManager();
+
+  // ─── extractImageRefs ───────────────────────────────────────────────────────
+
+  await testFunction("extractImageRefs finds image links with alt, heading, and resolved src", () => {
+    const markdown = [
+      "# Top",
+      "",
+      "## Benchmarks",
+      "text ![chart](bench.png \"Chart\") more",
+      "![plain](https://img.example/a.gif)",
+    ].join("\n");
+    const refs = extractImageRefs(markdown, new URL("https://site.example/page/"), 6);
+    assert.equal(refs.length, 2);
+    assert.equal(refs[0].alt, "chart");
+    assert.equal(refs[0].heading, "Benchmarks");
+    assert.equal(refs[0].absoluteSrc, "https://site.example/page/bench.png");
+    assert.equal(refs[1].alt, "plain");
+    assert.equal(refs[1].heading, "Benchmarks");
+    assert.equal(refs[1].absoluteSrc, "https://img.example/a.gif");
+  }, results);
+
+  await testFunction("extractImageRefs caps at maxImages and strips link titles", () => {
+    const markdown = "![a](a.png)\n![b](b.png)\n![c](c.png)\n![d](d.png)";
+    const refs = extractImageRefs(markdown, new URL("https://x.example/"), 2);
+    assert.equal(refs.length, 2);
+    assert.equal(refs[0].src, "a.png");
+    assert.equal(refs[1].src, "b.png");
+
+    const titled = extractImageRefs('![x](img "Title")', new URL("https://x.example/"), 6);
+    assert.equal(titled[0].src, "img");
+  }, results);
+
+  await testFunction("extractImageRefs keeps data URIs and skips src-less links", () => {
+    const dataUri = `data:image/png;base64,${PNG_1PX}`;
+    const markdown = `![d](${dataUri})\n![e]( )`;
+    const refs = extractImageRefs(markdown, new URL("https://x.example/"), 6);
+    assert.equal(refs.length, 1);
+    assert.ok(refs[0].absoluteSrc.startsWith("data:image/png"));
+  }, results);
+
+  // ─── getImageLimits env overrides ──────────────────────────────────────────
+
+  await testFunction("getImageLimits reads URL_READ_* env overrides", () => {
+    envManager.set("URL_READ_MAX_IMAGES", "3");
+    envManager.set("URL_READ_MAX_IMAGE_BYTES", "1024");
+    envManager.set("URL_READ_MAX_TOTAL_IMAGE_BYTES", "2048");
+    const l = getImageLimits();
+    assert.equal(l.maxImages, 3);
+    assert.equal(l.maxImageBytes, 1024);
+    assert.equal(l.maxTotalBytes, 2048);
+    envManager.set("URL_READ_MAX_IMAGES", "not-a-number");
+    assert.equal(getImageLimits().maxImages, DEFAULT_MAX_IMAGES);
+    envManager.restore();
+  }, results);
+
+  // ─── inlineImages ──────────────────────────────────────────────────────────
+
+  await testFunction("inlineImages inlines data URIs without network access", async () => {
+    const dataUri = `data:image/png;base64,${PNG_1PX}`;
+    const refs = extractImageRefs(`![d](${dataUri})`, new URL("https://x.example/"), 6);
+    const out = await inlineImages(refs, limits, 2000);
+    assert.equal(out.length, 1);
+    assert.equal(out[0].data, PNG_1PX);
+    assert.equal(out[0].mimeType, "image/png");
+  }, results);
+
+  const server = await startImageServer([
+    { path: "/ok.png", buffer: Buffer.from(PNG_1PX, "base64"), contentType: "image/png" },
+    { path: "/no-type.png", buffer: Buffer.from(PNG_1PX, "base64") },
+    { path: "/404.png", status: 404, body: "nope" },
+    { path: "/plain.txt", body: "not an image", contentType: "text/plain" },
+    { path: "/wrong-ctype.png", buffer: Buffer.from(PNG_1PX, "base64"), contentType: "text/plain" },
+    { path: "/hang.png", hang: true },
+  ]);
+  envManager.set("MCP_HTTP_ALLOW_PRIVATE_URLS", "true");
+  try {
+    await testFunction("inlineImages downloads http images and marks failures with notes", async () => {
+      const refs = extractImageRefs(
+        [
+          `![ok](${server.url}/ok.png)`,
+          `![404](${server.url}/404.png)`,
+          `![plain](${server.url}/plain.txt)`,
+          `![wrong](${server.url}/wrong-ctype.png)`,
+        ].join("\n"),
+        new URL(server.url),
+        6,
+      );
+      const out = await inlineImages(refs, limits, 2000);
+      assert.equal(out.length, 4);
+      assert.equal(out[0].data, PNG_1PX);
+      assert.equal(out[0].mimeType, "image/png");
+      assert.equal(out[1].note, "skipped: HTTP 404");
+      assert.equal(out[2].note, "skipped: not an image (Content-Type text/plain)");
+      assert.equal(out[2].data, undefined);
+      // A .png extension is trusted even when the server mislabels Content-Type.
+      assert.equal(out[3].data, PNG_1PX);
+      assert.equal(out[3].mimeType, "image/png");
+    }, results);
+
+    await testFunction("inlineImages honors per-image and total byte budgets", async () => {
+      const refs = extractImageRefs(
+        `![big](${server.url}/ok.png)`,
+        new URL(server.url),
+        6,
+      );
+      const tightLimits: ImageLimits = { maxImages: 6, maxImageBytes: 4096, maxTotalBytes: 4 };
+      const tiny: ImageLimits = { maxImages: 6, maxImageBytes: 10, maxTotalBytes: 100 };
+      const out = await inlineImages(refs, tiny, 2000);
+      assert.equal(out[0].note, "skipped: exceeds per-image limit of 10 B");
+      const out2 = await inlineImages(refs, tightLimits, 2000);
+      assert.equal(out2[0].note, "skipped: total image byte budget reached");
+    }, results);
+  } finally {
+    await server.close();
+    envManager.restore();
+  }
+
+  await testFunction("inlineImages times out without hanging the request", async () => {
+    const hung = await startImageServer([{ path: "/hang.png", hang: true }]);
+    envManager.set("MCP_HTTP_ALLOW_PRIVATE_URLS", "true");
+    try {
+      const refs = extractImageRefs(`![h](${hung.url}/hang.png)`, new URL(hung.url), 6);
+      const start = Date.now();
+      const out = await inlineImages(refs, limits, 300);
+      assert.ok(Date.now() - start < 5000, "should finish promptly");
+      assert.equal(out[0].data, undefined);
+      assert.match(out[0].note ?? "", /timed out/);
+    } finally {
+      await hung.close();
+      envManager.restore();
+    }
+  }, results);
+
+  printTestSummary(results, "web-images tests");
+  return results;
+}
+
+// Run if executed directly
+if (process.argv[1] !== undefined && fileURLToPath(import.meta.url) === process.argv[1]) {
+  runTests().then((results) => {
+    process.exit(results.failed > 0 ? 1 : 0);
+  }).catch(console.error);
+}
+
+export { runTests };

--- a/src/index.ts
+++ b/src/index.ts
@@ -20,6 +20,12 @@ import { performWebSearch } from "./search.js";
 import { performSearchSuggestions } from "./suggestions.js";
 import { fetchInstanceInfo } from "./instance-info.js";
 import { fetchAndConvertToMarkdown } from "./url-reader.js";
+import {
+  extractImageRefs,
+  getImageLimits,
+  inlineImages,
+  type ImageRef,
+} from "./web-images.js";
 import { createConfigResource, createHelpResource } from "./resources.js";
 import { createHttpServer, resolveBindHost } from "./http-server.js";
 import {
@@ -118,6 +124,7 @@ export function isWebUrlReadArgs(args: unknown): args is {
   section?: string;
   paragraphRange?: string;
   readHeadings?: boolean;
+  images?: "none" | "links" | "inline";
 } {
   if (
     typeof args !== "object" ||
@@ -148,6 +155,14 @@ export function isWebUrlReadArgs(args: unknown): args is {
     return false;
   }
   if (urlArgs.readHeadings !== undefined && typeof urlArgs.readHeadings !== "boolean") {
+    return false;
+  }
+  if (
+    urlArgs.images !== undefined &&
+    urlArgs.images !== "none" &&
+    urlArgs.images !== "links" &&
+    urlArgs.images !== "inline"
+  ) {
     return false;
   }
 
@@ -193,7 +208,10 @@ function getDefaultUrlReadMaxChars(mcpServer: McpServer): number | undefined {
 }
 
 type ToolCallResult = {
-  content: Array<{ type: "text"; text: string }>;
+  content: Array<
+    | { type: "text"; text: string }
+    | { type: "image"; data: string; mimeType: string }
+  >;
   isError?: boolean;
 };
 
@@ -243,7 +261,7 @@ async function executeUrlRead(
 ): Promise<ToolCallResult> {
   if (!isWebUrlReadArgs(args)) throw new Error("Invalid arguments for URL reading");
   const defaultMaxLength = getDefaultUrlReadMaxChars(mcpServer);
-  return textToolResult(await fetchAndConvertToMarkdown(
+  const markdown = await fetchAndConvertToMarkdown(
     mcpServer,
     args.url,
     getFetchTimeoutMs(mcpServer),
@@ -255,7 +273,59 @@ async function executeUrlRead(
       readHeadings: args.readHeadings,
     },
     signal,
-  ));
+  );
+
+  const imagesMode: "none" | "links" | "inline" =
+    args.images === "none" || args.images === "inline" ? args.images : "links";
+
+  if (imagesMode === "none") {
+    // Drop image links from the markdown so the model sees no images at all.
+    return textToolResult(markdown.replace(/!\[[^\]]*\]\([^)]+\)/g, ""));
+  }
+
+  if (imagesMode !== "inline") {
+    return textToolResult(markdown);
+  }
+
+  // inline: fetch the images referenced by the markdown and attach them as
+  // image content blocks alongside the markdown. Failures degrade to the
+  // plain markdown link with a note; they never fail the whole read.
+  const limits = getImageLimits();
+  let refs: ImageRef[] = [];
+  try {
+    refs = extractImageRefs(markdown, new URL(args.url), limits.maxImages);
+  } catch {
+    // Unparseable input URL: leave the markdown links as-is.
+  }
+  const images = refs.length > 0
+    ? await inlineImages(refs, limits, getFetchTimeoutMs(mcpServer), signal)
+    : [];
+  if (images.length === 0) {
+    return textToolResult(markdown);
+  }
+
+  const inlined = images.filter((img) => img.data !== undefined && img.mimeType !== undefined);
+  let attachedNumber = 0;
+  const notes = images
+    .map((img, index) => {
+      const label = img.alt ? `alt="${img.alt}"` : "(no alt text)";
+      const context = img.heading ? ` — under "${img.heading}"` : "";
+      const status = img.data !== undefined
+        ? `inlined as attached image ${++attachedNumber}`
+        : `left as link (${img.note ?? "unknown"})`;
+      return `${index + 1}. ${label}${context} — ${img.absoluteSrc} — ${status}`;
+    })
+    .join("\n");
+  return {
+    content: [
+      { type: "text" as const, text: `${markdown}\n\n**Images found on this page (in order):**\n${notes}` },
+      ...inlined.map((img) => ({
+        type: "image" as const,
+        data: img.data as string,
+        mimeType: img.mimeType as string,
+      })),
+    ],
+  };
 }
 
 async function executeTool(

--- a/src/resources.ts
+++ b/src/resources.ts
@@ -168,6 +168,7 @@ Reads and converts web page content to Markdown format.
 - \`section\` (optional): Extract content under a heading
 - \`paragraphRange\` (optional): Return a paragraph range such as "1-5" or "10-"
 - \`readHeadings\` (optional): Return only headings
+- \`images\` (optional): How to handle images in HTML pages. Values: \`links\` (default, keep markdown image links), \`inline\` (download the referenced images within bounded limits and attach them as image content blocks; limits set via \`URL_READ_MAX_IMAGES\`, \`URL_READ_MAX_IMAGE_BYTES\`, \`URL_READ_MAX_TOTAL_IMAGE_BYTES\`), \`none\` (drop image links from the markdown). Applies to HTML pages only.
 
 ## Configuration
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -386,6 +386,7 @@ export const READ_URL_TOOL: Tool = {
     "(1) Full content — omit filtering params; use `startChar`/`maxLength` to paginate large pages. " +
     "(2) Section extraction — set `section` to return content under a specific heading. " +
     "(3) Headings only — set `readHeadings: true` to list all headings (mutually exclusive with other filtering params). " +
+    "Images in HTML: `images` parameter controls handling — links (default) keep markdown image links, inline downloads images within bounded limits and attaches them as image content blocks, none drops image links. " +
     "Returns an error string if the URL is unreachable or content cannot be extracted. " +
     "Use after `searxng_web_search` to read the full content of individual result URLs.",
   annotations: {
@@ -420,6 +421,12 @@ export const READ_URL_TOOL: Tool = {
       readHeadings: {
         type: "boolean",
         description: "Return only a list of headings instead of full content",
+      },
+      images: {
+        type: "string",
+        enum: ["none", "links", "inline"],
+        description:
+          "How to handle images found in HTML pages. links (default): keep markdown image links. inline: download the referenced images (bounded by URL_READ_MAX_IMAGES, URL_READ_MAX_IMAGE_BYTES, and URL_READ_MAX_TOTAL_IMAGE_BYTES; defaults 6 / 512 KB / 1.5 MB) and attach them as image content blocks alongside the markdown, with per-image context lines (alt text, nearest heading, source URL, and inline/skip status). none: drop image links from the markdown. Applies to HTML content only; JSON, plain text, and PDF reads ignore this parameter.",
       },
     },
     required: ["url"],

--- a/src/web-images.ts
+++ b/src/web-images.ts
@@ -1,0 +1,280 @@
+// Image extraction and inlining for web_url_read (images: "inline").
+//
+// Extracts image links from the converted markdown (NodeHtmlMarkdown emits
+// <img> tags as ![alt](src) links) and optionally downloads the images so
+// the MCP result can carry them as image content blocks alongside the
+// markdown. All limits are bounded so a single page cannot blow up the
+// model context.
+import { fetch as undiciFetch } from "undici";
+import { createProxyAgent, createUrlReaderAgent, ProxyType } from "./proxy.js";
+import { assertUrlAllowed, isUrlSecurityPolicyDnsError } from "./url-security.js";
+import { parsePositiveInteger } from "./env-int.js";
+
+export type ImageMode = "none" | "links" | "inline";
+
+export interface ImageRef {
+  /** src as it appears in the markdown link (relative or absolute). */
+  src: string;
+  /** src resolved against the base URL (data: URIs pass through). */
+  absoluteSrc: string;
+  /** alt text, empty string when absent. */
+  alt: string;
+  /** Text of the nearest preceding markdown heading, empty when none. */
+  heading: string;
+}
+
+export interface InlinedImage extends ImageRef {
+  /** base64 image payload when inlined successfully. */
+  data?: string;
+  /** Resolved MIME type when inlined successfully. */
+  mimeType?: string;
+  /** Why the image was left as a link instead of inlined. */
+  note?: string;
+}
+
+export interface ImageLimits {
+  maxImages: number;
+  maxImageBytes: number;
+  maxTotalBytes: number;
+}
+
+export const DEFAULT_MAX_IMAGES = 6;
+export const DEFAULT_MAX_IMAGE_BYTES = 512 * 1024;
+export const DEFAULT_MAX_TOTAL_IMAGE_BYTES = 1.5 * 1024 * 1024;
+
+export function getImageLimits(): ImageLimits {
+  return {
+    maxImages: parsePositiveInteger(process.env.URL_READ_MAX_IMAGES, DEFAULT_MAX_IMAGES),
+    maxImageBytes: parsePositiveInteger(process.env.URL_READ_MAX_IMAGE_BYTES, DEFAULT_MAX_IMAGE_BYTES),
+    maxTotalBytes: parsePositiveInteger(process.env.URL_READ_MAX_TOTAL_IMAGE_BYTES, DEFAULT_MAX_TOTAL_IMAGE_BYTES),
+  };
+}
+
+const HEADING_LINE = /^#{1,6}\s+(.*)$/;
+// Strip optional ATX closing hashes: "## Foo ##" -> "Foo"
+const stripClosingHashes = (text: string): string => text.replace(/\s+#+\s*$/, "").trim();
+// ![alt](src) — group 1 = alt text, group 2 = the link target up to the first ")"
+const IMAGE_LINK = /!\[([^\]]*)\]\(([^)]+)\)/g;
+// Split a link target into (src, optional "title"); src is the first token.
+const splitImageTarget = (target: string): string => target.trim().split(/\s+/)[0] ?? "";
+
+/**
+ * Collect up to `maxImages` image references in document order, tracking the
+ * nearest preceding markdown heading for context. data: URIs are included;
+ * they can be inlined without a network fetch.
+ */
+export function extractImageRefs(markdown: string, baseUrl: URL, maxImages: number): ImageRef[] {
+  const refs: ImageRef[] = [];
+  let heading = "";
+  for (const line of markdown.split("\n")) {
+    const headingMatch = HEADING_LINE.exec(line);
+    if (headingMatch) {
+      heading = stripClosingHashes(headingMatch[1]);
+    }
+    IMAGE_LINK.lastIndex = 0;
+    let match: RegExpExecArray | null;
+    while ((match = IMAGE_LINK.exec(line)) !== null) {
+      const alt = match[1].trim();
+      const src = splitImageTarget(match[2]);
+      if (!src) continue;
+      let absoluteSrc = src;
+      try {
+        absoluteSrc = new URL(src, baseUrl).href;
+      } catch {
+        absoluteSrc = src;
+      }
+      refs.push({
+        src,
+        absoluteSrc,
+        alt,
+        heading,
+      });
+      if (refs.length >= maxImages) {
+        return refs;
+      }
+    }
+  }
+  return refs;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes} B`;
+  return `${(bytes / 1024).toFixed(1)} KB`;
+}
+
+function parseDataUri(uri: string): { data: string; mimeType: string; bytes: number } | null {
+  const base64 = /^data:([a-z0-9/+.-]+);base64,(.*)$/is.exec(uri);
+  if (base64) {
+    return {
+      data: base64[2],
+      mimeType: base64[1] || "application/octet-stream",
+      bytes: Math.floor((base64[2].length * 3) / 4),
+    };
+  }
+  const plain = /^data:([^,]*),(.*)$/s.exec(uri);
+  if (plain && !plain[1].toLowerCase().includes(";base64")) {
+    const payload = Buffer.from(decodeURIComponent(plain[2]), "utf8");
+    return {
+      data: payload.toString("base64"),
+      mimeType: plain[1] || "application/octet-stream",
+      bytes: payload.byteLength,
+    };
+  }
+  return null;
+}
+
+const IMAGE_TYPE_BY_EXTENSION: Record<string, string> = {
+  png: "image/png",
+  jpg: "image/jpeg",
+  jpeg: "image/jpeg",
+  gif: "image/gif",
+  webp: "image/webp",
+  svg: "image/svg+xml",
+  avif: "image/avif",
+};
+
+type FetchedImage =
+  | { ok: true; bytes: Uint8Array; mimeType: string }
+  | { ok: false; reason: string };
+
+async function fetchImageBytes(
+  url: string,
+  maxBytes: number,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<FetchedImage> {
+  let parsed: URL;
+  try {
+    parsed = new URL(url);
+  } catch {
+    return { ok: false, reason: "unparseable URL" };
+  }
+  if (parsed.protocol !== "http:" && parsed.protocol !== "https:") {
+    return { ok: false, reason: "unsupported protocol" };
+  }
+  try {
+    assertUrlAllowed(parsed);
+  } catch {
+    return { ok: false, reason: "blocked by URL security policy" };
+  }
+
+  const proxyAgent = createProxyAgent(url, ProxyType.URL_READER);
+  const dispatcher = proxyAgent ?? createUrlReaderAgent();
+  const controller = new AbortController();
+  const timer = setTimeout(() => controller.abort(), timeoutMs);
+  const onOuterAbort = () => controller.abort();
+  signal?.addEventListener("abort", onOuterAbort, { once: true });
+  try {
+    const requestOptions: Record<string, unknown> = {
+      redirect: "follow",
+      signal: controller.signal,
+    };
+    if (dispatcher) requestOptions.dispatcher = dispatcher;
+    const userAgent = process.env.URL_READER_USER_AGENT || process.env.USER_AGENT;
+    if (userAgent) requestOptions.headers = { "User-Agent": userAgent };
+
+    const response = await (undiciFetch as unknown as typeof fetch)(url, requestOptions);
+    if (!response.ok) {
+      return { ok: false, reason: `HTTP ${response.status}` };
+    }
+
+    const contentType = (response.headers.get("content-type") ?? "").split(";")[0].trim().toLowerCase();
+    let mimeType = contentType;
+    if (!mimeType.startsWith("image/")) {
+      const extension = parsed.pathname.split(".").pop()?.toLowerCase() ?? "";
+      mimeType = IMAGE_TYPE_BY_EXTENSION[extension] ?? "";
+    }
+    if (!mimeType.startsWith("image/")) {
+      return { ok: false, reason: `not an image (Content-Type ${contentType || "unknown"})` };
+    }
+
+    const chunks: Uint8Array[] = [];
+    let total = 0;
+    for await (const chunk of response.body as AsyncIterable<Uint8Array>) {
+      total += chunk.byteLength;
+      if (total > maxBytes) {
+        return { ok: false, reason: `exceeds per-image limit of ${formatBytes(maxBytes)}` };
+      }
+      chunks.push(chunk);
+    }
+    const bytes = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of chunks) {
+      bytes.set(chunk, offset);
+      offset += chunk.byteLength;
+    }
+    return { ok: true, bytes, mimeType };
+  } catch (error: any) {
+    if (isUrlSecurityPolicyDnsError(error)) {
+      return { ok: false, reason: "blocked by URL security policy" };
+    }
+    return {
+      ok: false,
+      reason: error?.name === "AbortError"
+        ? `timed out after ${timeoutMs} ms`
+        : error?.message ?? "fetch failed",
+    };
+  } finally {
+    clearTimeout(timer);
+    signal?.removeEventListener("abort", onOuterAbort);
+  }
+}
+
+/**
+ * Download the images for the given refs (in order) up to the byte budgets.
+ * Failures never throw: the image is kept as a markdown link with a `note`.
+ */
+export async function inlineImages(
+  refs: ImageRef[],
+  limits: ImageLimits,
+  timeoutMs: number,
+  signal?: AbortSignal,
+): Promise<InlinedImage[]> {
+  const out: InlinedImage[] = [];
+  let totalBytes = 0;
+  for (const ref of refs.slice(0, limits.maxImages)) {
+    const image: InlinedImage = { ...ref };
+    try {
+      if (ref.absoluteSrc.startsWith("data:")) {
+        const parsed = parseDataUri(ref.absoluteSrc);
+        if (!parsed || !parsed.mimeType.startsWith("image/")) {
+          image.note = "skipped: not a decodable image data URI";
+          out.push(image);
+          continue;
+        }
+        if (parsed.bytes > limits.maxImageBytes) {
+          image.note = `skipped: ${formatBytes(parsed.bytes)} exceeds per-image limit`;
+          out.push(image);
+          continue;
+        }
+        if (totalBytes + parsed.bytes > limits.maxTotalBytes) {
+          image.note = "skipped: total image byte budget reached";
+          out.push(image);
+          continue;
+        }
+        image.data = parsed.data;
+        image.mimeType = parsed.mimeType;
+        totalBytes += parsed.bytes;
+      } else {
+        const fetched = await fetchImageBytes(ref.absoluteSrc, limits.maxImageBytes, timeoutMs, signal);
+        if (!fetched.ok) {
+          image.note = `skipped: ${fetched.reason}`;
+          out.push(image);
+          continue;
+        }
+        if (totalBytes + fetched.bytes.byteLength > limits.maxTotalBytes) {
+          image.note = "skipped: total image byte budget reached";
+          out.push(image);
+          continue;
+        }
+        image.data = Buffer.from(fetched.bytes).toString("base64");
+        image.mimeType = fetched.mimeType;
+        totalBytes += fetched.bytes.byteLength;
+      }
+    } catch (error: any) {
+      image.note = `skipped: ${error?.message ?? "image fetch failed"}`;
+    }
+    out.push(image);
+  }
+  return out;
+}


### PR DESCRIPTION
Adds an opt-in images parameter (none|links|inline) to web_url_read. links (default) is unchanged; inline downloads referenced images within bounded limits (URL_READ_MAX_IMAGES / URL_READ_MAX_IMAGE_BYTES / URL_READ_MAX_TOTAL_IMAGE_BYTES) and attaches them as MCP image content blocks with per-image context lines (alt, nearest heading, source URL, status); none drops image links. Images go through the existing URL-security and proxy guards; failures degrade to markdown links with skip notes. LITE_READ_URL_TOOL stays query-only. New unit tests in __tests__/unit/web-images.test.ts; full suite passes.