### PR TITLE
Block native non-global IPv6 URL targets

### DIFF
--- a/CONFIGURATION.md
+++ b/CONFIGURATION.md
@@ -426,7 +426,7 @@ Every present `Origin` on `/mcp` is validated in all modes; an absent `Origin` r
 
 ## URL Reader Security
 
-`web_url_read` blocks private/internal URLs by default in all transport modes. This includes localhost, loopback addresses, private IPv4 ranges, link-local addresses, `0.0.0.0/8`, CGNAT (`100.64.0.0/10`), IANA special-purpose IPv4 ranges, IPv6 loopback/ULA/link-local addresses, and decoded private IPv4 payloads from `::/96`, `::ffff:0:0/96`, `::ffff:0:0:0/96`, `2002::/16`, and `64:ff9b::/96`. The entire `64:ff9b:1::/48` local-use range is a whole-prefix local-use denial before payload inspection.
+`web_url_read` blocks private/internal URLs by default in all transport modes. This includes localhost, loopback addresses, private IPv4 ranges, link-local addresses, `0.0.0.0/8`, CGNAT (`100.64.0.0/10`), IANA special-purpose IPv4 ranges, IPv6 loopback/ULA/link-local addresses, deprecated site-local (`fec0::/10`), multicast (`ff00::/8`), and decoded private IPv4 payloads from `::/96`, `::ffff:0:0/96`, `::ffff:0:0:0/96`, `2002::/16`, and `64:ff9b::/96`. The site-local range protects networks that still route it; the multicast denial is defense in depth. The entire `64:ff9b:1::/48` local-use range is a whole-prefix local-use denial before payload inspection.
 
 These targeted decoded forms protect untrusted URL reading; they do not claim complete NAT64 or complete transition coverage. Teredo and Network-Specific Prefix forms are not decoded by this classifier.
 
@@ -465,7 +465,7 @@ HEAD preflight (up to 3 seconds), solver acquisition (the selected provider
 timeout plus up to 5 response-transfer seconds), and then the same replay-fetch
 and parser budgets.
 
-Set `MCP_HTTP_ALLOW_PRIVATE_URLS=true` only when internal URL reads are intentional for your deployment. This also allows hostnames that DNS-resolve to private/internal addresses.
+Set `MCP_HTTP_ALLOW_PRIVATE_URLS=true` only when internal URL reads are intentional for your deployment. This also allows hostnames that DNS-resolve to private/internal addresses, including the site-local and multicast IPv6 ranges above.
 
 
 ## Combined Example (Representative Options)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -69,7 +69,7 @@ Private and internal URLs are **blocked by default** in all transport modes. The
 
 - `localhost` and `*.localhost`
 - IPv4 loopback (`127.0.0.0/8`), private (`10.0.0.0/8`, `172.16.0.0/12`, `192.168.0.0/16`), link-local (`169.254.0.0/16`), unspecified (`0.0.0.0/8`), CGNAT (`100.64.0.0/10`), IETF protocol assignments (`192.0.0.0/24`), 6to4 relay anycast (`192.88.99.0/24`), documentation/test ranges (`192.0.2.0/24`, `198.51.100.0/24`, `203.0.113.0/24`), benchmarking (`198.18.0.0/15`), multicast (`224.0.0.0/4`), and reserved/broadcast (`240.0.0.0/4`) ranges
-- IPv6 loopback (`::1`), unspecified (`::`), ULA (`fc00::/7`), link-local (`fe80::/10`)
+- IPv6 loopback (`::1`), unspecified (`::`), ULA (`fc00::/7`), link-local (`fe80::/10`), deprecated site-local (`fec0::/10`), and multicast (`ff00::/8`). Site-local is blocked to protect networks that still route it; multicast is a defense in depth denial.
 - Embedded IPv4 payloads in IPv4-compatible `::/96`, IPv4-mapped `::ffff:0:0/96`, IPv4-translated `::ffff:0:0:0/96`, 6to4 `2002::/16`, and RFC6052 `64:ff9b::/96` forms whenever the decoded IPv4 address is blocked above. This includes dotted and hexadecimal mapped literals.
 - The entire RFC8215 local-use `64:ff9b:1::/48` range, as a whole-prefix local-use denial regardless of its payload
 - Redirects are validated **before** they are followed — a public URL that redirects to a private address is also blocked
