### PR TITLE
fix: block private IPv4 destinations embedded in IPv6

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -426,13 +426,17 @@ Every present `Origin` on `/mcp` is validated in all modes; an absent `Origin` r
 
 ## URL Reader Security
 
-`web_url_read` blocks private/internal URLs by default in all transport modes. This includes localhost, loopback addresses, private IPv4 ranges, link-local addresses, `0.0.0.0/8`, CGNAT (`100.64.0.0/10`), IANA special-purpose IPv4 ranges, IPv6 loopback/ULA/link-local addresses, and IPv4-mapped IPv6 private addresses.
+`web_url_read` blocks private/internal URLs by default in all transport modes. This includes localhost, loopback addresses, private IPv4 ranges, link-local addresses, `0.0.0.0/8`, CGNAT (`100.64.0.0/10`), IANA special-purpose IPv4 ranges, IPv6 loopback/ULA/link-local addresses, and decoded private IPv4 payloads from `::/96`, `::ffff:0:0/96`, `::ffff:0:0:0/96`, `2002::/16`, and `64:ff9b::/96`. The entire `64:ff9b:1::/48` local-use range is a whole-prefix local-use denial before payload inspection.
+
+These targeted decoded forms protect untrusted URL reading; they do not claim complete NAT64 or complete transition coverage. Teredo and Network-Specific Prefix forms are not decoded by this classifier.
 
 Redirects are also checked before they are followed. A public URL that redirects to a private/internal URL is blocked.
 
 For direct URL-reader requests without a proxy, DNS answers are validated before connecting. A public-looking hostname that resolves to a private/internal address is blocked, and the connection is pinned to the validated DNS answer to prevent DNS rebinding between validation and connection.
 
-When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTPS_PROXY`, `HTTP_PROXY`, or `HTTPS_PROXY`), the proxy performs DNS resolution. Client-side DNS-answer validation cannot inspect proxied resolutions, so proxied deployments should rely on proxy, firewall, and egress controls.
+### Residual proxy-resolution boundary
+
+When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTPS_PROXY`, `HTTP_PROXY`, or `HTTPS_PROXY`), the proxy performs DNS resolution. Client-side DNS-answer validation cannot inspect proxied resolutions. Retain explicit proxy-side controls: restrict destinations at the proxy and use routing or firewall controls plus egress controls to protect internal networks.
 
 `URL_READ_MAX_CONTENT_LENGTH_BYTES` is enforced while streaming the response
 body, including chunked responses and responses whose GET body is larger than

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -70,12 +70,15 @@ Private and internal URLs are **blocked by default** in all transport modes. The
 - `localhost` and `*.localhost`
 - IPv4 loopback (`127.0.0.0/8`), private (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), link-local (`169.254.0.0/16`), unspecified (`0.0.0.0/8`), CGNAT (`100.64.0.0/10`), IETF protocol assignments (`192.0.0.0/24`), 6to4 relay anycast (`192.88.99.0/24`), documentation/test ranges (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`), benchmarking (`198.18.0.0/15`), multicast (`224.0.0.0/4`), and reserved/broadcast (`240.0.0.0/4`) ranges
 - IPv6 loopback (`::1`), unspecified (`::`), ULA (`fc00::/7`), link-local (`fe80::/10`)
-- IPv4-mapped IPv6 addresses that resolve to any of the above (e.g. `::ffff:127.0.0.1`)
+- Embedded IPv4 payloads in IPv4-compatible `::/96`, IPv4-mapped `::ffff:0:0/96`, IPv4-translated `::ffff:0:0:0/96`, 6to4 `2002::/16`, and RFC6052 `64:ff9b::/96` forms whenever the decoded IPv4 address is blocked above. This includes dotted and hexadecimal mapped literals.
+- The entire RFC8215 local-use `64:ff9b:1::/48` range, as a whole-prefix local-use denial regardless of its payload
 - Redirects are validated **before** they are followed — a public URL that redirects to a private address is also blocked
 
 For direct `web_url_read` requests, DNS answers are also validated before the TCP/TLS connection is established. If a public-looking hostname resolves to any blocked private, loopback, link-local, or unspecified address, the request is rejected. The connection is pinned to the validated DNS answer so a hostname cannot pass validation and then rebind to a different address for the actual connection.
 
-When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTPS_PROXY`, `HTTP_PROXY`, or `HTTPS_PROXY`), the proxy performs DNS resolution. In that mode, this client-side DNS validation cannot inspect the final resolved IP address; proxied deployments should rely on proxy, firewall, and egress controls to restrict internal network access.
+When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTPS_PROXY`, `HTTP_PROXY`, or `HTTPS_PROXY`), the proxy performs DNS resolution. In that mode, this client-side DNS validation cannot inspect the final resolved IP address; proxied deployments should rely on routing or firewall controls and egress controls to restrict internal network access.
+
+These targeted decoded forms protect untrusted URL reading; they do not claim complete NAT64 or complete transition coverage. Teredo and Network-Specific Prefix forms are not decoded by this classifier.
 
 To allow private URL reads and private DNS-resolved targets (e.g. for internal deployments), set `MCP_HTTP_ALLOW_PRIVATE_URLS=true`. Do this only when internal fetching is intentional.
 

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -22,6 +22,7 @@ import {
   MAX_BYPARR_RESPONSE_BYTES,
 } from '../../src/browser-solver.js';
 import { createUrlReaderLookup } from '../../src/proxy.js';
+import { isUrlSecurityPolicyDnsError } from '../../src/url-security.js';
 import { urlCache } from '../../src/cache.js';
 import { testFunction, createTestResults, printTestSummary } from '../helpers/test-utils.js';
 import { createMockServer, createMockServerWithTracking } from '../helpers/mock-server.js';
@@ -2043,6 +2044,7 @@ async function runTests() {
       'http://127.0.0.1:1/private',
       'http://localhost:1/private',
       'http://10.0.0.1/private',
+      'http://[::ffff:0:127.0.0.1]:1/private',
     ];
 
     try {
@@ -2120,6 +2122,7 @@ async function runTests() {
       'v6-loopback.example': [{ address: '::1', family: 6 }],
       'v6-ula.example': [{ address: 'fc00::1', family: 6 }],
       'v6-linklocal.example': [{ address: 'fe80::1', family: 6 }],
+      'v6-translated.example': [{ address: '::ffff:0:127.0.0.1', family: 6 }],
     };
     const restoreDns = installDnsLookupMock(privateCases);
 
@@ -2141,7 +2144,7 @@ async function runTests() {
     }
   }, results);
 
-  await testFunction('default mode allows hostnames resolving only to public addresses and pins the connection', async () => {
+  await testFunction('default mode pins the first resolver-ordered public answer without relookup', async () => {
     envManager.delete('MCP_HTTP_HARDEN');
     envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
 
@@ -2155,7 +2158,10 @@ async function runTests() {
       lookupCount++;
       const cb = typeof options === 'function' ? options : callback;
       if (options?.all) {
-        cb(null, [{ address: TEST_PUBLIC_IP, family: 4 }]);
+        cb(null, [
+          { address: TEST_PUBLIC_IP, family: 4 },
+          { address: '1.1.1.1', family: 4 },
+        ]);
         return;
       }
       cb(null, TEST_PUBLIC_IP, 4);
@@ -2186,7 +2192,7 @@ async function runTests() {
       });
 
       assert.deepEqual(allResult, [{ address: TEST_PUBLIC_IP, family: 4 }]);
-      assert.equal(lookupCount, 2, 'Expected one DNS lookup per custom lookup invocation');
+      assert.equal(lookupCount, 2, 'Expected exactly one DNS lookup per custom lookup invocation');
     } finally {
       (dnsModule as any).lookup = originalLookup;
       syncBuiltinESMExports();
@@ -2210,7 +2216,7 @@ async function runTests() {
     const restoreDns = installDnsLookupMock({
       'mixed.example': [
         { address: TEST_PUBLIC_IP, family: 4 },
-        { address: '127.0.0.1', family: 4 },
+        { address: '::ffff:0:127.0.0.1', family: 6 },
       ],
     });
 
@@ -2222,6 +2228,42 @@ async function runTests() {
         error.message.includes('blocked by security policy'),
         `Expected security policy error, got: ${error.message}`,
       );
+    } finally {
+      restoreDns();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('translated DNS answers produce URLSecurityPolicyDnsError while public answers map through', async () => {
+    envManager.delete('MCP_HTTP_HARDEN');
+    envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
+    const restoreDns = installDnsLookupMock({
+      'translated-dns.example': [{ address: '::ffff:0:127.0.0.1', family: 6 }],
+      'scoped-dns.example': [{ address: 'fe80::1%eth0', family: 6 }],
+      'public-dns.example': [{ address: TEST_PUBLIC_IP, family: 4 }],
+    });
+    const lookup = createUrlReaderLookup();
+
+    try {
+      const blocked = await new Promise<unknown>((resolve) => {
+        lookup('translated-dns.example', {}, (error) => resolve(error));
+      });
+      assert.equal((blocked as Error).name, 'URLSecurityPolicyDnsError');
+      assert.equal(isUrlSecurityPolicyDnsError(blocked), true);
+
+      const scopedBlocked = await new Promise<unknown>((resolve) => {
+        lookup('scoped-dns.example', {}, (error) => resolve(error));
+      });
+      assert.equal((scopedBlocked as Error).name, 'URLSecurityPolicyDnsError');
+      assert.equal(isUrlSecurityPolicyDnsError(scopedBlocked), true);
+
+      const allowed = await new Promise<{ address: string; family: number }>((resolve, reject) => {
+        lookup('public-dns.example', {}, (error, address, family) => {
+          if (error) return reject(error);
+          resolve({ address: address as string, family: family as number });
+        });
+      });
+      assert.deepEqual(allowed, { address: TEST_PUBLIC_IP, family: 4 });
     } finally {
       restoreDns();
       envManager.restore();
@@ -2244,6 +2286,8 @@ async function runTests() {
 
     const restoreDns = installDnsLookupMock({
       'internal.example': [{ address: '127.0.0.1', family: 4 }],
+      'translated-override.example': [{ address: '::ffff:0:127.0.0.1', family: 6 }],
+      'rfc8215-override.example': [{ address: '64:ff9b:1::1', family: 6 }],
     });
     const { url, close } = await startTestServer({ body: '<html><body><h1>Internal DNS target</h1></body></html>' });
     const port = new URL(url).port;
@@ -2251,6 +2295,15 @@ async function runTests() {
     try {
       const result = await fetchAndConvertToMarkdown(mockServer as any, `http://internal.example:${port}/article`, 1000);
       assert.ok(result.includes('Internal DNS target'), `Expected private DNS opt-out fetch, got: ${result}`);