@@ -80,7 +80,7 @@ When a URL-reader proxy is configured (`URL_READER_HTTP_PROXY`, `URL_READER_HTTP
 
 These targeted decoded forms protect untrusted URL reading; they do not claim complete NAT64 or complete transition coverage. Teredo and Network-Specific Prefix forms are not decoded by this classifier.
 
-To allow private URL reads and private DNS-resolved targets (e.g. for internal deployments), set `MCP_HTTP_ALLOW_PRIVATE_URLS=true`. Do this only when internal fetching is intentional.
+To allow private URL reads and private DNS-resolved targets (e.g. for internal deployments), set `MCP_HTTP_ALLOW_PRIVATE_URLS=true`. This intentional opt-out also allows the site-local and multicast ranges above; do this only when internal fetching is intentional.
 
 ### Delegated Browser Service
 

--- a/__tests__/unit/url-reader.test.ts
+++ b/__tests__/unit/url-reader.test.ts
@@ -2064,6 +2064,35 @@ async function runTests() {
     }
   }, results);
 
+  await testFunction('default mode blocks native non-global IPv6 literals before proxy dispatch', async () => {
+    const mockServer = createMockServer();
+    envManager.delete('MCP_HTTP_HARDEN');
+    envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
+
+    let deniedTargetDispatches = 0;
+    const proxy = await startConnectProxyServer(() => {
+      deniedTargetDispatches++;
+      return { body: '<html><body><h1>Denied target</h1></body></html>' };
+    });
+    envManager.set('URL_READER_HTTP_PROXY', proxy.url);
+    envManager.delete('NO_PROXY');
+
+    try {
+      for (const literal of ['http://[fec0::1]:12345/private', 'http://[ff0e::1]:12345/private']) {
+        try {
+          await fetchAndConvertToMarkdown(mockServer as any, literal, 250);
+          assert.fail(`Expected native non-global IPv6 literal to be blocked: ${literal}`);
+        } catch (error: any) {
+          assert.ok(error.message.includes('blocked by security policy'));
+        }
+      }
+      assert.equal(deniedTargetDispatches, 0, 'Denied literal targets must not be dispatched');
+    } finally {
+      await proxy.close();
+      envManager.restore();
+    }
+  }, results);
+
   await testFunction('default mode blocks hostnames resolving to private IPv4 ranges', async () => {
     const mockServer = createMockServer();
     envManager.delete('MCP_HTTP_HARDEN');
@@ -2122,6 +2151,8 @@ async function runTests() {
       'v6-loopback.example': [{ address: '::1', family: 6 }],
       'v6-ula.example': [{ address: 'fc00::1', family: 6 }],
       'v6-linklocal.example': [{ address: 'fe80::1', family: 6 }],
+      'v6-site-local.example': [{ address: 'FEC0::1', family: 6 }],
+      'v6-multicast.example': [{ address: 'ff0e::1', family: 6 }],
       'v6-translated.example': [{ address: '::ffff:0:127.0.0.1', family: 6 }],
     };
     const restoreDns = installDnsLookupMock(privateCases);
@@ -2218,16 +2249,28 @@ async function runTests() {
         { address: TEST_PUBLIC_IP, family: 4 },
         { address: '::ffff:0:127.0.0.1', family: 6 },
       ],
+      'mixed-native-v6.example': [
+        { address: TEST_PUBLIC_IP, family: 4 },
+        { address: 'ff0e::1', family: 6 },
+      ],
+      'mixed-site-local-v6.example': [
+        { address: TEST_PUBLIC_IP, family: 4 },
+        { address: 'fec0::1', family: 6 },
+      ],
     });
 
     try {
-      await fetchAndConvertToMarkdown(mockServer as any, 'http://mixed.example/private', 250);
-      assert.fail('Expected hostname with any private DNS answer to be blocked');
-    } catch (error: any) {
-      assert.ok(
-        error.message.includes('blocked by security policy'),
-        `Expected security policy error, got: ${error.message}`,
-      );
+      for (const hostname of ['mixed.example', 'mixed-native-v6.example', 'mixed-site-local-v6.example']) {
+        try {
+          await fetchAndConvertToMarkdown(mockServer as any, `http://${hostname}/private`, 250);
+          assert.fail(`Expected hostname with a denied DNS answer to be blocked: ${hostname}`);
+        } catch (error: any) {
+          assert.ok(
+            error.message.includes('blocked by security policy'),
+            `Expected security policy error, got: ${error.message}`,
+          );
+        }
+      }
     } finally {
       restoreDns();
       envManager.restore();
@@ -2240,6 +2283,8 @@ async function runTests() {
     const restoreDns = installDnsLookupMock({
       'translated-dns.example': [{ address: '::ffff:0:127.0.0.1', family: 6 }],
       'scoped-dns.example': [{ address: 'fe80::1%eth0', family: 6 }],
+      'site-local-dns.example': [{ address: 'fec0::1', family: 6 }],
+      'multicast-dns.example': [{ address: 'ff00::1', family: 6 }],
       'public-dns.example': [{ address: TEST_PUBLIC_IP, family: 4 }],
     });
     const lookup = createUrlReaderLookup();
@@ -2256,6 +2301,14 @@ async function runTests() {
       });
       assert.equal((scopedBlocked as Error).name, 'URLSecurityPolicyDnsError');
       assert.equal(isUrlSecurityPolicyDnsError(scopedBlocked), true);
+
+      for (const hostname of ['site-local-dns.example', 'multicast-dns.example']) {
+        const nativeBlocked = await new Promise<unknown>((resolve) => {
+          lookup(hostname, {}, (error) => resolve(error));
+        });
+        assert.equal((nativeBlocked as Error).name, 'URLSecurityPolicyDnsError');
+        assert.equal(isUrlSecurityPolicyDnsError(nativeBlocked), true);
+      }
 
       const allowed = await new Promise<{ address: string; family: number }>((resolve, reject) => {
         lookup('public-dns.example', {}, (error, address, family) => {
@@ -2288,6 +2341,8 @@ async function runTests() {
       'internal.example': [{ address: '127.0.0.1', family: 4 }],
       'translated-override.example': [{ address: '::ffff:0:127.0.0.1', family: 6 }],
       'rfc8215-override.example': [{ address: '64:ff9b:1::1', family: 6 }],
+      'site-local-override.example': [{ address: 'fec0::1', family: 6 }],
+      'multicast-override.example': [{ address: 'ff0e::1', family: 6 }],
     });
     const { url, close } = await startTestServer({ body: '<html><body><h1>Internal DNS target</h1></body></html>' });
     const port = new URL(url).port;
@@ -2295,7 +2350,10 @@ async function runTests() {
     try {
       const result = await fetchAndConvertToMarkdown(mockServer as any, `http://internal.example:${port}/article`, 1000);
       assert.ok(result.includes('Internal DNS target'), `Expected private DNS opt-out fetch, got: ${result}`);
-      for (const hostname of ['translated-override.example', 'rfc8215-override.example']) {
+      for (const hostname of [
+        'translated-override.example', 'rfc8215-override.example',
+        'site-local-override.example', 'multicast-override.example',
+      ]) {
         const allowed = await new Promise<{ address: string; family: number }>((resolve, reject) => {
           createUrlReaderLookup()(hostname, {}, (error, address, family) => {
             if (error) return reject(error);
@@ -2401,6 +2459,44 @@ async function runTests() {
         error.message.includes('blocked by security policy'),
         `Expected security policy error, got: ${error.message}`,
       );
+    } finally {
+      await proxy.close();
+      envManager.restore();
+    }
+  }, results);
+
+  await testFunction('redirects to native non-global IPv6 URLs are blocked before target dispatch', async () => {
+    const mockServer = createMockServer();
+    envManager.delete('MCP_HTTP_HARDEN');
+    envManager.delete('MCP_HTTP_ALLOW_PRIVATE_URLS');
+
+    let deniedTargetDispatches = 0;
+    const redirectTargets = ['fec0::1', 'ff0e::1'];
+    let currentTarget = redirectTargets[0];
+    const proxy = await startConnectProxyServer((authority) => {
+      if (authority === 'public.example:80') {
+        return {
+          status: 302,
+          headers: { Location: `http://[${currentTarget}]:12345/private` },
+        };
+      }
+      deniedTargetDispatches++;
+      return { body: '<html><body><h1>Denied target</h1></body></html>' };
+    });
+
+    envManager.set('URL_READER_HTTP_PROXY', proxy.url);
+    envManager.delete('NO_PROXY');
+    try {
+      for (const target of redirectTargets) {
+        currentTarget = target;
+        try {
+          await fetchAndConvertToMarkdown(mockServer as any, `http://public.example/${target}`, 1000);
+          assert.fail(`Expected redirect to native non-global IPv6 URL to be blocked: ${target}`);
+        } catch (error: any) {
+          assert.ok(error.message.includes('blocked by security policy'));
+        }
+      }
+      assert.equal(deniedTargetDispatches, 0, 'Denied redirect target must not be dispatched');
     } finally {
       await proxy.close();
       envManager.restore();

--- a/__tests__/unit/url-security.test.ts
+++ b/__tests__/unit/url-security.test.ts
@@ -139,12 +139,26 @@ async function runTests() {
   await testFunction('isPrivateIPv6 preserves native denials and blocks RFC8215 local-use prefix', () => {
     for (const address of [
       '::', '0:0:0:0:0:0:0:1', 'fc00::1', 'FD12::1', 'fe80::1', 'febf::1',
+      'febf:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
       '64:ff9b:1::', '64:ff9b:1:ffff:ffff:ffff:ffff:ffff',
     ]) {
       assert.equal(isPrivateIPv6(address), true, `${address} should be blocked`);
     }
-    for (const address of ['64:ff9b:0:ffff::', '64:ff9b:2::']) {
+    for (const address of ['fe7f::1', '64:ff9b:0:ffff::', '64:ff9b:2::']) {
       assert.equal(isPrivateIPv6(address), false, `${address} should remain public`);
+    }
+  }, results);
+
+  await testFunction('isPrivateIPv6 blocks native site-local and multicast ranges across URL spellings', () => {
+    for (const address of [
+      'fec0::', 'feff:ffff:ffff:ffff:ffff:ffff:ffff:ffff',
+      'FEC0::1', 'fec0:0000:0000:0000:0000:0000:0000:0001',
+      'ff00::', 'ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff', 'ff0e::1',
+    ]) {
+      assert.equal(isPrivateIPv6(address), true, `${address} should be blocked`);
+    }
+    for (const literal of ['http://[FEC0::1]/', 'http://[ff0e::1]/']) {
+      assert.equal(isPrivateIPv6(new URL(literal).hostname), true, `${literal} should be blocked`);
     }
   }, results);
 
@@ -233,6 +247,7 @@ async function runTests() {
     const requiredTerms = [
       '::/96', '::ffff:0:0/96', '::ffff:0:0:0/96', '2002::/16', '64:ff9b::/96',
       '64:ff9b:1::/48', 'whole-prefix local-use denial', 'Teredo', 'Network-Specific Prefix',
+      'fec0::/10', 'ff00::/8', 'defense in depth',
       'routing or firewall controls', 'untrusted URL reading',
       'do not claim complete NAT64 or complete transition coverage',
     ];
@@ -257,11 +272,21 @@ async function runTests() {
         () => assertUrlAllowed(new URL('http://100.64.0.1/')),
         /blocked by security policy/,
       );
+      assert.throws(
+        () => assertUrlAllowed(new URL('http://[fec0::1]/')),
+        /blocked by security policy/,
+      );
+      assert.throws(
+        () => assertUrlAllowed(new URL('http://[ff0e::1]/')),
+        /blocked by security policy/,
+      );
 
       envManager.set('MCP_HTTP_ALLOW_PRIVATE_URLS', 'true');
       assert.doesNotThrow(() => assertUrlAllowed(new URL('http://100.64.0.1/')));
       assert.doesNotThrow(() => assertUrlAllowed(new URL('http://[::ffff:0:127.0.0.1]/')));
       assert.doesNotThrow(() => assertUrlAllowed(new URL('http://[64:ff9b:1::1]/')));
+      assert.doesNotThrow(() => assertUrlAllowed(new URL('http://[fec0::1]/')));
+      assert.doesNotThrow(() => assertUrlAllowed(new URL('http://[ff0e::1]/')));
     } finally {
       envManager.restore();
     }

--- a/src/url-security.ts
+++ b/src/url-security.ts
@@ -141,6 +141,8 @@ export function isPrivateIPv6(hostname: string): boolean {
   if (bytes.slice(0, 15).every((value) => value === 0) && bytes[15] === 1) return true; // loopback ::1
   if ((bytes[0] & 0xfe) === 0xfc) return true; // ULA fc00::/7
   if (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0x80) return true; // link-local fe80::/10
+  if (bytes[0] === 0xfe && (bytes[1] & 0xc0) === 0xc0) return true; // site-local fec0::/10
+  if (bytes[0] === 0xff) return true; // multicast ff00::/8
 
   // RFC 8215 local-use prefix is entirely non-public, regardless of payload.
   if (hasPrefix(bytes, [0x00, 0x64, 0xff, 0x9b, 0x00, 0x01])) return true;


### PR DESCRIPTION
Block deprecated IPv6 site-local (`fec0::/10`) and multicast (`ff00::/8`) destinations in the shared URL security classifier. Literal URLs, DNS answers, mixed DNS results, and redirects use the same policy; the existing intentional private-URL opt-out remains available.

Regression tests cover range boundaries, address spellings, lookup pinning, and rejection before target dispatch. Verified 788 tests (96.03% line / 92.07% branch coverage), lint, build, 23 local end-to-end tests, and packed-consumer checks with zero production audit findings.