+      for (const hostname of ['translated-override.example', 'rfc8215-override.example']) {
+        const allowed = await new Promise<{ address: string; family: number }>((resolve, reject) => {
+          createUrlReaderLookup()(hostname, {}, (error, address, family) => {
+            if (error) return reject(error);
+            resolve({ address: address as string, family: family as number });
+          });
+        });
+        assert.equal(allowed.family, 6, `${hostname} should be allowed by the override`);
+      }
     } finally {
       restoreDns();
       await close();
@@ -2264,7 +2317,7 @@ async function runTests() {
     envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
 
     const restoreDns = installDnsLookupMock({
-      'private-redirect.example': [{ address: '127.0.0.1', family: 4 }],
+      'private-redirect.example': [{ address: '::ffff:0:127.0.0.1', family: 6 }],
     });
     const lookup = createUrlReaderLookup();
 

--- a/__tests__/unit/url-security.test.ts
+++ b/__tests__/unit/url-security.test.ts
@@ -1,6 +1,7 @@
 #!/usr/bin/env tsx
 
 import { strict as assert } from 'node:assert';
+import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import {
   assertUrlAllowed,
@@ -85,6 +86,168 @@ async function runTests() {
     assert.equal(isPrivateIPv6('::ffff:100.64.0.1'), true);
   }, results);
 
+  await testFunction('isPrivateIPv6 blocks IPv4-translated private addresses', () => {
+    assert.equal(isPrivateIPv6('::ffff:0:127.0.0.1'), true);
+  }, results);
+
+  await testFunction('isPrivateIPv6 decodes every blocked IPv4 category across embeddings', () => {
+    const blockedIpv4 = [
+      '0.0.0.0', '10.0.0.1', '100.64.0.1', '127.0.0.1', '169.254.169.254',
+      '172.16.0.1', '192.0.0.1', '192.0.2.1', '192.88.99.1', '192.168.0.1',
+      '198.18.0.1', '198.51.100.1', '203.0.113.1', '224.0.0.1', '240.0.0.1',
+    ];
+    const ipv4To6to4 = (ipv4: string) => {
+      const [a, b, c, d] = ipv4.split('.').map(Number);
+      return `2002:${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}::`;
+    };
+    const encodings = [
+      (ipv4: string) => `::${ipv4}`,
+      (ipv4: string) => `::ffff:${ipv4}`,
+      (ipv4: string) => `::ffff:0:${ipv4}`,
+      ipv4To6to4,
+      (ipv4: string) => `64:ff9b::${ipv4}`,
+    ];
+
+    for (const ipv4 of blockedIpv4) {
+      for (const encode of encodings) {
+        assert.equal(isPrivateIPv6(encode(ipv4)), true, `${encode(ipv4)} should be blocked`);
+      }
+    }
+  }, results);
+
+  await testFunction('isPrivateIPv6 allows public IPv4 payloads across embeddings', () => {
+    const publicIpv4 = ['8.8.8.8', '1.1.1.1'];
+    const ipv4To6to4 = (ipv4: string) => {
+      const [a, b, c, d] = ipv4.split('.').map(Number);
+      return `2002:${((a << 8) | b).toString(16)}:${((c << 8) | d).toString(16)}::`;
+    };
+    const encodings = [
+      (ipv4: string) => `::${ipv4}`,
+      (ipv4: string) => `::ffff:${ipv4}`,
+      (ipv4: string) => `::ffff:0:${ipv4}`,
+      ipv4To6to4,
+      (ipv4: string) => `64:ff9b::${ipv4}`,
+    ];
+
+    for (const ipv4 of publicIpv4) {
+      for (const encode of encodings) {
+        assert.equal(isPrivateIPv6(encode(ipv4)), false, `${encode(ipv4)} should be allowed`);
+      }
+    }
+  }, results);
+
+  await testFunction('isPrivateIPv6 preserves native denials and blocks RFC8215 local-use prefix', () => {
+    for (const address of [
+      '::', '0:0:0:0:0:0:0:1', 'fc00::1', 'FD12::1', 'fe80::1', 'febf::1',
+      '64:ff9b:1::', '64:ff9b:1:ffff:ffff:ffff:ffff:ffff',
+    ]) {
+      assert.equal(isPrivateIPv6(address), true, `${address} should be blocked`);
+    }
+    for (const address of ['64:ff9b:0:ffff::', '64:ff9b:2::']) {
+      assert.equal(isPrivateIPv6(address), false, `${address} should remain public`);
+    }
+  }, results);
+
+  await testFunction('isPrivateIPv6 has exact embedding-prefix boundaries and public neighbors', () => {
+    const blocked = [
+      '::10.0.0.1',
+      '::ffff:10.0.0.1',
+      '::ffff:0:10.0.0.1',
+      '2002:a00:1:1234:5678:9abc:def0:1',
+      '64:ff9b::10.0.0.1',
+    ];
+    const allowed = [
+      '::8.8.8.8',
+      '::ffff:8.8.8.8',
+      '::ffff:0:8.8.8.8',
+      '2002:808:808:1234:5678:9abc:def0:1',
+      '64:ff9b::8.8.8.8',
+      '::1:10.0.0.1',
+      '::fffe:10.0.0.1',
+      '::fffe:0:10.0.0.1',
+      '2003:a00:1::',
+      '64:ff9a::10.0.0.1',
+    ];
+    for (const address of blocked) {
+      assert.equal(isPrivateIPv6(address), true, `${address} should be blocked`);
+    }
+    for (const address of allowed) {
+      assert.equal(isPrivateIPv6(address), false, `${address} should be allowed`);
+    }
+  }, results);
+
+  await testFunction('isPrivateIPv6 handles compressed, expanded, uppercase, WHATWG, and malformed inputs', () => {
+    assert.equal(isPrivateIPv6('::FFFF:7F00:1'), true);
+    assert.equal(isPrivateIPv6('0:0:0:0:0:ffff:7f00:1'), true);
+    assert.equal(isPrivateIPv6(new URL('http://[::ffff:0:127.0.0.1]/').hostname), true);
+    assert.doesNotThrow(() => isPrivateIPv6('not-an-ip'));
+    assert.equal(isPrivateIPv6('not-an-ip'), false);
+    assert.doesNotThrow(() => isPrivateIPv6('[::ffff:broken]'));
+    assert.equal(isPrivateIPv6('[::ffff:broken]'), false);
+  }, results);
+
+  await testFunction('isPrivateIPv6 rejects hostile malformed IPv6 candidates without throwing', () => {
+    const hostile = [
+      '', '2001:db8:', '1:2:3:4:5:6:7:8:9', '2001::db8::1', '20000::1',
+      '2001: db8::1', '::ffff:127.0.0.256', '::ffff:127.0.0',
+    ];
+    for (const address of hostile) {
+      assert.doesNotThrow(() => isPrivateIPv6(address), address);
+      assert.equal(isPrivateIPv6(address), false, `${address || '<empty>'} should not classify as IPv6`);
+    }
+    assert.doesNotThrow(() => isPrivateIPv6('fe80::1%eth0'));
+    assert.equal(isPrivateIPv6('fe80::1%eth0'), true, 'family-6 parser disagreement must fail closed');
+  }, results);
+
+  await testFunction('WHATWG rejects malformed bracketed IPv6 literals before URL dispatch', () => {
+    for (const literal of [
+      'http://[2001:db8::1::2]/',
+      'http://[fe80::1%25eth0]/',
+      'http://[1:2:3:4:5:6:7:8:9]/',
+    ]) {
+      assert.throws(() => new URL(literal), TypeError, literal);
+    }
+  }, results);
+
+  await testFunction('isPrivateIPv6 permits an ordinary public global-unicast control', () => {
+    assert.equal(isPrivateIPv6('2606:4700::1111'), false);
+  }, results);
+
+  await testFunction('IPv6 byte parser stays private, follows family validation, and fails closed', () => {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- repository source URL is compile-time constant
+    const source = readFileSync(new URL('../../src/url-security.ts', import.meta.url), 'utf8');
+    assert.match(source, /function parseIpv6Bytes\(/);
+    assert.doesNotMatch(source, /export\s+(?:function|const)\s+parseIpv6Bytes/);
+    const familyValidation = source.indexOf('isIP(addr) !== 6');
+    const parserCall = source.indexOf('parseIpv6Bytes(addr)');
+    assert.ok(familyValidation >= 0 && familyValidation < parserCall);
+    assert.match(source, /catch\s*\{\s*return true;\s*\}/);
+    assert.match(source, /bytes\.length !== 16\)\s*return true;/);
+  }, results);
+
+  await testFunction('security documentation describes embedding limits without overclaiming coverage', () => {
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- repository documentation URL is compile-time constant
+    const security = readFileSync(new URL('../../SECURITY.md', import.meta.url), 'utf8');
+    // eslint-disable-next-line security/detect-non-literal-fs-filename -- repository documentation URL is compile-time constant
+    const configuration = readFileSync(new URL('../../CONFIGURATION.md', import.meta.url), 'utf8');
+    const requiredTerms = [
+      '::/96', '::ffff:0:0/96', '::ffff:0:0:0/96', '2002::/16', '64:ff9b::/96',
+      '64:ff9b:1::/48', 'whole-prefix local-use denial', 'Teredo', 'Network-Specific Prefix',
+      'routing or firewall controls', 'untrusted URL reading',
+      'do not claim complete NAT64 or complete transition coverage',
+    ];
+    for (const document of [security, configuration]) {
+      for (const term of requiredTerms) {
+        assert.ok(document.includes(term), `Missing documentation term ${term}`);
+      }
+    }
+    assert.match(configuration, /explicit proxy-side controls/i);
+    assert.match(configuration, /Residual proxy-resolution boundary/i);
+    const affirmativeOverclaim = /(?<!do not claim )\bcomplete NAT64 coverage\b|(?<!do not claim complete NAT64 or )\bcomplete transition coverage\b|\ball NAT64\b/i;
+    assert.doesNotMatch(security, affirmativeOverclaim);
+    assert.doesNotMatch(configuration, affirmativeOverclaim);
+  }, results);
+
   await testFunction('assertUrlAllowed blocks CGNAT by default and honors private URL override', () => {
     envManager.delete('MCP_HTTP_HARDEN');
     envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
@@ -97,6 +260,8 @@ async function runTests() {
 
       envManager.set('MCP_HTTP_ALLOW_PRIVATE_URLS', 'true');
       assert.doesNotThrow(() => assertUrlAllowed(new URL('http://100.64.0.1/')));
+      assert.doesNotThrow(() => assertUrlAllowed(new URL('http://[::ffff:0:127.0.0.1]/')));
+      assert.doesNotThrow(() => assertUrlAllowed(new URL('http://[64:ff9b:1::1]/')));
     } finally {
       envManager.restore();
     }

--- a/src/url-security.ts
+++ b/src/url-security.ts
@@ -43,6 +43,62 @@ export function isPrivateIpv4(hostname: string): boolean {
   return BLOCKED_V4_CIDRS.some(([net, bits]) => ((ip ^ net) >>> (32 - bits)) === 0);
 }
 
+function parseIpv6Bytes(address: string): Uint8Array {
+  const compressionAt = address.indexOf("::");
+  const hasCompression = compressionAt !== -1;
+  if (hasCompression && address.indexOf("::", compressionAt + 1) !== -1) {
+    throw new Error("invalid IPv6 compression");
+  }
+
+  const leftParts = hasCompression
+    ? address.slice(0, compressionAt).split(":").filter(Boolean)
+    : address.split(":");
+  const rightParts = hasCompression
+    ? address.slice(compressionAt + 2).split(":").filter(Boolean)
+    : [];
+  const parts = [...leftParts, ...rightParts];
+  const octets: number[] = [];
+  let leftOctetLength = 0;
+
+  for (let index = 0; index < parts.length; index++) {
+    const part = parts[index];
+    if (part.includes(".")) {
+      if (index !== parts.length - 1 || isIP(part) !== 4) {
+        throw new Error("invalid embedded IPv4");
+      }
+      octets.push(...part.split(".").map(Number));
+    } else {
+      if (!/^[0-9a-f]{1,4}$/i.test(part)) {
+        throw new Error("invalid IPv6 hextet");
+      }
+      const value = Number.parseInt(part, 16);
+      octets.push(value >> 8, value & 0xff);
+    }
+    if (index < leftParts.length) {
+      leftOctetLength = octets.length;
+    }
+  }
+
+  if (!hasCompression) {
+    if (octets.length !== 16) throw new Error("invalid IPv6 length");
+    return Uint8Array.from(octets);
+  }
+  if (octets.length >= 16) throw new Error("invalid IPv6 compression length");
+
+  const bytes = new Uint8Array(16);
+  bytes.set(octets.slice(0, leftOctetLength));
+  bytes.set(octets.slice(leftOctetLength), 16 - (octets.length - leftOctetLength));
+  return bytes;
+}
+
+function ipv4FromBytes(bytes: Uint8Array, offset: number): string {
+  return `${bytes[offset]}.${bytes[offset + 1]}.${bytes[offset + 2]}.${bytes[offset + 3]}`;
+}
+
+function hasPrefix(bytes: Uint8Array, prefix: number[]): boolean {
+  return prefix.every((value, index) => bytes[index] === value);
+}
+
 export function isPrivateIPv6(hostname: string): boolean {
   // url.hostname wraps IPv6 in brackets (e.g. "[::1]") - strip them first
   const addr = (hostname.startsWith("[") && hostname.endsWith("]")
@@ -52,22 +108,34 @@ export function isPrivateIPv6(hostname: string): boolean {
 
   if (isIP(addr) !== 6) return false;
 
-  if (addr === "::1") return true;                     // loopback
-  if (addr === "::") return true;                      // unspecified
-  if (/^f[cd]/i.test(addr)) return true;               // ULA fc00::/7
-  if (/^fe[89ab][0-9a-f]:/i.test(addr)) return true;  // link-local fe80::/10
+  let bytes: Uint8Array;
+  try {
+    bytes = parseIpv6Bytes(addr);
+  } catch {
+    return true;
+  }
+  if (bytes.length !== 16) return true;
 
-  // IPv4-mapped ::ffff:<ipv4> - delegate to the IPv4 check
-  const mapped = addr.match(/^::ffff:(\d{1,3}\.\d{1,3}\.\d{1,3}\.\d{1,3})$/);
-  if (mapped) return isPrivateIpv4(mapped[1]);
+  // Native singleton and CIDR denials.
+  if (bytes.every((value) => value === 0)) return true; // unspecified ::
+  if (bytes.slice(0, 15).every((value) => value === 0) && bytes[15] === 1) return true; // loopback ::1
+  if ((bytes[0] & 0xfe) === 0xfc) return true; // ULA fc00::/7
+  if (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80) return true; // link-local fe80::/10
 
-  // IPv4-mapped ::ffff:<hhhh>:<hhhh> - convert the hex segments to dotted decimal
-  const hexMapped = addr.match(/^::ffff:([0-9a-f]{1,4}):([0-9a-f]{1,4})$/);
-  if (hexMapped) {
-    const high = parseInt(hexMapped[1], 16);
-    const low = parseInt(hexMapped[2], 16);
-    const ipv4 = `${high >> 8}.${high & 0xff}.${low >> 8}.${low & 0xff}`;
-    return isPrivateIpv4(ipv4);
+  // RFC 8215 local-use prefix is entirely non-public, regardless of payload.
+  if (hasPrefix(bytes, [0x00, 0x64, 0xff, 0x9b, 0x00, 0x01])) return true;
+
+  // Mutually exclusive IPv4 embedding forms, in their RFC prefix order.
+  if (hasPrefix(bytes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0])) { // IPv4-compatible ::/96
+    return isPrivateIpv4(ipv4FromBytes(bytes, 12));
+  } else if (hasPrefix(bytes, [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff])) { // IPv4-mapped ::ffff:0:0/96
+    return isPrivateIpv4(ipv4FromBytes(bytes, 12));
+  } else if (hasPrefix(bytes, [0, 0, 0, 0, 0, 0, 0, 0, 0xff, 0xff, 0, 0])) { // IPv4-translated ::ffff:0:0:0/96
+    return isPrivateIpv4(ipv4FromBytes(bytes, 12));
+  } else if (hasPrefix(bytes, [0x20, 0x02])) { // 6to4 2002::/16, bits 16-47 carry IPv4
+    return isPrivateIpv4(ipv4FromBytes(bytes, 2));
+  } else if (hasPrefix(bytes, [0x00, 0x64, 0xff, 0x9b, 0, 0, 0, 0, 0, 0, 0, 0])) { // RFC 6052 64:ff9b::/96
+    return isPrivateIpv4(ipv4FromBytes(bytes, 12));
   }
 
   return false;

--- a/src/url-security.ts
+++ b/src/url-security.ts
@@ -34,6 +34,8 @@ const BLOCKED_V4_CIDRS: [number, number][] = [
   [ipv4ToInt("240.0.0.0"), 4],     // reserved / 255.255.255.255 broadcast
 ];
 
+const IPV6_HEX_DIGITS = "0123456789abcdef";
+
 export function isPrivateIpv4(hostname: string): boolean {
   if (isIP(hostname) !== 4) {
     return false;
@@ -73,7 +75,11 @@ function parseIpv6Part(part: string, isLast: boolean): number[] {
     return part.split(".").map(Number);
   }
 
-  if (!/^[0-9a-f]{1,4}$/i.test(part)) {
+  if (
+    part.length < 1
+    || part.length > 4
+    || ![...part.toLowerCase()].every((character) => IPV6_HEX_DIGITS.includes(character))
+  ) {
     throw new Error("invalid IPv6 hextet");
   }
   const value = Number.parseInt(part, 16);

--- a/src/url-security.ts
+++ b/src/url-security.ts
@@ -43,42 +43,48 @@ export function isPrivateIpv4(hostname: string): boolean {
   return BLOCKED_V4_CIDRS.some(([net, bits]) => ((ip ^ net) >>> (32 - bits)) === 0);
 }
 
-function parseIpv6Bytes(address: string): Uint8Array {
+function splitIpv6Parts(address: string): {
+  hasCompression: boolean;
+  leftParts: string[];
+  rightParts: string[];
+} {
   const compressionAt = address.indexOf("::");
   const hasCompression = compressionAt !== -1;
   if (hasCompression && address.indexOf("::", compressionAt + 1) !== -1) {
     throw new Error("invalid IPv6 compression");
   }
 
-  const leftParts = hasCompression
-    ? address.slice(0, compressionAt).split(":").filter(Boolean)
-    : address.split(":");
-  const rightParts = hasCompression
-    ? address.slice(compressionAt + 2).split(":").filter(Boolean)
-    : [];
-  const parts = [...leftParts, ...rightParts];
-  const octets: number[] = [];
-  let leftOctetLength = 0;
+  return {
+    hasCompression,
+    leftParts: hasCompression
+      ? address.slice(0, compressionAt).split(":").filter(Boolean)
+      : address.split(":"),
+    rightParts: hasCompression
+      ? address.slice(compressionAt + 2).split(":").filter(Boolean)
+      : [],
+  };
+}
 
-  for (let index = 0; index < parts.length; index++) {
-    const part = parts[index];
-    if (part.includes(".")) {
-      if (index !== parts.length - 1 || isIP(part) !== 4) {
-        throw new Error("invalid embedded IPv4");
-      }
-      octets.push(...part.split(".").map(Number));
-    } else {
-      if (!/^[0-9a-f]{1,4}$/i.test(part)) {
-        throw new Error("invalid IPv6 hextet");
-      }
-      const value = Number.parseInt(part, 16);
-      octets.push(value >> 8, value & 0xff);
+function parseIpv6Part(part: string, isLast: boolean): number[] {
+  if (part.includes(".")) {
+    if (!isLast || isIP(part) !== 4) {
+      throw new Error("invalid embedded IPv4");
     }
-    if (index < leftParts.length) {
-      leftOctetLength = octets.length;
-    }
+    return part.split(".").map(Number);
   }
 
+  if (!/^[0-9a-f]{1,4}$/i.test(part)) {
+    throw new Error("invalid IPv6 hextet");
+  }
+  const value = Number.parseInt(part, 16);
+  return [value >> 8, value & 0xff];
+}
+
+function parseIpv6Parts(parts: string[]): number[] {
+  return parts.flatMap((part, index) => parseIpv6Part(part, index === parts.length - 1));
+}
+
+function expandIpv6Bytes(octets: number[], hasCompression: boolean, leftOctetLength: number): Uint8Array {
   if (!hasCompression) {
     if (octets.length !== 16) throw new Error("invalid IPv6 length");
     return Uint8Array.from(octets);
@@ -89,6 +95,14 @@ function parseIpv6Bytes(address: string): Uint8Array {
   bytes.set(octets.slice(0, leftOctetLength));
   bytes.set(octets.slice(leftOctetLength), 16 - (octets.length - leftOctetLength));
   return bytes;
+}
+
+function parseIpv6Bytes(address: string): Uint8Array {
+  const { hasCompression, leftParts, rightParts } = splitIpv6Parts(address);
+  const parts = [...leftParts, ...rightParts];
+  const octets = parseIpv6Parts(parts);
+  const leftOctetLength = parseIpv6Parts(leftParts).length;
+  return expandIpv6Bytes(octets, hasCompression, leftOctetLength);
 }
 
 function ipv4FromBytes(bytes: Uint8Array, offset: number): string {


### PR DESCRIPTION
## Summary
- block private IPv4 payloads in standardized IPv6 transition forms
- deny the RFC 8215 local-use translation prefix as a whole
- preserve public IPv6, public embedded IPv4, and the explicit private-URL override
- document residual transition-prefix and proxy-resolution boundaries

## Verification
- 785 tests passed with coverage thresholds satisfied
- 35 live E2E checks passed
- lint and TypeScript build passed
- packed-consumer verification passed with zero audit findings
- full and production dependency audits report zero advisories